### PR TITLE
[openronin] Smoke test: add stars badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ File issues like you'd brief a remote developer. The agent picks them up, asks f
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/Node-22%2B-green.svg)](https://nodejs.org/)
 [![Status](https://img.shields.io/badge/Status-alpha-orange.svg)]()
+[![GitHub Stars](https://img.shields.io/github/stars/openronin/openronin?color=yellow)](https://github.com/openronin/openronin/stargazers)
 
 </div>
 


### PR DESCRIPTION
🤖 openronin: автоматический PR.

Closes #6.

This PR was opened automatically by [openronin](https://github.com/openronin/openronin) in response to issue #6.

## Agent summary

## Summary

**What changed:** Added a GitHub stars badge to `README.md` immediately after the existing "Status alpha" badge (line 15). The badge uses shields.io (`img.shields.io/github/stars/openronin/openronin?color=yellow`) with yellow color, and links to the repository's stargazers page.

**Tests/lint:** No code changes were made — this is a README-only edit. The project's `pnpm run check` suite (build + lint + unit tests + format check) operates on TypeScript source files and is not affected by this change.

## Diff stats

- Files changed: 1
- Lines: +1 / -0

---
*Marked as draft for human review. The agent (claude_code) wrote this; please review before merging.*