### PR TITLE
[openronin] Admin UI: component library (buttons, badges, cards, forms, code blocks)

### DIFF
--- a/src/server/admin.ts
+++ b/src/server/admin.ts
@@ -35,6 +35,8 @@ import { isBotMessage } from "../lanes/messages.js";
 import { parseSqliteUtc } from "../lib/time.js";
 import { isPaused } from "../lib/pause.js";
 import { html, page, isHtmx, raw, escapeHtml, t as time, type TrustedHtml } from "./layout.js";
+import { button } from "./components/button.js";
+import { badge, type BadgeTone } from "./components/badge.js";
 
 interface Args {
   db: Db;
@@ -511,53 +513,51 @@ export function adminRoute({ db, getConfig, scheduler, startedAt }: Args): Hono 
         : raw("")}
       <div class="flex items-center justify-between mb-4">
         <h1 class="text-2xl font-semibold">Dashboard</h1>
-        <div class="flex items-center gap-2 text-sm">
-          <button
-            type="button"
-            hx-post="/admin/api/kick-first-pending"
-            hx-target="#dash-flash"
-            hx-swap="innerHTML"
-            hx-indicator="#dash-busy"
-            class="px-2 py-1 rounded bg-amber-600 hover:bg-amber-700 text-white"
-            title="Pull the next pending task (the one waiting the longest) into the head of the queue"
-          >
-            ⚡ kick pending
-          </button>
-          <button
-            type="button"
-            hx-post="/admin/api/reconcile-now"
-            hx-target="#dash-flash"
-            hx-swap="innerHTML"
-            hx-indicator="#dash-busy"
-            class="px-2 py-1 rounded bg-slate-700 hover:bg-slate-800 text-white"
-            title="Re-scan all watched repos for new items"
-          >
-            ↻ reconcile now
-          </button>
-          <button
-            type="button"
-            hx-post="/admin/api/drain-now"
-            hx-target="#dash-flash"
-            hx-swap="innerHTML"
-            hx-indicator="#dash-busy"
-            class="px-2 py-1 rounded bg-slate-700 hover:bg-slate-800 text-white"
-            title="Process whatever is due in the queue right now"
-          >
-            ▶ drain now
-          </button>
-          <button
-            type="button"
-            hx-post="/admin/api/clear-rate-limit"
-            hx-target="#dash-flash"
-            hx-swap="innerHTML"
-            hx-indicator="#dash-busy"
-            class="px-2 py-1 rounded bg-amber-700 hover:bg-amber-800 text-white"
-            title="Topped up Claude tokens? Clear the rate-limit cooldown on all parked tasks."
-            onclick="return confirm('Clear rate-limit cooldown on all parked tasks? They will be re-queued immediately.')"
-          >
-            🔓 clear rate-limit
-          </button>
-          <span id="dash-busy" class="htmx-indicator text-muted">…</span>
+        <div class="flex items-center gap-2">
+          ${button({
+            variant: "ghost",
+            size: "sm",
+            label: "⚡ kick pending",
+            hxPost: "/admin/api/kick-first-pending",
+            hxTarget: "#dash-flash",
+            hxSwap: "innerHTML",
+            hxIndicator: "#dash-busy",
+            title:
+              "Pull the next pending task (the one waiting the longest) into the head of the queue",
+          })}
+          ${button({
+            variant: "secondary",
+            size: "sm",
+            label: "↻ reconcile now",
+            hxPost: "/admin/api/reconcile-now",
+            hxTarget: "#dash-flash",
+            hxSwap: "innerHTML",
+            hxIndicator: "#dash-busy",
+            title: "Re-scan all watched repos for new items",
+          })}
+          ${button({
+            variant: "primary",
+            size: "sm",
+            label: "▶ drain now",
+            hxPost: "/admin/api/drain-now",
+            hxTarget: "#dash-flash",
+            hxSwap: "innerHTML",
+            hxIndicator: "#dash-busy",
+            title: "Process whatever is due in the queue right now",
+          })}
+          ${button({
+            variant: "destructive",
+            size: "sm",
+            label: "🔓 clear rate-limit",
+            hxPost: "/admin/api/clear-rate-limit",
+            hxTarget: "#dash-flash",
+            hxSwap: "innerHTML",
+            hxIndicator: "#dash-busy",
+            hxConfirm:
+              "Clear rate-limit cooldown on all parked tasks? They will be re-queued immediately.",
+            title: "Topped up Claude tokens? Clear the rate-limit cooldown on all parked tasks.",
+          })}
+          <span id="dash-busy" class="htmx-indicator text-muted text-sm">…</span>
         </div>
       </div>
       <div id="dash-flash" class="mb-4"></div>
@@ -627,11 +627,7 @@ export function adminRoute({ db, getConfig, scheduler, startedAt }: Args): Hono 
                         <td>#${r.id}</td>
                         <td>${time(r.started_at)}</td>
                         <td>${r.engine}/${r.model ?? "?"}</td>
-                        <td>
-                          <span class="${runStatusClass(r.status)} px-1.5 py-0.5 rounded text-xs"
-                            >${r.status}</span
-                          >
-                        </td>
+                        <td>${badge({ label: r.status, tone: runStatusTone(r.status) })}</td>
                         <td>${r.tokens_in ?? "-"}/${r.tokens_out ?? "-"}</td>
                         <td>${r.cost_usd != null ? "$" + r.cost_usd.toFixed(4) : "-"}</td>
                       </tr>`,
@@ -3557,6 +3553,13 @@ function runStatusClass(status: string): string {
   if (status === "running") return "badge-info";
   if (status === "error") return "badge-danger";
   return "badge-neutral";
+}
+
+function runStatusTone(status: string): BadgeTone {
+  if (status === "ok") return "success";
+  if (status === "running") return "info";
+  if (status === "error") return "danger";
+  return "neutral";
 }
 
 function taskStatusClass(status: string): string {

--- a/src/server/components/badge.ts
+++ b/src/server/components/badge.ts
@@ -1,0 +1,19 @@
+import { raw, escapeHtml, type TrustedHtml } from "../layout.js";
+
+export type BadgeTone = "neutral" | "success" | "warning" | "danger" | "info";
+export type BadgeVariant = "soft" | "solid" | "outline";
+
+export interface BadgeProps {
+  label: string;
+  tone?: BadgeTone;
+  variant?: BadgeVariant;
+  dot?: boolean;
+}
+
+export function badge(props: BadgeProps): TrustedHtml {
+  const tone = props.tone ?? "neutral";
+  const variant = props.variant ?? "soft";
+  const cls = variant === "soft" ? `bdg bdg-${tone}` : `bdg bdg-${variant}-${tone}`;
+  const dot = props.dot ? `<span aria-hidden="true">● </span>` : "";
+  return raw(`<span class="${cls}">${dot}${escapeHtml(props.label)}</span>`);
+}

--- a/src/server/components/button.ts
+++ b/src/server/components/button.ts
@@ -1,0 +1,70 @@
+import { raw, escapeHtml, type TrustedHtml } from "../layout.js";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "destructive" | "link";
+export type ButtonSize = "sm" | "md" | "lg";
+
+export interface ButtonProps {
+  label: string;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  disabled?: boolean;
+  loading?: boolean;
+  type?: "button" | "submit" | "reset";
+  hxPost?: string;
+  hxGet?: string;
+  hxPut?: string;
+  hxDelete?: string;
+  hxTarget?: string;
+  hxSwap?: string;
+  hxConfirm?: string;
+  hxIndicator?: string;
+  onclick?: string;
+  href?: string;
+  title?: string;
+  extraClass?: string;
+  extraAttrs?: string;
+}
+
+const SPINNER =
+  `<svg class="btn-spinner" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true" stroke="currentColor" stroke-width="3">` +
+  `<circle cx="12" cy="12" r="10" stroke-dasharray="60 20" stroke-linecap="round"/>` +
+  `</svg>`;
+
+export function button(props: ButtonProps): TrustedHtml {
+  const variant = props.variant ?? "secondary";
+  const size = props.size ?? "md";
+  const isDisabled = props.disabled || props.loading;
+
+  const cls = [
+    "btn",
+    `btn-${variant}`,
+    `btn-${size}`,
+    isDisabled ? "btn-disabled" : "",
+    props.extraClass ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const parts: string[] = [`class="${escapeHtml(cls)}"`];
+  if (props.hxPost) parts.push(`hx-post="${escapeHtml(props.hxPost)}"`);
+  if (props.hxGet) parts.push(`hx-get="${escapeHtml(props.hxGet)}"`);
+  if (props.hxPut) parts.push(`hx-put="${escapeHtml(props.hxPut)}"`);
+  if (props.hxDelete) parts.push(`hx-delete="${escapeHtml(props.hxDelete)}"`);
+  if (props.hxTarget) parts.push(`hx-target="${escapeHtml(props.hxTarget)}"`);
+  if (props.hxSwap) parts.push(`hx-swap="${escapeHtml(props.hxSwap)}"`);
+  if (props.hxConfirm) parts.push(`hx-confirm="${escapeHtml(props.hxConfirm)}"`);
+  if (props.hxIndicator) parts.push(`hx-indicator="${escapeHtml(props.hxIndicator)}"`);
+  if (props.onclick) parts.push(`onclick="${escapeHtml(props.onclick)}"`);
+  if (props.title) parts.push(`title="${escapeHtml(props.title)}"`);
+  if (props.extraAttrs) parts.push(props.extraAttrs);
+  if (isDisabled) parts.push("disabled");
+
+  const content = (props.loading ? SPINNER : "") + escapeHtml(props.label);
+
+  if (props.href !== undefined) {
+    return raw(`<a href="${escapeHtml(props.href)}" ${parts.join(" ")}>${content}</a>`);
+  }
+
+  const type = props.type ?? "button";
+  return raw(`<button type="${type}" ${parts.join(" ")}>${content}</button>`);
+}

--- a/src/server/components/card.ts
+++ b/src/server/components/card.ts
@@ -1,0 +1,35 @@
+import { html, raw, type TrustedHtml } from "../layout.js";
+
+export type CardVariant = "bordered" | "elevated" | "inset";
+export type CardPadding = "sm" | "md" | "lg";
+
+export interface CardProps {
+  title?: string;
+  actions?: TrustedHtml;
+  body: TrustedHtml;
+  variant?: CardVariant;
+  padding?: CardPadding;
+}
+
+export function card(props: CardProps): TrustedHtml {
+  const variant = props.variant ?? "bordered";
+  const padClass =
+    props.padding === "sm" ? "card-body-sm" : props.padding === "lg" ? "card-body-lg" : "card-body";
+
+  const header =
+    props.title !== undefined || props.actions !== undefined
+      ? html`<div class="card-header">
+          ${props.title !== undefined
+            ? html`<div class="card-title">${props.title}</div>`
+            : raw("")}
+          ${props.actions !== undefined
+            ? html`<div class="card-actions">${props.actions}</div>`
+            : raw("")}
+        </div>`
+      : raw("");
+
+  return html`<div class="card card-${variant}">
+    ${header}
+    <div class="${padClass}">${props.body}</div>
+  </div>`;
+}

--- a/src/server/components/code.ts
+++ b/src/server/components/code.ts
@@ -1,0 +1,49 @@
+import { raw, escapeHtml, type TrustedHtml } from "../layout.js";
+
+export interface CodeBlockProps {
+  code: string;
+  lang?: string;
+  copyButton?: boolean;
+}
+
+export function codeInline(content: string): TrustedHtml {
+  return raw(`<code class="code-inline">${escapeHtml(content)}</code>`);
+}
+
+export function codeBlock(props: CodeBlockProps): TrustedHtml {
+  const inner = props.lang === "yaml" ? highlightYaml(props.code) : escapeHtml(props.code);
+  const copyBtn = props.copyButton
+    ? `<button class="code-copy-btn" type="button" onclick="(function(b){` +
+      `var pre=b.closest('.code-block-wrap').querySelector('pre');` +
+      `navigator.clipboard&&navigator.clipboard.writeText(pre.innerText)` +
+      `.then(function(){b.textContent='Copied!';setTimeout(function(){b.textContent='Copy';},1500);})` +
+      `})(this)">Copy</button>`
+    : "";
+  return raw(
+    `<div class="code-block-wrap">${copyBtn}<pre class="code-block"><code>${inner}</code></pre></div>`,
+  );
+}
+
+function highlightYaml(code: string): string {
+  return code
+    .split("\n")
+    .map((line) => {
+      const m = line.match(/^( *)([\w][\w.-]*)(:)( *)(.*)$/);
+      if (!m) return escapeHtml(line);
+      const indent = m[1] ?? "";
+      const key = m[2] ?? "";
+      const colon = m[3] ?? "";
+      const space = m[4] ?? "";
+      const rest = m[5] ?? "";
+      const header =
+        `${escapeHtml(indent)}<span class="yaml-key">${escapeHtml(key)}</span>` +
+        `${escapeHtml(colon)}${escapeHtml(space)}`;
+      if (!rest) return header;
+      const trimmed = rest.trimStart();
+      if (trimmed.startsWith('"') || trimmed.startsWith("'")) {
+        return `${header}<span class="yaml-string">${escapeHtml(rest)}</span>`;
+      }
+      return `${header}${escapeHtml(rest)}`;
+    })
+    .join("\n");
+}

--- a/src/server/components/form.ts
+++ b/src/server/components/form.ts
@@ -1,0 +1,223 @@
+import { html, raw, escapeHtml, type TrustedHtml } from "../layout.js";
+
+export interface FormFieldProps {
+  label: string;
+  control: TrustedHtml;
+  id?: string;
+  helper?: string;
+  error?: string;
+}
+
+export interface InputProps {
+  name: string;
+  id?: string;
+  type?: "text" | "number" | "password" | "email" | "url";
+  value?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  hasError?: boolean;
+  extraClass?: string;
+  extraAttrs?: string;
+}
+
+export interface SelectProps {
+  name: string;
+  id?: string;
+  options: { value: string; label: string }[];
+  value?: string;
+  disabled?: boolean;
+  required?: boolean;
+  hasError?: boolean;
+  extraClass?: string;
+}
+
+export interface TextareaProps {
+  name: string;
+  id?: string;
+  value?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  mono?: boolean;
+  rows?: number;
+  hasError?: boolean;
+  extraClass?: string;
+  extraAttrs?: string;
+}
+
+export interface CheckboxProps {
+  name: string;
+  id?: string;
+  label: string;
+  checked?: boolean;
+  disabled?: boolean;
+  value?: string;
+}
+
+export interface ToggleProps {
+  name: string;
+  id?: string;
+  label: string;
+  checked?: boolean;
+  disabled?: boolean;
+}
+
+export interface YamlEditorProps {
+  name: string;
+  id?: string;
+  value?: string;
+  rows?: number;
+  disabled?: boolean;
+}
+
+export function formField(props: FormFieldProps): TrustedHtml {
+  const forAttr = props.id ? ` for="${escapeHtml(props.id)}"` : "";
+  return html`<div class="form-field">
+    <label class="form-label" ${raw(forAttr)}>${props.label}</label>
+    ${props.control}
+    ${props.helper ? html`<span class="form-helper">${props.helper}</span>` : raw("")}
+    ${props.error ? html`<span class="form-error" role="alert">${props.error}</span>` : raw("")}
+  </div>`;
+}
+
+export function formInput(props: InputProps): TrustedHtml {
+  const id = props.id ?? props.name;
+  const cls = ["form-input", props.hasError ? "form-input-error" : "", props.extraClass ?? ""]
+    .filter(Boolean)
+    .join(" ");
+  const attrs: string[] = [
+    `id="${escapeHtml(id)}"`,
+    `name="${escapeHtml(props.name)}"`,
+    `type="${props.type ?? "text"}"`,
+    `class="${escapeHtml(cls)}"`,
+  ];
+  if (props.value !== undefined) attrs.push(`value="${escapeHtml(props.value)}"`);
+  if (props.placeholder) attrs.push(`placeholder="${escapeHtml(props.placeholder)}"`);
+  if (props.disabled) attrs.push("disabled");
+  if (props.required) attrs.push("required");
+  if (props.extraAttrs) attrs.push(props.extraAttrs);
+  return raw(`<input ${attrs.join(" ")}>`);
+}
+
+export function formSelect(props: SelectProps): TrustedHtml {
+  const id = props.id ?? props.name;
+  const cls = ["form-select", props.hasError ? "form-select-error" : "", props.extraClass ?? ""]
+    .filter(Boolean)
+    .join(" ");
+  const attrs = [
+    `id="${escapeHtml(id)}"`,
+    `name="${escapeHtml(props.name)}"`,
+    `class="${escapeHtml(cls)}"`,
+    ...(props.disabled ? ["disabled"] : []),
+    ...(props.required ? ["required"] : []),
+  ];
+  const options = props.options
+    .map(
+      (o) =>
+        `<option value="${escapeHtml(o.value)}"${o.value === props.value ? " selected" : ""}>${escapeHtml(o.label)}</option>`,
+    )
+    .join("");
+  return raw(`<select ${attrs.join(" ")}>${options}</select>`);
+}
+
+export function formTextarea(props: TextareaProps): TrustedHtml {
+  const id = props.id ?? props.name;
+  const cls = [
+    "form-textarea",
+    props.mono ? "form-textarea-mono" : "",
+    props.hasError ? "form-textarea-error" : "",
+    props.extraClass ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const attrs: string[] = [
+    `id="${escapeHtml(id)}"`,
+    `name="${escapeHtml(props.name)}"`,
+    `class="${escapeHtml(cls)}"`,
+  ];
+  if (props.rows) attrs.push(`rows="${props.rows}"`);
+  if (props.placeholder) attrs.push(`placeholder="${escapeHtml(props.placeholder)}"`);
+  if (props.disabled) attrs.push("disabled");
+  if (props.required) attrs.push("required");
+  if (props.extraAttrs) attrs.push(props.extraAttrs);
+  return raw(
+    `<textarea ${attrs.join(" ")}>${props.value !== undefined ? escapeHtml(props.value) : ""}</textarea>`,
+  );
+}
+
+export function formCheckbox(props: CheckboxProps): TrustedHtml {
+  const id = props.id ?? props.name;
+  const attrs = [
+    `type="checkbox"`,
+    `id="${escapeHtml(id)}"`,
+    `name="${escapeHtml(props.name)}"`,
+    `class="form-checkbox"`,
+  ];
+  if (props.value !== undefined) attrs.push(`value="${escapeHtml(props.value)}"`);
+  if (props.checked) attrs.push("checked");
+  if (props.disabled) attrs.push("disabled");
+  return html`<label class="form-check-wrap" for="${id}">
+    <input ${raw(attrs.join(" "))} />
+    <span>${props.label}</span>
+  </label>`;
+}
+
+export function formToggle(props: ToggleProps): TrustedHtml {
+  const id = props.id ?? props.name;
+  const attrs = [
+    `type="checkbox"`,
+    `id="${escapeHtml(id)}"`,
+    `name="${escapeHtml(props.name)}"`,
+    `class="form-toggle"`,
+    `role="switch"`,
+  ];
+  if (props.checked) attrs.push("checked");
+  if (props.disabled) attrs.push("disabled");
+  return html`<label class="form-toggle-wrap" for="${id}">
+    <input ${raw(attrs.join(" "))} />
+    <span>${props.label}</span>
+  </label>`;
+}
+
+export function yamlEditor(props: YamlEditorProps): TrustedHtml {
+  const id = props.id ?? props.name;
+  const value = props.value ?? "";
+  const lineCount = Math.max(value.split("\n").length, 5);
+  const gutterNums = Array.from({ length: lineCount }, (_, i) => i + 1).join("\n");
+  const rows = props.rows ?? Math.max(lineCount, 8);
+
+  const taAttrs = [
+    `id="${escapeHtml(id)}"`,
+    `name="${escapeHtml(props.name)}"`,
+    `class="yaml-editor"`,
+    `rows="${rows}"`,
+    `spellcheck="false"`,
+    `autocomplete="off"`,
+    `wrap="off"`,
+    ...(props.disabled ? ["disabled"] : []),
+  ].join(" ");
+
+  const initScript =
+    `(function(){` +
+    `var sc=document.currentScript,w=sc&&sc.previousElementSibling;` +
+    `if(!w)return;` +
+    `var ta=w.querySelector('textarea'),g=w.querySelector('.yaml-gutter');` +
+    `if(!ta||!g)return;` +
+    `function sync(){` +
+    `var n=Math.max(ta.value.split('\\n').length,1);` +
+    `g.textContent=Array.from({length:n},function(_,i){return i+1;}).join('\\n');` +
+    `g.scrollTop=ta.scrollTop;` +
+    `}` +
+    `ta.addEventListener('input',sync);` +
+    `ta.addEventListener('scroll',function(){g.scrollTop=ta.scrollTop;});` +
+    `})();`;
+
+  return raw(
+    `<div class="yaml-editor-wrap">` +
+      `<div class="yaml-gutter" aria-hidden="true">${gutterNums}</div>` +
+      `<textarea ${taAttrs}>${escapeHtml(value)}</textarea>` +
+      `</div>` +
+      `<script>${initScript}</script>`,
+  );
+}

--- a/src/server/components/table.ts
+++ b/src/server/components/table.ts
@@ -1,0 +1,80 @@
+import { html, raw, escapeHtml, type TrustedHtml } from "../layout.js";
+
+export interface TableColumn {
+  key: string;
+  label: string;
+  sortable?: boolean;
+  nowrap?: boolean;
+}
+
+export interface TableProps {
+  columns: TableColumn[];
+  rows: TrustedHtml[];
+  emptyMessage?: string;
+  emptyCta?: TrustedHtml;
+  maxHeight?: string;
+  currentSort?: { key: string; dir: "asc" | "desc" };
+  sortHxGet?: string;
+  hxTarget?: string;
+  hxSwap?: string;
+}
+
+export function table(props: TableProps): TrustedHtml {
+  const wrapStyle = props.maxHeight
+    ? ` style="max-height:${escapeHtml(props.maxHeight)};overflow-y:auto"`
+    : "";
+
+  const headers = props.columns.map((col) => {
+    const isActive = props.currentSort?.key === col.key;
+    const dir = isActive ? props.currentSort!.dir : undefined;
+    const sortClass = col.sortable ? " data-table-sort" : "";
+    const dirAttr = dir ? ` data-dir="${dir}"` : "";
+    const nowrapAttr = col.nowrap ? ` style="white-space:nowrap"` : "";
+    if (col.sortable && props.sortHxGet) {
+      const nextDir = isActive && dir === "asc" ? "desc" : "asc";
+      const url = `${props.sortHxGet}?sort=${encodeURIComponent(col.key)}&dir=${nextDir}`;
+      const hxTarget = props.hxTarget ? ` hx-target="${escapeHtml(props.hxTarget)}"` : "";
+      const hxSwap = props.hxSwap ? ` hx-swap="${escapeHtml(props.hxSwap)}"` : "";
+      return raw(
+        `<th class="data-table-th${sortClass}"${dirAttr}${nowrapAttr} hx-get="${escapeHtml(url)}"${hxTarget}${hxSwap}>${escapeHtml(col.label)}</th>`,
+      );
+    }
+    return raw(
+      `<th class="data-table-th${sortClass}"${dirAttr}${nowrapAttr}>${escapeHtml(col.label)}</th>`,
+    );
+  });
+
+  if (props.rows.length === 0) {
+    const colSpan = props.columns.length;
+    return html`<div class="data-table-wrap" ${raw(wrapStyle)}>
+      <table class="data-table">
+        <thead>
+          <tr>
+            ${headers}
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td colspan="${colSpan}" class="data-table-empty">
+              <div>${props.emptyMessage ?? "Nothing here yet."}</div>
+              ${props.emptyCta ? html`<div class="mt-2">${props.emptyCta}</div>` : raw("")}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>`;
+  }
+
+  return html`<div class="data-table-wrap" ${raw(wrapStyle)}>
+    <table class="data-table">
+      <thead>
+        <tr>
+          ${headers}
+        </tr>
+      </thead>
+      <tbody>
+        ${props.rows}
+      </tbody>
+    </table>
+  </div>`;
+}

--- a/src/server/layout.ts
+++ b/src/server/layout.ts
@@ -267,6 +267,100 @@ pre,code,textarea{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
 #more-menu.open{display:block}
 /* ─── Breadcrumb tabs ────────────────────────────────────────────────────── */
 [role="tablist"] a{text-decoration:none}
+/* ─── Button component ────────────────────────────────────────────────────── */
+.btn{display:inline-flex;align-items:center;gap:6px;font-weight:500;border-radius:var(--radius-md);cursor:pointer;border:none;text-decoration:none;white-space:nowrap;line-height:1;box-sizing:border-box;transition:background .15s,opacity .15s,border-color .15s}
+.btn:focus-visible{outline:2px solid var(--brand-primary);outline-offset:2px}
+.btn-sm{height:28px;padding:0 12px;font-size:13px}
+.btn-md{height:36px;padding:0 16px;font-size:14px}
+.btn-lg{height:44px;padding:0 20px;font-size:16px}
+.btn-primary{background:var(--brand-primary);color:var(--brand-primary-fg)}
+.btn-primary:hover:not(:disabled){background:var(--brand-primary-hover)}
+.btn-secondary{background:var(--surface-sunken);color:var(--fg-secondary);border:1px solid var(--border-subtle)}
+.btn-secondary:hover:not(:disabled){background:var(--surface-elevated);border-color:var(--border-strong)}
+.btn-ghost{background:transparent;color:var(--fg-secondary);border:1px solid transparent}
+.btn-ghost:hover:not(:disabled){background:var(--surface-sunken)}
+.btn-destructive{background:var(--status-danger-bg);color:var(--status-danger-fg);border:1px solid var(--status-danger-border)}
+.btn-destructive:hover:not(:disabled){opacity:.85}
+.btn-link{background:none;color:var(--brand-primary);border:none;padding:0;height:auto;font-size:inherit}
+.btn-link:hover:not(:disabled){text-decoration:underline}
+.btn-disabled,.btn:disabled{opacity:.5;cursor:not-allowed!important}
+.btn-spinner{width:14px;height:14px;animation:btn-spin .7s linear infinite;flex-shrink:0}
+@keyframes btn-spin{to{transform:rotate(360deg)}}
+/* ─── Badge component ─────────────────────────────────────────────────────── */
+.bdg{display:inline-flex;align-items:center;gap:4px;border-radius:9999px;font-size:12px;font-weight:500;line-height:1;padding:3px 8px;border:1px solid transparent}
+.bdg-neutral{background:var(--status-neutral-bg);color:var(--status-neutral-fg);border-color:var(--status-neutral-border)}
+.bdg-success{background:var(--status-success-bg);color:var(--status-success-fg);border-color:var(--status-success-border)}
+.bdg-warning{background:var(--status-warning-bg);color:var(--status-warning-fg);border-color:var(--status-warning-border)}
+.bdg-danger {background:var(--status-danger-bg); color:var(--status-danger-fg); border-color:var(--status-danger-border)}
+.bdg-info   {background:var(--status-info-bg);   color:var(--status-info-fg);   border-color:var(--status-info-border)}
+.bdg-solid-neutral{background:var(--status-neutral-fg);color:var(--surface-elevated)}
+.bdg-solid-success{background:var(--status-success-fg);color:#fff}
+.bdg-solid-warning{background:var(--status-warning-fg);color:#fff}
+.bdg-solid-danger {background:var(--status-danger-fg); color:#fff}
+.bdg-solid-info   {background:var(--status-info-fg);   color:#fff}
+.bdg-outline-neutral{background:transparent;color:var(--status-neutral-fg);border-color:var(--status-neutral-border)}
+.bdg-outline-success{background:transparent;color:var(--status-success-fg);border-color:var(--status-success-border)}
+.bdg-outline-warning{background:transparent;color:var(--status-warning-fg);border-color:var(--status-warning-border)}
+.bdg-outline-danger {background:transparent;color:var(--status-danger-fg); border-color:var(--status-danger-border)}
+.bdg-outline-info   {background:transparent;color:var(--status-info-fg);   border-color:var(--status-info-border)}
+/* ─── Card component ──────────────────────────────────────────────────────── */
+.card{border-radius:var(--radius-lg);overflow:hidden}
+.card-bordered{background:var(--surface-elevated);border:1px solid var(--border-subtle);box-shadow:var(--shadow-1)}
+.card-elevated{background:var(--surface-elevated);box-shadow:var(--shadow-3)}
+.card-inset{background:var(--surface-sunken);border:1px solid var(--border-subtle)}
+.card-header{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;border-bottom:1px solid var(--border-subtle)}
+.card-title{font-weight:600;font-size:14px;color:var(--fg-primary)}
+.card-actions{display:flex;align-items:center;gap:8px}
+.card-body{padding:16px}
+.card-body-sm{padding:12px}
+.card-body-lg{padding:20px}
+/* ─── Form controls ───────────────────────────────────────────────────────── */
+.form-field{display:flex;flex-direction:column;gap:4px}
+.form-label{font-size:13px;font-weight:500;color:var(--fg-secondary)}
+.form-helper{font-size:12px;color:var(--fg-muted)}
+.form-error{font-size:12px;color:var(--status-danger-fg)}
+.form-input,.form-select,.form-textarea{background:var(--surface-elevated);color:var(--fg-primary);border:1px solid var(--border-subtle);border-radius:var(--radius-md);font-size:14px;outline:none;transition:border-color .15s,box-shadow .15s;width:100%;box-sizing:border-box}
+.form-input{height:36px;padding:0 12px}
+.form-select{height:44px;padding:0 12px}
+.form-textarea{padding:8px 12px;min-height:80px;resize:vertical;line-height:1.5}
+.form-input:focus,.form-select:focus,.form-textarea:focus{border-color:var(--brand-primary);box-shadow:0 0 0 3px rgba(79,70,229,.2)}
+.form-input:disabled,.form-select:disabled,.form-textarea:disabled{opacity:.6;cursor:not-allowed;background:var(--surface-sunken)}
+.form-input-error,.form-select-error,.form-textarea-error{border-color:var(--status-danger-border)!important}
+.form-input-error:focus,.form-select-error:focus,.form-textarea-error:focus{box-shadow:0 0 0 3px rgba(153,27,27,.2)!important}
+.form-textarea-mono{font-family:ui-monospace,"JetBrains Mono",SF Mono,Menlo,monospace}
+.form-check-wrap,.form-toggle-wrap{display:inline-flex;align-items:center;gap:8px;cursor:pointer;font-size:13px;color:var(--fg-secondary)}
+.form-checkbox,.form-radio{width:16px;height:16px;accent-color:var(--brand-primary);cursor:pointer;flex-shrink:0}
+.form-toggle{appearance:none;width:36px;height:20px;background:var(--border-strong);border-radius:9999px;position:relative;cursor:pointer;transition:background .2s;flex-shrink:0}
+.form-toggle:checked{background:var(--brand-primary)}
+.form-toggle::after{content:"";position:absolute;width:14px;height:14px;background:#fff;border-radius:9999px;top:3px;left:3px;transition:left .2s}
+.form-toggle:checked::after{left:19px}
+.form-toggle:focus-visible,.form-checkbox:focus-visible,.form-radio:focus-visible{outline:2px solid var(--brand-primary);outline-offset:2px}
+/* ─── YAML editor ─────────────────────────────────────────────────────────── */
+.yaml-editor-wrap{border:1px solid var(--border-subtle);border-radius:var(--radius-md);overflow:hidden;display:flex;background:var(--surface-elevated)}
+.yaml-editor-wrap:focus-within{border-color:var(--brand-primary);box-shadow:0 0 0 3px rgba(79,70,229,.2)}
+.yaml-gutter{user-select:none;background:var(--surface-sunken);color:var(--fg-muted);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;line-height:1.5;padding:8px 8px 8px 4px;text-align:right;min-width:36px;border-right:1px solid var(--border-subtle);overflow:hidden;white-space:pre}
+.yaml-editor{flex:1;border:none!important;border-radius:0!important;box-shadow:none!important;resize:vertical;font-family:ui-monospace,"JetBrains Mono",SF Mono,Menlo,monospace;font-size:13px;line-height:1.5;padding:8px 12px;tab-size:2;background:var(--surface-elevated);color:var(--fg-primary);min-height:160px;outline:none}
+/* ─── Code blocks ─────────────────────────────────────────────────────────── */
+.code-inline{background:var(--surface-sunken);border:1px solid var(--border-subtle);border-radius:var(--radius-sm);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.9em;padding:1px 5px}
+.code-block-wrap{position:relative;border-radius:var(--radius-lg);overflow:hidden;background:var(--surface-sunken);border:1px solid var(--border-subtle)}
+.code-block{display:block;margin:0;padding:16px;font-family:ui-monospace,"JetBrains Mono",SF Mono,Menlo,monospace;font-size:13px;line-height:1.5;overflow-x:auto;white-space:pre;color:var(--fg-primary)}
+.code-copy-btn{position:absolute;top:8px;right:8px;padding:3px 8px;font-size:12px;background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:var(--radius-sm);cursor:pointer;color:var(--fg-secondary);z-index:1}
+.code-copy-btn:hover{background:var(--surface-overlay);border-color:var(--border-strong)}
+.yaml-key{color:var(--brand-primary)}
+.yaml-string{color:var(--status-success-fg)}
+/* ─── Data table ──────────────────────────────────────────────────────────── */
+.data-table-wrap{overflow-x:auto;border:1px solid var(--border-subtle);border-radius:var(--radius-lg)}
+.data-table{width:100%;border-collapse:collapse;font-size:13px}
+.data-table thead{position:sticky;top:0;z-index:var(--z-sticky);background:var(--surface-sunken)}
+.data-table-th{padding:8px 12px;text-align:left;font-weight:600;font-size:12px;color:var(--fg-secondary);border-bottom:1px solid var(--border-subtle);white-space:nowrap;text-transform:uppercase;letter-spacing:.025em}
+.data-table td{padding:8px 12px;border-bottom:1px solid var(--border-subtle);color:var(--fg-primary)}
+.data-table tbody tr:hover{background:var(--surface-sunken)}
+.data-table tbody tr:last-child td{border-bottom:none}
+.data-table-sort{cursor:pointer;user-select:none}
+.data-table-sort::after{content:" ↕";opacity:.4;font-size:11px}
+.data-table-sort[data-dir="asc"]::after{content:" ↑";opacity:.9}
+.data-table-sort[data-dir="desc"]::after{content:" ↓";opacity:.9}
+.data-table-empty{text-align:center;padding:32px 16px;color:var(--fg-muted);font-size:14px}
 </style>
 </head>
 <body class="bg-surface text-primary min-h-screen">

--- a/src/server/styleguide.ts
+++ b/src/server/styleguide.ts
@@ -1,5 +1,18 @@
 import { Hono } from "hono";
 import { html, page, isHtmx } from "./layout.js";
+import { button } from "./components/button.js";
+import { badge } from "./components/badge.js";
+import { card } from "./components/card.js";
+import {
+  formField,
+  formInput,
+  formSelect,
+  formTextarea,
+  formCheckbox,
+  formToggle,
+} from "./components/form.js";
+import { codeInline, codeBlock } from "./components/code.js";
+import { table } from "./components/table.js";
 
 const SURFACE_TOKENS = [
   { var: "--surface-base", label: "surface-base" },
@@ -120,6 +133,96 @@ export function styleguideRoute(): Hono {
           Z-index Layers
         </h2>
         <div class="grid grid-cols-3 gap-3 max-w-sm">${zIndexTable()}</div>
+      </section>
+
+      <section class="mb-10">
+        <h2 class="text-lg font-semibold text-primary mb-4 border-b border-subtle pb-2">Buttons</h2>
+        <h3 class="text-sm font-medium text-secondary uppercase tracking-wide mb-3">Variants (md)</h3>
+        <div class="flex flex-wrap gap-3 items-center mb-4">
+          ${button({ variant: "primary", label: "Primary" })} ${button({ variant: "secondary", label: "Secondary" })}
+          ${button({ variant: "ghost", label: "Ghost" })} ${button({ variant: "destructive", label: "Destructive" })}
+          ${button({ variant: "link", label: "Link" })}
+        </div>
+        <h3 class="text-sm font-medium text-secondary uppercase tracking-wide mb-3">Sizes</h3>
+        <div class="flex flex-wrap gap-3 items-center mb-4">
+          ${button({ variant: "primary", size: "sm", label: "Small (sm)" })} ${button({ variant: "primary", size: "md", label: "Medium (md)" })}
+          ${button({ variant: "primary", size: "lg", label: "Large (lg)" })}
+        </div>
+        <h3 class="text-sm font-medium text-secondary uppercase tracking-wide mb-3">States</h3>
+        <div class="flex flex-wrap gap-3 items-center">
+          ${button({ variant: "primary", label: "Default" })} ${button({ variant: "primary", label: "Disabled", disabled: true })}
+          ${button({ variant: "primary", label: "Loading…", loading: true })} ${button({ variant: "secondary", label: "Disabled", disabled: true })}
+          ${button({ variant: "destructive", label: "Disabled", disabled: true })}
+        </div>
+      </section>
+
+      <section class="mb-10">
+        <h2 class="text-lg font-semibold text-primary mb-4 border-b border-subtle pb-2">Badges</h2>
+        <h3 class="text-sm font-medium text-secondary uppercase tracking-wide mb-3">Soft (default)</h3>
+        <div class="flex flex-wrap gap-2 mb-4">
+          ${badge({ tone: "neutral", label: "neutral" })} ${badge({ tone: "success", label: "success" })}
+          ${badge({ tone: "warning", label: "warning" })} ${badge({ tone: "danger", label: "danger" })}
+          ${badge({ tone: "info", label: "info" })}
+        </div>
+        <h3 class="text-sm font-medium text-secondary uppercase tracking-wide mb-3">Solid</h3>
+        <div class="flex flex-wrap gap-2 mb-4">
+          ${badge({ tone: "neutral", variant: "solid", label: "neutral" })} ${badge({ tone: "success", variant: "solid", label: "success" })}
+          ${badge({ tone: "warning", variant: "solid", label: "warning" })} ${badge({ tone: "danger", variant: "solid", label: "danger" })}
+          ${badge({ tone: "info", variant: "solid", label: "info" })}
+        </div>
+        <h3 class="text-sm font-medium text-secondary uppercase tracking-wide mb-3">Outline</h3>
+        <div class="flex flex-wrap gap-2 mb-4">
+          ${badge({ tone: "neutral", variant: "outline", label: "neutral" })} ${badge({ tone: "success", variant: "outline", label: "success" })}
+          ${badge({ tone: "warning", variant: "outline", label: "warning" })} ${badge({ tone: "danger", variant: "outline", label: "danger" })}
+          ${badge({ tone: "info", variant: "outline", label: "info" })}
+        </div>
+        <h3 class="text-sm font-medium text-secondary uppercase tracking-wide mb-3">
+          With dot (status use)
+        </h3>
+        <div class="flex flex-wrap gap-2">
+          ${badge({ tone: "success", label: "done", dot: true })} ${badge({ tone: "info", label: "running", dot: true })}
+          ${badge({ tone: "warning", label: "pending", dot: true })} ${badge({ tone: "danger", label: "error", dot: true })}
+          ${badge({ tone: "neutral", label: "closed", dot: true })}
+        </div>
+      </section>
+
+      <section class="mb-10">
+        <h2 class="text-lg font-semibold text-primary mb-4 border-b border-subtle pb-2">Cards</h2>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          ${card({ title: "Bordered (default)", variant: "bordered", body: html`<p class="text-secondary text-sm">Default card with border and subtle shadow.</p>` })} ${card({ title: "Elevated", variant: "elevated", body: html`<p class="text-secondary text-sm">Drop shadow, no border. For floating panels.</p>` })}
+          ${card({ title: "Inset", variant: "inset", body: html`<p class="text-secondary text-sm">Sunken background. For code previews and embeds.</p>` })}
+        </div>
+        <div class="mt-4">${card({ title: "With actions", variant: "bordered", actions: html`${button({ variant: "ghost", size: "sm", label: "Edit" })} ${button({ variant: "destructive", size: "sm", label: "Delete" })}`, body: html`<p class="text-secondary text-sm">Card with a title bar and right-aligned action buttons.</p>` })}</div>
+      </section>
+
+      <section class="mb-10">
+        <h2 class="text-lg font-semibold text-primary mb-4 border-b border-subtle pb-2">Form Controls</h2>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 max-w-2xl">
+          ${formField({ id: "ex-text", label: "Text input", helper: "Helper text below the field", control: formInput({ name: "ex-text", id: "ex-text", placeholder: "Enter text…" }) })} ${formField({ id: "ex-pass", label: "Password input", control: formInput({ name: "ex-pass", id: "ex-pass", type: "password", placeholder: "••••••" }) })}
+          ${formField({ id: "ex-select", label: "Select", helper: "Pick one option", control: formSelect({ name: "ex-select", id: "ex-select", options: [{ value: "", label: "Choose…" }, { value: "a", label: "Option A" }, { value: "b", label: "Option B" }] }) })} ${formField({ id: "ex-err", label: "With error", error: "This field is required", control: formInput({ name: "ex-err", id: "ex-err", hasError: true, placeholder: "Required field" }) })}
+        </div>
+        <div class="mt-4 max-w-2xl">${formField({ id: "ex-ta", label: "Textarea", helper: "Resizable multi-line input", control: formTextarea({ name: "ex-ta", id: "ex-ta", rows: 3, placeholder: "Enter description…" }) })}</div>
+        <div class="mt-4 flex flex-wrap gap-6 items-center">
+          ${formCheckbox({ name: "ex-cb", label: "Checkbox option" })} ${formCheckbox({ name: "ex-cb2", label: "Checked checkbox", checked: true })}
+          ${formToggle({ name: "ex-tog", label: "Toggle off" })} ${formToggle({ name: "ex-tog2", label: "Toggle on", checked: true })}
+        </div>
+      </section>
+
+      <section class="mb-10">
+        <h2 class="text-lg font-semibold text-primary mb-4 border-b border-subtle pb-2">Code Blocks</h2>
+        <div class="mb-4">
+          <p class="text-sm text-secondary mb-2">
+            Inline: use ${codeInline("codeInline()")} for short references like
+            ${codeInline("--brand-primary")} or ${codeInline("src/server/layout.ts")}.
+          </p>
+        </div>
+        <div class="mb-4">${codeBlock({ code: `# Block code example\nconst greeting = "hello world";\nconsole.log(greeting);`, copyButton: true })}</div>
+        <div>${codeBlock({ lang: "yaml", code: `repos:\n  - provider: github\n    owner: openronin\n    name: openronin\nengine:\n  model: claude-sonnet-4-6`, copyButton: true })}</div>
+      </section>
+
+      <section class="mb-10">
+        <h2 class="text-lg font-semibold text-primary mb-4 border-b border-subtle pb-2">Data Table</h2>
+        ${tableDemo()}
       </section>
 
       <script>
@@ -277,4 +380,48 @@ function zIndexTable(): string {
         `</div>`,
     )
     .join("");
+}
+
+function tableDemo(): import("./layout.js").TrustedHtml {
+  const demoRows = [
+    html`<tr>
+      <td class="px-3 py-2">#1</td>
+      <td class="px-3 py-2">openronin/openronin</td>
+      <td class="px-3 py-2">${badge({ tone: "success", label: "active", dot: true })}</td>
+      <td class="px-3 py-2">${button({ variant: "ghost", size: "sm", label: "View" })}</td>
+    </tr>`,
+    html`<tr>
+      <td class="px-3 py-2">#2</td>
+      <td class="px-3 py-2">openronin/docs</td>
+      <td class="px-3 py-2">${badge({ tone: "warning", label: "pending", dot: true })}</td>
+      <td class="px-3 py-2">${button({ variant: "ghost", size: "sm", label: "View" })}</td>
+    </tr>`,
+    html`<tr>
+      <td class="px-3 py-2">#3</td>
+      <td class="px-3 py-2">openronin/playground</td>
+      <td class="px-3 py-2">${badge({ tone: "neutral", label: "inactive", dot: true })}</td>
+      <td class="px-3 py-2">${button({ variant: "ghost", size: "sm", label: "View" })}</td>
+    </tr>`,
+  ];
+  const fullTable = table({
+    columns: [
+      { key: "id", label: "#", nowrap: true },
+      { key: "name", label: "Name", sortable: true },
+      { key: "status", label: "Status", sortable: true },
+      { key: "actions", label: "" },
+    ],
+    rows: demoRows,
+    currentSort: { key: "name", dir: "asc" },
+  });
+  const emptyTable = table({
+    columns: [
+      { key: "id", label: "#" },
+      { key: "name", label: "Name" },
+    ],
+    rows: [],
+    emptyMessage: "No repos configured yet.",
+    emptyCta: button({ variant: "primary", size: "sm", label: "Add repo", href: "/admin/repos" }),
+  });
+  return html`${fullTable}
+    <div class="mt-4">${emptyTable}</div>`;
 }


### PR DESCRIPTION
🤖 openronin: автоматический PR.

Closes #11.

This PR was opened automatically by [openronin](https://github.com/openronin/openronin) in response to issue #11.

## Agent summary

Committed. Here's a summary of what was done:

---

## Summary

### What changed

**New files — `src/server/components/`**

| File | Exports | Description |
|---|---|---|
| `button.ts` | `button(props)` | 5 variants (primary, secondary, ghost, destructive, link) × 3 sizes (sm/md/lg); supports disabled, loading spinner, HTMX attrs including `hx-confirm` and `hx-indicator` |
| `badge.ts` | `badge(props)` | 5 tones (neutral/success/warning/danger/info) × 3 variants (soft/solid/outline); optional dot prefix for status use |
| `card.ts` | `card(props)` | 3 variants (bordered/elevated/inset); optional title bar + right-aligned actions slot |
| `form.ts` | `formField`, `formInput`, `formSelect`, `formTextarea`, `formCheckbox`, `formToggle`, `yamlEditor` | Consistent height/focus/disabled/error states; YAML editor with live line-number gutter via inline script |
| `code.ts` | `codeInline`, `codeBlock` | Inline `<code>` and block `<pre><code>` with optional copy button; YAML syntax highlighting (keys + string values) via regex, no library |
| `table.ts` | `table(props)` | Sticky header, compact 13px rows, hover tint, sort indicators, empty-state with CTA slot |

**Modified — `src/server/layout.ts`**  
Added ~94 lines of CSS for all component classes, consuming existing design tokens. Includes focus rings (`:focus-visible`), toggle switch animation, loading spinner keyframe, and sort indicator arrows.

**Modified — `src/server/styleguide.ts`**  
Extended `/_tokens` page with six new sections showcasing every component variant and state.

**Modified — `src/server/admin.ts`**  
Dashboard refactored as the demonstration page:
- 4 action buttons replaced with `button()` component calls
- Recent-runs status pills replaced with `badge()` component calls (`runStatusTone()` helper added)

### Checks run
- `pnpm run check` — build ✓, lint (0 errors, 5 pre-existing warnings unrelated to this PR) ✓, 39/39 unit tests ✓, format ✓

## Diff stats

- Files changed: 9
- Lines: +772 / -52

---
*Marked as draft for human review. The agent (claude_code) wrote this; please review before merging.*