### PR TITLE
[openronin] Triage lane re-runs forever on unchanged done tasks (snapshot_hash not compared)

### DIFF
--- a/src/lanes/review.ts
+++ b/src/lanes/review.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import { createHash } from "node:crypto";
 import type { VcsItem } from "../providers/vcs.js";
 import { loadTemplate, renderTemplate } from "../prompts/registry.js";
 import { runJob, type SelectionOverride, type SupervisorContext } from "../supervisor/index.js";
 import { ensureRepo, recordTaskDecision, upsertTask } from "../storage/tasks.js";
+import { computeItemSnapshot } from "../lib/snapshot.js";
 
 export const ReviewDecisionSchema = z.object({
   decision: z.enum(["close", "keep_open"]),
@@ -100,18 +100,7 @@ export async function runReview(input: ReviewRunInput): Promise<ReviewRunOutput>
     decision.comment = "";
   }
 
-  const snapshot = createHash("sha256")
-    .update(
-      JSON.stringify({
-        title: item.title,
-        body: item.body,
-        state: item.state,
-        labels: item.labels,
-        updatedAt: item.updatedAt,
-      }),
-    )
-    .digest("hex")
-    .slice(0, 16);
+  const snapshot = computeItemSnapshot(item);
 
   recordTaskDecision(ctx.db, taskId, snapshot, JSON.stringify(decision));
 

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -1,0 +1,18 @@
+import { createHash } from "node:crypto";
+import type { VcsItem } from "../providers/vcs.js";
+
+export function computeItemSnapshot(item: VcsItem): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        title: item.title,
+        body: item.body.slice(0, 8000),
+        state: item.state,
+        labels: [...item.labels].sort().join(","),
+        updatedAt: item.updatedAt,
+        author: item.author,
+      }),
+    )
+    .digest("hex")
+    .slice(0, 16);
+}

--- a/src/scheduler/reconcile.ts
+++ b/src/scheduler/reconcile.ts
@@ -9,6 +9,7 @@ import { computeNextDueAt } from "./cadence.js";
 import { listPrBranches } from "../storage/pr-branches.js";
 import { isBotMessage } from "../lanes/messages.js";
 import { parseSqliteUtc } from "../lib/time.js";
+import { computeItemSnapshot } from "../lib/snapshot.js";
 
 export interface ReconcileResult {
   repo: string;
@@ -191,19 +192,30 @@ function planTask(
     return false;
   }
 
-  // First scan ever (no snapshot) → high priority, due now.
-  // Past-due → normal priority, due now.
-  // Otherwise leave it.
+  const currentSnapshot = computeItemSnapshot(item);
   const newToUs = !existing.snapshot_hash;
+  const unchanged = existing.snapshot_hash === currentSnapshot;
   const dueNow = !existing.next_due_at || new Date(existing.next_due_at).getTime() <= now.getTime();
 
+  // First scan ever → high priority.
   if (newToUs) {
     enqueue(db, taskId, "high", null);
     return true;
   }
+
   if (dueNow) {
-    enqueue(db, taskId, "normal", computeNextDueAt(item.createdAt, cadence, now));
-    return true;
+    if (!unchanged) {
+      // Content changed → re-triage at normal priority.
+      enqueue(db, taskId, "normal", computeNextDueAt(item.createdAt, cadence, now));
+      return true;
+    }
+    // Content unchanged → push next_due_at forward without enqueueing.
+    db.prepare("UPDATE tasks SET next_due_at = ? WHERE id = ?").run(
+      computeNextDueAt(item.createdAt, cadence, now),
+      taskId,
+    );
+    return false;
   }
+
   return false;
 }

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -207,4 +207,21 @@ function applyMigrations(db: Db): void {
       "INSERT INTO schema_version (version, applied_at) VALUES (10, datetime('now'))",
     ).run();
   }
+
+  if (current < 11) {
+    // Push done tasks that are overdue into the cold bucket so the reconciler
+    // stops re-triaging them immediately. New code prevents this state going forward
+    // by comparing snapshot_hash before enqueueing.
+    db.exec(`
+      UPDATE tasks
+      SET next_due_at = datetime('now', '+24 hours')
+      WHERE status = 'done'
+        AND snapshot_hash IS NOT NULL
+        AND next_due_at IS NOT NULL
+        AND next_due_at < datetime('now', '+12 hours');
+    `);
+    db.prepare(
+      "INSERT INTO schema_version (version, applied_at) VALUES (11, datetime('now'))",
+    ).run();
+  }
 }

--- a/test/reconcile.test.mjs
+++ b/test/reconcile.test.mjs
@@ -1,0 +1,155 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function makeItem(overrides = {}) {
+  return {
+    number: 42,
+    kind: "issue",
+    title: "Test issue",
+    body: "Some body text",
+    author: "alice",
+    authorAssociation: "CONTRIBUTOR",
+    state: "open",
+    labels: ["bug"],
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-02T00:00:00Z",
+    url: "https://github.com/test/repo/issues/42",
+    ...overrides,
+  };
+}
+
+function makeProvider(items) {
+  return {
+    id: "mock",
+    async *listOpenItems() {
+      for (const item of items) yield item;
+    },
+    async getItem() {
+      throw new Error("not expected");
+    },
+    async postComment() {
+      throw new Error("not expected");
+    },
+    async updateComment() {
+      throw new Error("not expected");
+    },
+    async closeItem() {
+      throw new Error("not expected");
+    },
+    async listAllPrFeedback() {
+      return [];
+    },
+    verifyWebhookSignature() {
+      return true;
+    },
+  };
+}
+
+const cadence = { hot: "1h", default: "24h", cold: "72h" };
+
+const baseRepo = {
+  provider: "github",
+  owner: "test",
+  name: "repo",
+  lanes: ["review"],
+  cadence,
+  patch_trigger_label: undefined,
+  pr_dialog_skip_authors: [],
+  auto_merge: { enabled: false },
+  protected_labels: [],
+  language_for_communication: "English",
+  language_for_commits: "English",
+  language_for_code_identifiers: "English",
+};
+
+test("reconcile: new item is enqueued at high priority", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "reconcile-test-"));
+  try {
+    const { initDb } = await import("../dist/storage/db.js");
+    const { reconcileRepo } = await import("../dist/scheduler/reconcile.js");
+
+    const db = initDb(tmp);
+    const item = makeItem();
+    const provider = makeProvider([item]);
+
+    const result = await reconcileRepo(db, baseRepo, cadence, provider);
+
+    assert.equal(result.enqueued, 1);
+    const task = db.prepare("SELECT * FROM tasks WHERE external_id = '42'").get();
+    assert.equal(task.status, "pending");
+    assert.equal(task.priority, "high");
+    db.close();
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("reconcile: done item with unchanged content is not re-enqueued", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "reconcile-test-"));
+  try {
+    const { initDb } = await import("../dist/storage/db.js");
+    const { ensureRepo, upsertTask, recordTaskDecision } = await import("../dist/storage/tasks.js");
+    const { computeItemSnapshot } = await import("../dist/lib/snapshot.js");
+    const { reconcileRepo } = await import("../dist/scheduler/reconcile.js");
+
+    const db = initDb(tmp);
+    const item = makeItem();
+
+    const repoId = ensureRepo(db, { provider: "github", owner: "test", name: "repo" });
+    const taskId = upsertTask(db, repoId, "42", "issue");
+    const snapshot = computeItemSnapshot(item);
+    recordTaskDecision(db, taskId, snapshot, '{"decision":"keep_open"}');
+    db.prepare(
+      "UPDATE tasks SET status = 'done', next_due_at = datetime('now', '-1 hour') WHERE id = ?",
+    ).run(taskId);
+
+    const provider = makeProvider([item]);
+    const result = await reconcileRepo(db, baseRepo, cadence, provider);
+
+    assert.equal(result.enqueued, 0);
+    const task = db.prepare("SELECT * FROM tasks WHERE id = ?").get(taskId);
+    assert.equal(task.status, "done");
+    // next_due_at should have been bumped forward
+    const nextDue = new Date(task.next_due_at);
+    assert.ok(nextDue.getTime() > Date.now(), "next_due_at should be in the future");
+    db.close();
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("reconcile: done item with changed labels triggers re-enqueue", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "reconcile-test-"));
+  try {
+    const { initDb } = await import("../dist/storage/db.js");
+    const { ensureRepo, upsertTask, recordTaskDecision } = await import("../dist/storage/tasks.js");
+    const { computeItemSnapshot } = await import("../dist/lib/snapshot.js");
+    const { reconcileRepo } = await import("../dist/scheduler/reconcile.js");
+
+    const db = initDb(tmp);
+    const oldItem = makeItem({ labels: ["bug"] });
+
+    const repoId = ensureRepo(db, { provider: "github", owner: "test", name: "repo" });
+    const taskId = upsertTask(db, repoId, "42", "issue");
+    const oldSnapshot = computeItemSnapshot(oldItem);
+    recordTaskDecision(db, taskId, oldSnapshot, '{"decision":"keep_open"}');
+    db.prepare(
+      "UPDATE tasks SET status = 'done', next_due_at = datetime('now', '-1 hour') WHERE id = ?",
+    ).run(taskId);
+
+    // Same item but labels changed
+    const newItem = makeItem({ labels: ["bug", "enhancement"] });
+    const provider = makeProvider([newItem]);
+    const result = await reconcileRepo(db, baseRepo, cadence, provider);
+
+    assert.equal(result.enqueued, 1);
+    const task = db.prepare("SELECT * FROM tasks WHERE id = ?").get(taskId);
+    assert.equal(task.status, "pending");
+    db.close();
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
🤖 openronin: автоматический PR.

Closes #19.

This PR was opened automatically by [openronin](https://github.com/openronin/openronin) in response to issue #19.

## Agent summary

## Summary

**Problem:** The triage lane re-ran on every cadence cycle for already-done tasks because `planTask()` treated `snapshot_hash` as a boolean "ever processed" flag — it was never compared to the current item's content.

**Changes made:**

### `src/lib/snapshot.ts` (new)
Exports `computeItemSnapshot(item: VcsItem): string` — a deterministic SHA-256 hash over `title`, `body` (capped at 8000 chars), `state`, sorted `labels`, `updatedAt`, and `author`. Returns 16 hex chars to match the existing column size.

### `src/lanes/review.ts`
Removed the inline hash computation; now imports and calls `computeItemSnapshot()`. The hash inputs are now consistent between the recorder and the reconciler.

### `src/scheduler/reconcile.ts`
In `planTask()`, after the early-exit guards, computes the current snapshot and compares:
- **New item** (no stored hash) → enqueue at high priority (unchanged)
- **Past-due + content changed** → enqueue at normal priority
- **Past-due + content unchanged** → bump `next_due_at` forward without enqueueing; no triage run, no cost

### `src/storage/db.ts`
Added migration v11: pushes all existing `done` tasks with stale `next_due_at` to `+24 hours`, stopping the in-flight polling storm immediately on deploy.

### `test/reconcile.test.mjs` (new)
Three unit tests covering the three key decision-tree branches: new item enqueued high, unchanged done item not re-enqueued (with `next_due_at` bumped), changed labels trigger re-enqueue.

**Checks:** `pnpm run check` — build ✓, lint ✓ (5 pre-existing warnings, 0 errors), 42/42 tests pass, format ✓.

## Diff stats

- Files changed: 5
- Lines: +209 / -18

---
*Marked as draft for human review. The agent (claude_code) wrote this; please review before merging.*