### PR TITLE
feat(director): foundation — schema, types, chat, charter, budget, service entry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,27 @@ TODOIST_TOKEN=
 # Get from @BotFather: https://t.me/BotFather
 TELEGRAM_BOT_TOKEN=
 
+# ── Director — autonomous PM layer (optional) ─────────────────────────────
+# See docs/DIRECTOR.md. The Director is a separate systemd service that
+# shares this code, DB, and OPENRONIN_DATA_DIR but acts in a different role:
+# it watches project state and decides what to do next. Per-repo enable +
+# charter live in the per-repo YAML config (under `director:`).
+
+# Master kill switch. Set to 1 to make the director service start, log
+# "disabled", and idle without ticking. Useful for emergency pause without
+# stopping the systemd unit.
+# OPENRONIN_DIRECTOR_DISABLED=0
+
+# Telegram bridge for the director's chat thread. Different bot from the
+# tracker provider's TELEGRAM_BOT_TOKEN above. Get token from @BotFather.
+# Authorized user IDs go in $OPENRONIN_DATA_DIR/config/director.yaml,
+# never in this file.
+# OPENRONIN_DIRECTOR_TELEGRAM_TOKEN=
+
+# Anthropic API model used for director planning ticks. Defaults to a
+# reasoning-capable model; the supervisor's MIMO is too thin for this role.
+# OPENRONIN_DIRECTOR_THINK_MODEL=claude-sonnet-4-5
+
 # ── Backups (optional) ─────────────────────────────────────────────────────
 # rsync destination for daily off-host backups. See deploy/openronin-backup-*
 # systemd units. Format: user@remote:/path/to/dest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to **openronin** are documented here. The format follows [Ke
 
 ## [Unreleased]
 
+### Added — Director (autonomous PM layer), foundation
+
+A new optional service, `openronin-director.service`, adds a third architectural layer above the existing supervisor/worker split. The Director runs as a separate systemd unit but shares this codebase, the SQLite DB, and `OPENRONIN_DATA_DIR`. It's the source of intent — what the project should work on next — where the existing daemon is purely reactive to events.
+
+This release is the **foundation only**: schema, scaffolding, charter loader, adaptive-budget tracker, decision audit trail, chat thread data layer, read-only admin timeline at `/admin/director`. The service ticks per `cadence_hours`, captures the charter version, and writes a no-op message to its chat. The LLM-driven planning tick lands in the next release.
+
+- New schema migration **v12** — `director_messages`, `director_decisions`, `director_charter_versions`, `director_budget_state`. All new tables; nothing existing is touched.
+- New per-repo YAML block: `director:` (Zod-validated). Default disabled; needs `enabled: true` plus a non-empty `charter` to do anything.
+- New entry point: `node dist/index.js director:run` — the long-running director service.
+- New env vars: `OPENRONIN_DIRECTOR_DISABLED` (master kill switch), `OPENRONIN_DIRECTOR_TELEGRAM_TOKEN` (reserved for the upcoming Telegram bridge).
+- New systemd unit template at `deploy/openronin-director.service`.
+- New docs: `docs/DIRECTOR.md`.
+- 11 new unit tests covering migration, charter parsing/versioning/dedup, chat append + recent + since helpers, decision lifecycle, budget gate (paused / failure-streak / think / daily / weekly).
+
+Safe to upgrade without enabling: existing functionality is unchanged. The director sub-route at `/admin/director` returns "no director-enabled repos" until you opt in per repo.
+
+
 ## [0.1.0] — Initial public release
 
 First public release. The codebase has been used in production on a handful of personal repos for several weeks before this point; this release is the cleaned-up, sanitized, and re-licensed version of that work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,11 @@ Instructions for Claude Code (and other AI coding agents) working on this reposi
 
 ## What this is
 
-`openronin` — a self-hosted AI developer agent. It watches repos, picks up issues, opens PRs, iterates on review feedback, and merges when ready. Architecturally it's a **MIMO supervisor + Claude Code worker** split: cheap classifier routes, expensive coder writes.
+`openronin` — a self-hosted AI developer agent. It watches repos, picks up issues, opens PRs, iterates on review feedback, and merges when ready. Architecturally it's a three-layer split:
+
+1. **Director** *(opt-in, separate systemd unit)* — proactive PM layer. Reads a per-repo charter and decides what the project should work on next. Emits decisions (create issue, comment, approve merge) into a chat thread. **Never edits source files.** See `docs/DIRECTOR.md` and `src/director/`.
+2. **Supervisor** (MIMO) — cheap classifier that routes lanes.
+3. **Worker** (Claude Code) — the only engine allowed to mutate code.
 
 The agent eats its own dog food — most lanes after the bootstrap landed via the bot's own pipeline. If you're reading this as Claude Code working on this repo, you're literally working on yourself.
 
@@ -36,13 +40,16 @@ The agent eats its own dog food — most lanes after the bootstrap landed via th
 - **Iteration counter** (pr_dialog) only bumps on **successful pushes**. Failed iterations don't burn the budget.
 - **SQLite UTC parsing.** Always use `parseSqliteUtc()` from `src/lib/time.ts` when comparing DB cutoffs to API ISO timestamps. Bare `new Date(sqlite_text)` shifts by the server's local TZ.
 - **Force-push.** Always pass an explicit `<branch>:<sha>` lease to `git push --force-with-lease`. Bare form fails with `(stale info)` after a single-branch clone.
+- **Director boundary.** The Director (`src/director/`) is read-only on source code. It only writes to its own DB tables (`director_*`) and emits decisions that the existing lane infrastructure carries out. Don't have it call `runPatch` directly, don't have it touch worktrees. If you're tempted to skip the lane router from the Director, you're doing something wrong.
+- **Charter-pin every Director decision.** Each row in `director_decisions` must reference the `charter_version` it was produced under. Never write a decision without one — the audit trail breaks.
 
 ## Project layout
 
 ```
 src/
-├── index.ts                CLI vs server entry, graceful SIGTERM
-├── server/                 Hono: admin (HTMX+Tailwind CDN), webhooks, healthz, /api, layout
+├── index.ts                CLI vs server vs director:run entry, graceful SIGTERM
+├── director/               Director: types, charter, chat, decisions, budget, service entry (separate systemd unit)
+├── server/                 Hono: admin (HTMX+Tailwind CDN), webhooks, healthz, /api, layout, admin-director
 ├── supervisor/             selectEngine + runJob (cost cap + RateLimited handling)
 ├── engines/                mimo (cost calc), claude-code (RateLimited detect), anthropic, multi-agent
 ├── providers/              vcs interface; github, gitlab; tracker interface; jira, todoist, telegram

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ That entire flow happens without you visiting any UI besides GitHub. The agent i
 
 ```mermaid
 flowchart TD
+    Z["👔 Director<br/>(opt-in, separate service)"] -. "proposes issue" .-> A
     A["📝 You file an issue<br/>(label: openronin:do-it)"] --> B{"🧭 Supervisor<br/>reads + analyzes"}
     B -- "ambiguous" --> C["💬 Posts clarifying questions<br/>waits for your reply"]
     C --> A
@@ -89,8 +90,9 @@ flowchart TD
     H --> I["🚀 Auto-deploy<br/>(opt-in)"]
 ```
 
-Two engines, split by cost and capability:
+Three layers, split by role and cost:
 
+- **Director** *(opt-in, separate service).* Reads a per-repo charter and proposes what to work on next. Never edits code. Lives at `/admin/director`. See [docs/DIRECTOR.md](docs/DIRECTOR.md).
 - **Supervisor.** Reads issues, classifies, asks clarifying questions, plans. Cheap and fast — handles the bulk of the conversational work.
 - **Coder agent.** The only thing allowed to mutate code, and only inside an isolated worktree.
 
@@ -153,6 +155,14 @@ Tasks travel through **lanes**. Each lane has a trigger, an engine, and an outpu
 | **deploy** *(opt-in)* | push to trigger branch | shell | run configured commands |
 
 The router is a single function (`pickLane` in `src/scheduler/worker.ts`) — no opaque agent loop deciding what's next.
+
+## Director — autonomous PM (opt-in)
+
+Want the agent to also pick *what* to work on, not just execute issues you file? There's a separate **Director** service that reads a per-repo charter (vision, priorities, definition-of-done, out-of-bounds zones) and proposes work items autonomously. It runs as its own systemd unit, has its own adaptive budget, and writes everything it does to a chat thread you can read at `/admin/director`.
+
+Five autonomy levels — `disabled` → `dry_run` → `propose` → `semi_auto` → `full_auto`. Start in `dry_run` for a few days to calibrate the charter; ramp up as confidence grows. Default authority is conservative (no merging, no closing issues, no charter modification without explicit opt-in).
+
+See [docs/DIRECTOR.md](docs/DIRECTOR.md) for the full schema and rollout plan.
 
 Full reference: **[docs/LANES.md](docs/LANES.md)**.
 

--- a/deploy/openronin-director.service
+++ b/deploy/openronin-director.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=openronin Director — autonomous PM layer
+Documentation=https://github.com/openronin/openronin/blob/main/docs/DIRECTOR.md
+After=network-online.target openronin.service
+Wants=openronin.service
+
+[Service]
+Type=simple
+User=claude
+WorkingDirectory=/opt/openronin
+# Re-uses the main openronin secrets (GITHUB_TOKEN, ANTHROPIC_API_KEY, ...).
+# Director-specific values (OPENRONIN_DIRECTOR_TELEGRAM_TOKEN, etc.) live
+# in director.env — kept separate so the main service doesn't have to load
+# them and so they can be rotated independently.
+EnvironmentFile=/var/lib/openronin/secrets.env
+EnvironmentFile=-/var/lib/openronin/director.env
+Environment=OPENRONIN_DATA_DIR=/var/lib/openronin
+ExecStart=/usr/bin/node /opt/openronin/dist/index.js director:run
+# Don't tear down child processes — same trick as the main service uses for
+# self-deploy. The director is a simple loop with no children right now,
+# but matching behaviour keeps deploys uniform.
+KillMode=process
+TimeoutStopSec=120
+Restart=on-failure
+RestartSec=10s
+# Modest cap so runaway prompts can't OOM the host.
+MemoryMax=512M
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=openronin-director
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/DIRECTOR.md
+++ b/docs/DIRECTOR.md
@@ -1,0 +1,199 @@
+# Director — autonomous PM layer
+
+> **Status:** foundation only. The service runs, ticks, captures the charter, and writes a no-op message to its chat thread. Real LLM-driven planning lands in PR #22; two-way chat with execution gates in PR #23; Telegram bridge in PR #24; adaptive budget in PR #25.
+
+The Director is a separate systemd service (`openronin-director.service`) that runs alongside the main openronin daemon. It shares the same code, database, and `OPENRONIN_DATA_DIR` but plays a different role: where the main daemon **reacts** to events (issue created, PR comment, push), the Director **proactively** decides what the project should work on next.
+
+This is the third layer in the architecture:
+
+```
+Director  ── source of intent (what should the project work on?)
+   ↓
+Supervisor ── routes lanes (which lane runs next?)
+   ↓
+Worker    ── writes code (the actual change)
+```
+
+The Director never edits source files directly. Code mutations stay with the Claude Code worker — the Director only emits **decisions** (create issue, comment on PR, approve merge, …) which are then carried out via the existing `VcsProvider` and lane infrastructure.
+
+## Why a separate service
+
+- **Independent lifecycle.** Stop / restart / pause the Director without touching the main daemon. Different resource limits, different restart policy.
+- **Clear blast radius.** A bug in Director planning can't crash the scheduler that's mid-flight on a PR.
+- **Single source of intent per repo.** One Director per repo, one chat thread, one charter. No coordination problem.
+- **Same DB, same code.** Not a microservice — just a different entry point on the same bundle.
+
+## Modes
+
+The Director runs in one of five modes. We ramp up confidence by stepping through them; each mode is more autonomous than the last:
+
+| Mode        | Creates artifacts | Acts on chat | Merges | Use when |
+|-------------|-------------------|--------------|--------|----------|
+| `disabled`  | —                 | —            | —      | switched off |
+| `dry_run`   | logs only         | logs only    | —      | calibrating the charter — read what the Director *would* do for a few days before letting it act |
+| `propose`   | only after explicit chat-approval | drafts replies, doesn't post | — | tighter feedback loop, you ack each proposal |
+| `semi_auto` | yes               | yes          | queued for approval | most operations autonomous; you still approve merges |
+| `full_auto` | yes               | yes          | yes    | fully autonomous; escalates only on failures |
+
+**Foundation phase (this PR) only `dry_run` is meaningful** — the LLM tick that produces real proposals lands in PR #22.
+
+## Charter
+
+The charter is the Director's "constitution" for a repo: vision, priorities, out-of-bounds zones, definition of done. It lives in the per-repo YAML config under `director.charter:` and is **versioned** in `director_charter_versions` — every decision pins exactly which version of the charter produced it, so the audit trail stays meaningful even when the charter evolves.
+
+Minimal charter:
+
+```yaml
+director:
+  enabled: true
+  mode: dry_run
+  cadence_hours: 6
+  charter:
+    vision: |
+      Reliable, observable AI dev agent. Reliability and observability
+      come before features.
+    priorities:
+      - id: reliability
+        weight: 0.5
+        rubric: "graceful failure, crash recovery, no lost work"
+      - id: observability
+        weight: 0.5
+        rubric: "user can debug runs without SSH"
+    out_of_bounds:
+      - "do not change DB schema without a versioned migration"
+      - "do not add npm dependencies without explicit approval"
+    out_of_bounds_paths:
+      - "src/storage/db.ts"
+      - "package.json"
+    definition_of_done:
+      - "pnpm run check is green"
+```
+
+**Without `enabled: true` and a non-empty `charter`, the Director silently skips that repo.** This is the safe default.
+
+## Adaptive budget
+
+Two cost streams, capped independently:
+
+- **project budget** — the cumulative cost of work the Director-spawned issues end up consuming via the worker. Daily + weekly caps. In phase 1 these are static (set from `initial_*_usd`); in PR #25 they climb on good outcomes and shrink on bad ones.
+- **think budget** — what the Director itself spends on its planning LLM calls. Hard daily cap (`think_daily_usd`, default $1.00).
+
+Plus a **failure-streak gate**: N consecutive failures (rejected proposal, red CI, lane error) auto-pause the Director and post an `error` message in the chat asking for a human directive. Default: 3.
+
+## Authority
+
+Per-decision-type permissions. The composition `mode × authority × budget × out-of-bounds` decides whether a particular decision is executed automatically, queued for approval, or refused outright.
+
+```yaml
+director:
+  authority:
+    can_create_issues: true
+    can_label: true
+    can_close_issues: false   # safer default — humans close issues
+    can_comment: true
+    can_approve_pr: true
+    can_merge: false          # default OFF, require explicit opt-in
+    can_modify_charter: false # human-only zone
+```
+
+## Chat thread
+
+Each director-enabled repo has one chat thread, stored in `director_messages`. It's the live communication channel between the Director and the human:
+
+| Sender    | Type                                  | Purpose |
+|-----------|---------------------------------------|---------|
+| Director  | `tick_log`                            | "tick fired (no-op)" — boring, but proves the loop is alive |
+| Director  | `status`                              | "I started working on issue #X, here's why" |
+| Director  | `proposal`                            | "I want to do X — approve / reject" (with HTMX buttons in PR #23) |
+| Director  | `question`                            | "ambiguity in priorities X vs Y, please decide" |
+| Director  | `report`                              | "did X, outcome was Y" |
+| User      | `directive`                           | "focus on tests this week" |
+| User      | `answer`                              | reply to a `question` |
+| User      | `veto`                                | cancel a pending decision |
+| System    | `error`                               | "tick threw, paused" |
+
+In phase 1 the chat is **read-only in the admin UI** at `/admin/director/<slug>`. Two-way (HTMX message form, approval buttons) lands in PR #23. Telegram bridge lands in PR #24.
+
+## Decisions audit trail
+
+Every decision the Director takes — even no-ops — is persisted into `director_decisions` **before** any side-effect runs:
+
+```
+ts             | type           | outcome  | charter | rationale
+2026-05-01 03  | no_op          | dry_run  | v1      | Foundation tick: scheduler...
+2026-05-01 09  | create_issue   | pending  | v1      | observability priority is at 0.30...
+2026-05-01 10  | create_issue   | executed | v1      | (from above; user approved)
+```
+
+So if the service crashes mid-execution, the next tick can pick up exactly where it left off without double-acting. And if the user wants to know "why did the Director close issue #34?" — the rationale is right there in the table, pinned to the charter version that produced it.
+
+## Operations
+
+### Enable on a new repo
+
+1. Add a `director:` block to the per-repo YAML in `$OPENRONIN_DATA_DIR/config/repos/<slug>.yaml`. Set `enabled: true`, write a charter.
+2. Config is hot-reloaded — no restart needed. Director picks up the new repo on its next loop tick (≤ 60s).
+
+### Disable temporarily
+
+- **One repo:** `director.enabled: false` in the per-repo YAML, or `director.mode: disabled`.
+- **All repos / kill switch:** `OPENRONIN_DIRECTOR_DISABLED=1` in env. Service stays up, logs `disabled`, idles. Restart needed to reload env.
+- **Permanent:** `systemctl stop openronin-director.service` (followed by `disable` if you want it not to come back).
+
+### Manual pause for one repo
+
+Currently via direct DB write (admin UI controls land in PR #23):
+
+```bash
+sqlite3 $OPENRONIN_DATA_DIR/db/openronin.db \
+  "UPDATE director_budget_state SET paused = 1, pause_reason = 'manual' WHERE repo_id = ?"
+```
+
+The Director will write `tick skipped: paused: manual` to the chat on its next tick instead of acting.
+
+### Watching the Director
+
+```bash
+# logs
+journalctl -u openronin-director -f
+
+# what it's saying
+sqlite3 $OPENRONIN_DATA_DIR/db/openronin.db \
+  "SELECT ts, role, type, substr(body, 1, 80) FROM director_messages
+   ORDER BY id DESC LIMIT 20;"
+
+# decisions
+sqlite3 $OPENRONIN_DATA_DIR/db/openronin.db \
+  "SELECT ts, decision_type, outcome, substr(rationale, 1, 60)
+   FROM director_decisions ORDER BY id DESC LIMIT 20;"
+
+# budget
+sqlite3 $OPENRONIN_DATA_DIR/db/openronin.db \
+  "SELECT * FROM director_budget_state;"
+```
+
+Or the admin UI: `https://your-host/admin/director`.
+
+### systemd unit
+
+```
+deploy/openronin-director.service
+```
+
+Production install:
+
+```bash
+sudo cp deploy/openronin-director.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now openronin-director.service
+```
+
+Director-specific secrets (e.g. `OPENRONIN_DIRECTOR_TELEGRAM_TOKEN`) go in `$OPENRONIN_DATA_DIR/director.env` — kept separate from the main `secrets.env` so they can be rotated independently. Mode `0600` so only the service user can read.
+
+## Roadmap
+
+- **PR #21 — foundation** (this PR). Schema, scaffolding, no-op tick.
+- **PR #22 — dry_run tick.** Real LLM call producing structured decisions; written to chat, never executed.
+- **PR #23 — execution gates + chat UI.** Mode toggle drives whether decisions execute. HTMX approve/reject buttons in admin UI.
+- **PR #24 — Telegram bridge.** Mirror chat to Telegram, accept directives/answers from the phone.
+- **PR #25 — adaptive budget + retrospective.** Budget caps adjust based on outcome quality; 7-day quarantine before counting a merge as "good".

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,4 +1,10 @@
 import { z } from "zod";
+import {
+  BudgetConfigSchema,
+  CharterSchema,
+  DirectorAuthoritySchema,
+  DirectorModeSchema,
+} from "../director/types.js";
 
 // Server config (loaded from env on top, optionally overridden by openronin.yaml/server)
 export const ServerConfigSchema = z.object({
@@ -218,6 +224,21 @@ export const RepoConfigSchema = z.object({
   awaiting_action_label: z.string().default("openronin:awaiting-action"),
   acknowledge_with_reaction: z.boolean().default(true),
   acknowledge_with_comment: z.boolean().default(true),
+  // Director — autonomous PM layer (opt-in per repo). When `enabled: true`
+  // and a `charter` is supplied, the openronin-director.service will tick
+  // this repo. Without a charter the director silently skips. See
+  // docs/DIRECTOR.md for the full schema.
+  director: z
+    .object({
+      enabled: z.boolean().default(false),
+      mode: DirectorModeSchema.default("dry_run"),
+      cadence_hours: z.number().positive().default(6),
+      bot_prefix: z.string().default("👔 director:"),
+      charter: CharterSchema.optional(),
+      budget: BudgetConfigSchema,
+      authority: DirectorAuthoritySchema,
+    })
+    .default({}),
 });
 
 export type RepoConfig = z.infer<typeof RepoConfigSchema>;

--- a/src/director/budget.ts
+++ b/src/director/budget.ts
@@ -1,0 +1,183 @@
+// Adaptive budget tracker for the Director.
+//
+// Two cost streams:
+//   • project budget — what the Director's spawned issues end up costing the
+//     worker. Capped per-day and per-week, climbs slowly on good outcomes,
+//     shrinks on bad ones.
+//   • think budget   — what the Director itself spends on its planning LLM
+//     calls. Hard daily cap, no adaptation.
+//
+// Plus a failure-streak gate: N consecutive failures (rejected proposal,
+// red CI, lane error) → pause and wait for human directive in chat.
+//
+// This file implements the bookkeeping. The actual decisions about *when*
+// to check the budget live in `tick.ts` (foundation tick is no-op).
+
+import type { Db } from "../storage/db.js";
+import type { BudgetConfig, BudgetState } from "./types.js";
+
+type BudgetRow = {
+  repo_id: number;
+  daily_cap_usd: number;
+  weekly_cap_usd: number;
+  spent_today_usd: number;
+  spent_week_usd: number;
+  spent_today_think_usd: number;
+  failure_streak: number;
+  last_tick_at: string | null;
+  last_reset_day: string | null;
+  paused: number;
+  pause_reason: string | null;
+};
+
+function rowToState(row: BudgetRow): BudgetState {
+  return {
+    repoId: row.repo_id,
+    dailyCapUsd: row.daily_cap_usd,
+    weeklyCapUsd: row.weekly_cap_usd,
+    spentTodayUsd: row.spent_today_usd,
+    spentWeekUsd: row.spent_week_usd,
+    spentTodayThinkUsd: row.spent_today_think_usd,
+    failureStreak: row.failure_streak,
+    lastTickAt: row.last_tick_at,
+    lastResetDay: row.last_reset_day,
+    paused: row.paused !== 0,
+    pauseReason: row.pause_reason,
+  };
+}
+
+export function ensureBudgetState(
+  db: Db,
+  repoId: number,
+  cfg: BudgetConfig,
+): BudgetState {
+  const existing = db
+    .prepare(`SELECT * FROM director_budget_state WHERE repo_id = ?`)
+    .get(repoId) as BudgetRow | undefined;
+  if (existing) return rowToState(existing);
+  db.prepare(
+    `INSERT INTO director_budget_state
+       (repo_id, daily_cap_usd, weekly_cap_usd)
+     VALUES (?, ?, ?)`,
+  ).run(repoId, cfg.initial_daily_usd, cfg.initial_weekly_usd);
+  return rowToState(
+    db
+      .prepare(`SELECT * FROM director_budget_state WHERE repo_id = ?`)
+      .get(repoId) as BudgetRow,
+  );
+}
+
+function utcDayString(d: Date = new Date()): string {
+  return d.toISOString().slice(0, 10);
+}
+
+// Reset spent_today_* counters once per UTC day.
+export function rolloverDayIfNeeded(db: Db, repoId: number): void {
+  const today = utcDayString();
+  db.prepare(
+    `UPDATE director_budget_state
+     SET spent_today_usd = 0,
+         spent_today_think_usd = 0,
+         last_reset_day = ?
+     WHERE repo_id = ? AND (last_reset_day IS NULL OR last_reset_day < ?)`,
+  ).run(today, repoId, today);
+}
+
+export function recordThinkSpend(db: Db, repoId: number, costUsd: number): void {
+  db.prepare(
+    `UPDATE director_budget_state
+     SET spent_today_think_usd = spent_today_think_usd + ?,
+         updated_at = datetime('now')
+     WHERE repo_id = ?`,
+  ).run(costUsd, repoId);
+}
+
+export function recordProjectSpend(db: Db, repoId: number, costUsd: number): void {
+  db.prepare(
+    `UPDATE director_budget_state
+     SET spent_today_usd = spent_today_usd + ?,
+         spent_week_usd = spent_week_usd + ?,
+         updated_at = datetime('now')
+     WHERE repo_id = ?`,
+  ).run(costUsd, costUsd, repoId);
+}
+
+export function bumpFailureStreak(db: Db, repoId: number): number {
+  db.prepare(
+    `UPDATE director_budget_state
+     SET failure_streak = failure_streak + 1,
+         updated_at = datetime('now')
+     WHERE repo_id = ?`,
+  ).run(repoId);
+  const row = db
+    .prepare(`SELECT failure_streak FROM director_budget_state WHERE repo_id = ?`)
+    .get(repoId) as { failure_streak: number };
+  return row.failure_streak;
+}
+
+export function resetFailureStreak(db: Db, repoId: number): void {
+  db.prepare(
+    `UPDATE director_budget_state
+     SET failure_streak = 0,
+         updated_at = datetime('now')
+     WHERE repo_id = ?`,
+  ).run(repoId);
+}
+
+export function pause(db: Db, repoId: number, reason: string): void {
+  db.prepare(
+    `UPDATE director_budget_state
+     SET paused = 1, pause_reason = ?, updated_at = datetime('now')
+     WHERE repo_id = ?`,
+  ).run(reason, repoId);
+}
+
+export function unpause(db: Db, repoId: number): void {
+  db.prepare(
+    `UPDATE director_budget_state
+     SET paused = 0, pause_reason = NULL, updated_at = datetime('now')
+     WHERE repo_id = ?`,
+  ).run(repoId);
+}
+
+export function markTick(db: Db, repoId: number): void {
+  db.prepare(
+    `UPDATE director_budget_state
+     SET last_tick_at = datetime('now'),
+         updated_at = datetime('now')
+     WHERE repo_id = ?`,
+  ).run(repoId);
+}
+
+// "Should we tick this repo right now?" — pure check, no side effect.
+export type GateResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+export function checkBudgetGate(
+  state: BudgetState,
+  cfg: BudgetConfig,
+): GateResult {
+  if (state.paused) {
+    return { ok: false, reason: `paused: ${state.pauseReason ?? "manual"}` };
+  }
+  if (state.failureStreak >= cfg.pause_on_failure_streak) {
+    return {
+      ok: false,
+      reason: `failure_streak ${state.failureStreak} >= ${cfg.pause_on_failure_streak}`,
+    };
+  }
+  if (state.spentTodayThinkUsd >= cfg.think_daily_usd) {
+    return {
+      ok: false,
+      reason: `think budget exhausted ($${state.spentTodayThinkUsd.toFixed(2)})`,
+    };
+  }
+  if (state.spentTodayUsd >= state.dailyCapUsd) {
+    return { ok: false, reason: `daily project budget exhausted` };
+  }
+  if (state.spentWeekUsd >= state.weeklyCapUsd) {
+    return { ok: false, reason: `weekly project budget exhausted` };
+  }
+  return { ok: true };
+}

--- a/src/director/budget.ts
+++ b/src/director/budget.ts
@@ -46,11 +46,7 @@ function rowToState(row: BudgetRow): BudgetState {
   };
 }
 
-export function ensureBudgetState(
-  db: Db,
-  repoId: number,
-  cfg: BudgetConfig,
-): BudgetState {
+export function ensureBudgetState(db: Db, repoId: number, cfg: BudgetConfig): BudgetState {
   const existing = db
     .prepare(`SELECT * FROM director_budget_state WHERE repo_id = ?`)
     .get(repoId) as BudgetRow | undefined;
@@ -61,9 +57,7 @@ export function ensureBudgetState(
      VALUES (?, ?, ?)`,
   ).run(repoId, cfg.initial_daily_usd, cfg.initial_weekly_usd);
   return rowToState(
-    db
-      .prepare(`SELECT * FROM director_budget_state WHERE repo_id = ?`)
-      .get(repoId) as BudgetRow,
+    db.prepare(`SELECT * FROM director_budget_state WHERE repo_id = ?`).get(repoId) as BudgetRow,
   );
 }
 
@@ -150,14 +144,9 @@ export function markTick(db: Db, repoId: number): void {
 }
 
 // "Should we tick this repo right now?" — pure check, no side effect.
-export type GateResult =
-  | { ok: true }
-  | { ok: false; reason: string };
+export type GateResult = { ok: true } | { ok: false; reason: string };
 
-export function checkBudgetGate(
-  state: BudgetState,
-  cfg: BudgetConfig,
-): GateResult {
+export function checkBudgetGate(state: BudgetState, cfg: BudgetConfig): GateResult {
   if (state.paused) {
     return { ok: false, reason: `paused: ${state.pauseReason ?? "manual"}` };
   }

--- a/src/director/charter.ts
+++ b/src/director/charter.ts
@@ -32,11 +32,7 @@ export function parseCharter(input: unknown): Charter | null {
 
 // Snapshot the current charter into the versioned table if it's changed
 // since last seen. Returns the version number to stamp on decisions.
-export function captureCharterVersion(
-  db: Db,
-  repoId: number,
-  charter: Charter,
-): number {
+export function captureCharterVersion(db: Db, repoId: number, charter: Charter): number {
   const yaml = YAML.stringify({ charter });
   const latest = db
     .prepare(
@@ -54,11 +50,7 @@ export function captureCharterVersion(
   return nextVersion;
 }
 
-export function getCharterVersion(
-  db: Db,
-  repoId: number,
-  version: number,
-): CharterVersion | null {
+export function getCharterVersion(db: Db, repoId: number, version: number): CharterVersion | null {
   const row = db
     .prepare(
       `SELECT repo_id, version, charter_yaml, effective_from

--- a/src/director/charter.ts
+++ b/src/director/charter.ts
@@ -1,0 +1,106 @@
+// Charter loader.
+//
+// The charter is the Director's "constitution" for a given repo: vision,
+// priorities, out-of-bounds zones, definition-of-done. It lives in the
+// per-repo YAML config (under `director.charter`) and is versioned in
+// `director_charter_versions` so every decision can pin exactly which
+// version of the charter produced it.
+
+import { createHash } from "node:crypto";
+import YAML from "yaml";
+import type { Db } from "../storage/db.js";
+import { CharterSchema, type Charter } from "./types.js";
+
+export type CharterVersion = {
+  repoId: number;
+  version: number;
+  charter: Charter;
+  charterYaml: string;
+  effectiveFrom: string;
+};
+
+export function charterHash(charter: Charter): string {
+  return createHash("sha256").update(JSON.stringify(charter)).digest("hex").slice(0, 16);
+}
+
+export function parseCharter(input: unknown): Charter | null {
+  if (input === null || input === undefined) return null;
+  const parsed = CharterSchema.safeParse(input);
+  if (!parsed.success) return null;
+  return parsed.data;
+}
+
+// Snapshot the current charter into the versioned table if it's changed
+// since last seen. Returns the version number to stamp on decisions.
+export function captureCharterVersion(
+  db: Db,
+  repoId: number,
+  charter: Charter,
+): number {
+  const yaml = YAML.stringify({ charter });
+  const latest = db
+    .prepare(
+      `SELECT version, charter_yaml FROM director_charter_versions
+       WHERE repo_id = ?
+       ORDER BY version DESC LIMIT 1`,
+    )
+    .get(repoId) as { version: number; charter_yaml: string } | undefined;
+  if (latest && latest.charter_yaml === yaml) return latest.version;
+  const nextVersion = (latest?.version ?? 0) + 1;
+  db.prepare(
+    `INSERT INTO director_charter_versions (repo_id, version, charter_yaml)
+     VALUES (?, ?, ?)`,
+  ).run(repoId, nextVersion, yaml);
+  return nextVersion;
+}
+
+export function getCharterVersion(
+  db: Db,
+  repoId: number,
+  version: number,
+): CharterVersion | null {
+  const row = db
+    .prepare(
+      `SELECT repo_id, version, charter_yaml, effective_from
+       FROM director_charter_versions
+       WHERE repo_id = ? AND version = ?`,
+    )
+    .get(repoId, version) as
+    | { repo_id: number; version: number; charter_yaml: string; effective_from: string }
+    | undefined;
+  if (!row) return null;
+  const parsed = YAML.parse(row.charter_yaml) as { charter: unknown };
+  const charter = parseCharter(parsed.charter);
+  if (!charter) return null;
+  return {
+    repoId: row.repo_id,
+    version: row.version,
+    charter,
+    charterYaml: row.charter_yaml,
+    effectiveFrom: row.effective_from,
+  };
+}
+
+export function latestCharterVersion(db: Db, repoId: number): CharterVersion | null {
+  const row = db
+    .prepare(
+      `SELECT repo_id, version, charter_yaml, effective_from
+       FROM director_charter_versions
+       WHERE repo_id = ?
+       ORDER BY version DESC LIMIT 1`,
+    )
+    .get(repoId) as
+    | { repo_id: number; version: number; charter_yaml: string; effective_from: string }
+    | undefined;
+  if (!row) return null;
+  const parsed = YAML.parse(row.charter_yaml) as { charter: unknown };
+  const charter = parseCharter(parsed.charter);
+  if (!charter) return null;
+  return {
+    repoId: row.repo_id,
+    version: row.version,
+    charter,
+    charterYaml: row.charter_yaml,
+    effectiveFrom: row.effective_from,
+  };
+}

--- a/src/director/chat.ts
+++ b/src/director/chat.ts
@@ -6,12 +6,7 @@
 // bridge are both pure consumers of this table.
 
 import type { Db } from "../storage/db.js";
-import type {
-  DirectorMessage,
-  MessageRole,
-  MessageType,
-  NewDirectorMessage,
-} from "./types.js";
+import type { DirectorMessage, MessageRole, MessageType, NewDirectorMessage } from "./types.js";
 
 type MessageRow = {
   id: number;
@@ -71,11 +66,7 @@ export function recentMessages(db: Db, repoId: number, limit = 50): DirectorMess
   return rows.map(rowToMessage).reverse();
 }
 
-export function messagesSince(
-  db: Db,
-  repoId: number,
-  sinceMessageId: number,
-): DirectorMessage[] {
+export function messagesSince(db: Db, repoId: number, sinceMessageId: number): DirectorMessage[] {
   const rows = db
     .prepare(
       `SELECT id, repo_id, ts, role, type, body, metadata, parent_id, decision_id

--- a/src/director/chat.ts
+++ b/src/director/chat.ts
@@ -1,0 +1,114 @@
+// Chat data layer — the Director's conversation thread per repo.
+//
+// Messages are append-only. The Director reads recent N messages each tick
+// to incorporate user directives/answers; writes status, proposals, and
+// reports back. The admin UI (/admin/director/<repo>) and the Telegram
+// bridge are both pure consumers of this table.
+
+import type { Db } from "../storage/db.js";
+import type {
+  DirectorMessage,
+  MessageRole,
+  MessageType,
+  NewDirectorMessage,
+} from "./types.js";
+
+type MessageRow = {
+  id: number;
+  repo_id: number;
+  ts: string;
+  role: string;
+  type: string;
+  body: string;
+  metadata: string | null;
+  parent_id: number | null;
+  decision_id: number | null;
+};
+
+function rowToMessage(row: MessageRow): DirectorMessage {
+  return {
+    id: row.id,
+    repoId: row.repo_id,
+    ts: row.ts,
+    role: row.role as MessageRole,
+    type: row.type as MessageType,
+    body: row.body,
+    metadata: row.metadata ? (JSON.parse(row.metadata) as Record<string, unknown>) : null,
+    parentId: row.parent_id,
+    decisionId: row.decision_id,
+  };
+}
+
+export function appendMessage(db: Db, msg: NewDirectorMessage): DirectorMessage {
+  const stmt = db.prepare(
+    `INSERT INTO director_messages
+       (repo_id, role, type, body, metadata, parent_id, decision_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     RETURNING id, repo_id, ts, role, type, body, metadata, parent_id, decision_id`,
+  );
+  const row = stmt.get(
+    msg.repoId,
+    msg.role,
+    msg.type,
+    msg.body,
+    msg.metadata ? JSON.stringify(msg.metadata) : null,
+    msg.parentId ?? null,
+    msg.decisionId ?? null,
+  ) as MessageRow;
+  return rowToMessage(row);
+}
+
+export function recentMessages(db: Db, repoId: number, limit = 50): DirectorMessage[] {
+  const rows = db
+    .prepare(
+      `SELECT id, repo_id, ts, role, type, body, metadata, parent_id, decision_id
+       FROM director_messages
+       WHERE repo_id = ?
+       ORDER BY id DESC
+       LIMIT ?`,
+    )
+    .all(repoId, limit) as MessageRow[];
+  return rows.map(rowToMessage).reverse();
+}
+
+export function messagesSince(
+  db: Db,
+  repoId: number,
+  sinceMessageId: number,
+): DirectorMessage[] {
+  const rows = db
+    .prepare(
+      `SELECT id, repo_id, ts, role, type, body, metadata, parent_id, decision_id
+       FROM director_messages
+       WHERE repo_id = ? AND id > ?
+       ORDER BY id ASC`,
+    )
+    .all(repoId, sinceMessageId) as MessageRow[];
+  return rows.map(rowToMessage);
+}
+
+export function unansweredUserDirectives(db: Db, repoId: number): DirectorMessage[] {
+  // User messages that haven't yet been acknowledged by a director report.
+  // A simple heuristic: user message with no later director message of any kind.
+  const rows = db
+    .prepare(
+      `SELECT id, repo_id, ts, role, type, body, metadata, parent_id, decision_id
+       FROM director_messages
+       WHERE repo_id = ?
+         AND role = 'user'
+         AND id > COALESCE(
+           (SELECT MAX(id) FROM director_messages
+              WHERE repo_id = ? AND role = 'director'),
+           0)
+       ORDER BY id ASC`,
+    )
+    .all(repoId, repoId) as MessageRow[];
+  return rows.map(rowToMessage);
+}
+
+export function messageCount(db: Db, repoId: number): number {
+  const row = db
+    .prepare("SELECT COUNT(*) AS n FROM director_messages WHERE repo_id = ?")
+    .get(repoId) as { n: number };
+  return row.n;
+}

--- a/src/director/decisions.ts
+++ b/src/director/decisions.ts
@@ -1,0 +1,97 @@
+// Decision data layer.
+//
+// Every decision the Director takes — even no-ops — is persisted before any
+// side-effect. This gives a complete audit trail (visible in /admin/director)
+// and lets us recover gracefully if the service crashes mid-execution.
+
+import type { Db } from "../storage/db.js";
+import type { Decision, DecisionOutcome, DecisionType, NewDecision } from "./types.js";
+
+type DecisionRow = {
+  id: number;
+  repo_id: number;
+  ts: string;
+  decision_type: string;
+  rationale: string;
+  charter_version: number | null;
+  state_snapshot: string | null;
+  payload: string | null;
+  outcome: string;
+  outcome_ts: string | null;
+  outcome_details: string | null;
+  cost_usd: number;
+};
+
+function rowToDecision(row: DecisionRow): Decision {
+  return {
+    id: row.id,
+    repoId: row.repo_id,
+    ts: row.ts,
+    decisionType: row.decision_type as DecisionType,
+    rationale: row.rationale,
+    charterVersion: row.charter_version,
+    stateSnapshot: row.state_snapshot ? JSON.parse(row.state_snapshot) : null,
+    payload: row.payload ? JSON.parse(row.payload) : null,
+    outcome: row.outcome as DecisionOutcome,
+    outcomeTs: row.outcome_ts,
+    outcomeDetails: row.outcome_details,
+    costUsd: row.cost_usd,
+  };
+}
+
+export function recordDecision(db: Db, d: NewDecision): Decision {
+  const row = db
+    .prepare(
+      `INSERT INTO director_decisions
+         (repo_id, decision_type, rationale, charter_version,
+          state_snapshot, payload, outcome, cost_usd)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       RETURNING *`,
+    )
+    .get(
+      d.repoId,
+      d.decisionType,
+      d.rationale,
+      d.charterVersion ?? null,
+      d.stateSnapshot ? JSON.stringify(d.stateSnapshot) : null,
+      d.payload ? JSON.stringify(d.payload) : null,
+      d.outcome ?? "pending",
+      d.costUsd ?? 0,
+    ) as DecisionRow;
+  return rowToDecision(row);
+}
+
+export function setDecisionOutcome(
+  db: Db,
+  decisionId: number,
+  outcome: DecisionOutcome,
+  details?: string,
+): void {
+  db.prepare(
+    `UPDATE director_decisions
+     SET outcome = ?, outcome_ts = datetime('now'), outcome_details = ?
+     WHERE id = ?`,
+  ).run(outcome, details ?? null, decisionId);
+}
+
+export function recentDecisions(db: Db, repoId: number, limit = 50): Decision[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM director_decisions
+       WHERE repo_id = ?
+       ORDER BY id DESC LIMIT ?`,
+    )
+    .all(repoId, limit) as DecisionRow[];
+  return rows.map(rowToDecision);
+}
+
+export function pendingDecisions(db: Db, repoId: number): Decision[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM director_decisions
+       WHERE repo_id = ? AND outcome = 'pending'
+       ORDER BY id ASC`,
+    )
+    .all(repoId) as DecisionRow[];
+  return rows.map(rowToDecision);
+}

--- a/src/director/index.ts
+++ b/src/director/index.ts
@@ -1,0 +1,213 @@
+// Director service entry point.
+//
+// Run as a separate systemd unit (`openronin-director.service`) alongside
+// the main openronin service. Shares the same code, DB, and OPENRONIN_DATA_DIR.
+//
+//   ExecStart=node dist/index.js director:run
+//
+// FOUNDATION SCOPE: this entry point currently runs a no-op tick loop —
+// every cadence_hours it writes a `tick_log` message into the chat saying
+// "tick fired, no-op (foundation phase)". The real LLM-driven tick lands
+// in PR #22.
+
+import { loadConfig, watchConfig } from "../config/loader.js";
+import type { RepoConfig, RuntimeConfig } from "../config/schema.js";
+import { repoKey } from "../config/schema.js";
+import { initDb, type Db } from "../storage/db.js";
+import { syncReposFromConfig } from "../storage/repos.js";
+import {
+  ensureBudgetState,
+  rolloverDayIfNeeded,
+  markTick,
+  checkBudgetGate,
+} from "./budget.js";
+import { appendMessage } from "./chat.js";
+import { captureCharterVersion } from "./charter.js";
+import { recordDecision } from "./decisions.js";
+import type { DirectorConfig } from "./types.js";
+
+const SERVICE_LOOP_INTERVAL_MS = 60_000; // wake up every minute
+const KILL_SWITCH_ENV = "OPENRONIN_DIRECTOR_DISABLED";
+
+type RepoLookup = {
+  repoId: number;
+  repo: RepoConfig;
+  director: DirectorConfig;
+};
+
+function listRepoIdsByKey(db: Db): Map<string, number> {
+  const rows = db
+    .prepare(`SELECT id, provider, owner, name FROM repos WHERE watched = 1`)
+    .all() as { id: number; provider: string; owner: string; name: string }[];
+  const out = new Map<string, number>();
+  for (const r of rows) {
+    out.set(`${r.provider}--${r.owner}--${r.name}`, r.id);
+  }
+  return out;
+}
+
+function listDirectorEnabledRepos(db: Db, config: RuntimeConfig): RepoLookup[] {
+  const idByKey = listRepoIdsByKey(db);
+  const out: RepoLookup[] = [];
+  for (const repo of config.repos) {
+    const director = repo.director;
+    if (!director || !director.enabled || director.mode === "disabled") continue;
+    if (!director.charter) continue; // no charter → silently skip (safe default)
+    const id = idByKey.get(repoKey(repo));
+    if (id === undefined) continue;
+    out.push({ repoId: id, repo, director });
+  }
+  return out;
+}
+
+function shouldTickNow(state: { lastTickAt: string | null }, cadenceHours: number): boolean {
+  if (!state.lastTickAt) return true;
+  const last = Date.parse(state.lastTickAt + "Z"); // sqlite text is UTC
+  if (Number.isNaN(last)) return true;
+  const elapsedMs = Date.now() - last;
+  return elapsedMs >= cadenceHours * 3600_000;
+}
+
+async function tickNoOp(db: Db, target: RepoLookup): Promise<void> {
+  const { repoId, repo, director } = target;
+  if (!director.charter) return;
+
+  rolloverDayIfNeeded(db, repoId);
+  const state = ensureBudgetState(db, repoId, director.budget);
+
+  const gate = checkBudgetGate(state, director.budget);
+  if (!gate.ok) {
+    appendMessage(db, {
+      repoId,
+      role: "system",
+      type: "tick_log",
+      body: `tick skipped: ${gate.reason}`,
+      metadata: { repo: repoKey(repo), mode: director.mode },
+    });
+    return;
+  }
+
+  const charterVersion = captureCharterVersion(db, repoId, director.charter);
+
+  const decision = recordDecision(db, {
+    repoId,
+    decisionType: "no_op",
+    rationale:
+      "Foundation tick: scheduler+chat+charter+budget infrastructure is wired. " +
+      "Real LLM-driven planning lands in PR #22. This entry confirms the loop " +
+      "ran end-to-end (charter parsed, budget gate passed, message appended).",
+    charterVersion,
+    stateSnapshot: {
+      mode: director.mode,
+      cadenceHours: director.cadence_hours,
+      charterVersion,
+      spentTodayUsd: state.spentTodayUsd,
+      spentTodayThinkUsd: state.spentTodayThinkUsd,
+      failureStreak: state.failureStreak,
+    },
+    outcome: "dry_run",
+  });
+
+  appendMessage(db, {
+    repoId,
+    role: "director",
+    type: "tick_log",
+    body: `tick fired (mode=${director.mode}, charter v${charterVersion}). Foundation phase: no planning yet.`,
+    metadata: { repo: repoKey(repo), decisionId: decision.id },
+    decisionId: decision.id,
+  });
+
+  markTick(db, repoId);
+}
+
+let stopping = false;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function loopOnce(db: Db, config: RuntimeConfig): Promise<void> {
+  const targets = listDirectorEnabledRepos(db, config);
+  for (const t of targets) {
+    if (stopping) return;
+    rolloverDayIfNeeded(db, t.repoId);
+    const state = ensureBudgetState(db, t.repoId, t.director.budget);
+    if (!shouldTickNow(state, t.director.cadence_hours)) continue;
+    try {
+      await tickNoOp(db, t);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      try {
+        appendMessage(db, {
+          repoId: t.repoId,
+          role: "system",
+          type: "error",
+          body: `tick threw: ${detail}`,
+          metadata: { repo: repoKey(t.repo), stack: err instanceof Error ? err.stack : null },
+        });
+      } catch {
+        // chat write failed too — just log
+      }
+      // eslint-disable-next-line no-console
+      console.error(`[director] tick error on ${repoKey(t.repo)}:`, err);
+    }
+  }
+}
+
+export async function runDirectorService(): Promise<void> {
+  if (process.env[KILL_SWITCH_ENV] === "1") {
+    // eslint-disable-next-line no-console
+    console.log(`[director] disabled via ${KILL_SWITCH_ENV}=1; idling.`);
+    while (!stopping) {
+      await sleep(SERVICE_LOOP_INTERVAL_MS);
+    }
+    return;
+  }
+
+  let config = loadConfig();
+  const db = initDb(config.dataDir);
+  syncReposFromConfig(db, config.repos);
+
+  watchConfig(config.dataDir, () => {
+    try {
+      config = loadConfig({ dataDir: config.dataDir });
+      syncReposFromConfig(db, config.repos);
+      // eslint-disable-next-line no-console
+      console.log(
+        `[director] config reloaded; ${listDirectorEnabledRepos(db, config).length} director-enabled repo(s)`,
+      );
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[director] config reload error:", err);
+    }
+  });
+
+  const onSignal = (sig: string): void => {
+    // eslint-disable-next-line no-console
+    console.log(`[director] received ${sig}; stopping.`);
+    stopping = true;
+  };
+  process.on("SIGTERM", () => onSignal("SIGTERM"));
+  process.on("SIGINT", () => onSignal("SIGINT"));
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `[director] started (pid ${process.pid}); ${listDirectorEnabledRepos(db, config).length} enabled repo(s); ` +
+      `loop every ${SERVICE_LOOP_INTERVAL_MS / 1000}s.`,
+  );
+
+  while (!stopping) {
+    try {
+      await loopOnce(db, config);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[director] loop error:", err);
+    }
+    if (stopping) break;
+    await sleep(SERVICE_LOOP_INTERVAL_MS);
+  }
+
+  // eslint-disable-next-line no-console
+  console.log("[director] stopped cleanly.");
+  db.close();
+}

--- a/src/director/index.ts
+++ b/src/director/index.ts
@@ -15,12 +15,7 @@ import type { RepoConfig, RuntimeConfig } from "../config/schema.js";
 import { repoKey } from "../config/schema.js";
 import { initDb, type Db } from "../storage/db.js";
 import { syncReposFromConfig } from "../storage/repos.js";
-import {
-  ensureBudgetState,
-  rolloverDayIfNeeded,
-  markTick,
-  checkBudgetGate,
-} from "./budget.js";
+import { ensureBudgetState, rolloverDayIfNeeded, markTick, checkBudgetGate } from "./budget.js";
 import { appendMessage } from "./chat.js";
 import { captureCharterVersion } from "./charter.js";
 import { recordDecision } from "./decisions.js";

--- a/src/director/types.ts
+++ b/src/director/types.ts
@@ -210,12 +210,7 @@ export type NewDecision = {
 };
 
 // ── Tick result ──────────────────────────────────────────────────────────
-export type TickReason =
-  | "scheduled"
-  | "manual"
-  | "user_message"
-  | "pr_event"
-  | "issue_event";
+export type TickReason = "scheduled" | "manual" | "user_message" | "pr_event" | "issue_event";
 
 export type TickContext = {
   reason: TickReason;

--- a/src/director/types.ts
+++ b/src/director/types.ts
@@ -1,0 +1,230 @@
+// Director — autonomous PM layer.
+//
+// The Director is a separate systemd service (`openronin-director.service`)
+// that shares the same code, DB, and data dir as the main openronin service
+// but acts in a different role: it watches project state and decides what
+// to do next, instead of waiting for human-supplied issues.
+//
+// This file defines the shapes that flow through the Director loop. The
+// Director never edits source files directly — code mutations stay with the
+// Claude Code worker, exactly like everywhere else. The Director only emits
+// decisions (create issue, comment, approve merge, …) which are then carried
+// out via the existing VcsProvider and lane infrastructure.
+
+import { z } from "zod";
+
+// ── Modes ────────────────────────────────────────────────────────────────
+// Spectrum, not toggle. We ramp up confidence by stepping through these.
+export const DirectorModeSchema = z.enum([
+  "disabled",
+  "dry_run", // think aloud, write to chat, never act
+  "propose", // create artifacts only after explicit chat-approval
+  "semi_auto", // act, except merges still need approval
+  "full_auto", // act on everything, escalate only on failures
+]);
+export type DirectorMode = z.infer<typeof DirectorModeSchema>;
+
+// ── Authority ────────────────────────────────────────────────────────────
+// Per-decision-type permission. The composition `mode × authority` decides
+// whether a particular decision is executed automatically, queued for human
+// approval, or refused.
+export const DirectorAuthoritySchema = z
+  .object({
+    can_create_issues: z.boolean().default(true),
+    can_label: z.boolean().default(true),
+    can_close_issues: z.boolean().default(false),
+    can_comment: z.boolean().default(true),
+    can_approve_pr: z.boolean().default(true),
+    can_merge: z.boolean().default(false),
+    can_modify_charter: z.boolean().default(false),
+  })
+  .default({});
+export type DirectorAuthority = z.infer<typeof DirectorAuthoritySchema>;
+
+// ── Charter ──────────────────────────────────────────────────────────────
+// The Director's "constitution" for a repo. Static base in YAML; runtime
+// overlays come from the chat thread (e.g. `directive` messages can adjust
+// priorities). Hashed so every decision can pin exactly which version of
+// the charter it was produced under.
+export const CharterPrioritySchema = z.object({
+  id: z.string().min(1),
+  weight: z.number().min(0).max(1),
+  rubric: z.string().min(1),
+});
+export type CharterPriority = z.infer<typeof CharterPrioritySchema>;
+
+export const CharterSchema = z.object({
+  vision: z.string().min(1),
+  priorities: z.array(CharterPrioritySchema).min(1),
+  out_of_bounds: z.array(z.string()).default([]),
+  out_of_bounds_paths: z.array(z.string()).default([]),
+  definition_of_done: z.array(z.string()).default([]),
+  notes: z.string().optional(),
+});
+export type Charter = z.infer<typeof CharterSchema>;
+
+// ── Budget ───────────────────────────────────────────────────────────────
+// Adaptive: starts conservative, climbs on good outcomes, shrinks on bad.
+// Two separate cost streams:
+//   • project budget — what the Director's spawned issues cost the worker
+//   • think budget   — what the Director itself spends on Claude calls
+// Failure-streak gate is independent of budget.
+export const BudgetConfigSchema = z
+  .object({
+    initial_daily_usd: z.number().nonnegative().default(2.0),
+    initial_weekly_usd: z.number().nonnegative().default(10.0),
+    max_daily_usd: z.number().nonnegative().default(10.0),
+    max_weekly_usd: z.number().nonnegative().default(50.0),
+    think_daily_usd: z.number().nonnegative().default(1.0),
+    pause_on_failure_streak: z.number().int().nonnegative().default(3),
+    good_outcome_quarantine_days: z.number().int().positive().default(7),
+  })
+  .default({});
+export type BudgetConfig = z.infer<typeof BudgetConfigSchema>;
+
+export type BudgetState = {
+  repoId: number;
+  dailyCapUsd: number;
+  weeklyCapUsd: number;
+  spentTodayUsd: number;
+  spentWeekUsd: number;
+  spentTodayThinkUsd: number;
+  failureStreak: number;
+  lastTickAt: string | null;
+  lastResetDay: string | null;
+  paused: boolean;
+  pauseReason: string | null;
+};
+
+// ── Director config (per-repo block, lives in repo YAML) ─────────────────
+export const DirectorConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    mode: DirectorModeSchema.default("dry_run"),
+    cadence_hours: z.number().positive().default(6),
+    bot_prefix: z.string().default("👔 director:"),
+    charter: CharterSchema.optional(),
+    budget: BudgetConfigSchema,
+    authority: DirectorAuthoritySchema,
+  })
+  .default({});
+export type DirectorConfig = z.infer<typeof DirectorConfigSchema>;
+
+// ── Messages ─────────────────────────────────────────────────────────────
+// The chat thread is the live communication channel between user and
+// Director. Each tick reads recent messages, each decision writes a
+// status/proposal/report message back. Approvals queue is just messages
+// of type `proposal` whose decision_id is still in outcome=pending.
+export const MessageRoleSchema = z.enum(["director", "user", "system"]);
+export type MessageRole = z.infer<typeof MessageRoleSchema>;
+
+export const MessageTypeSchema = z.enum([
+  "status",
+  "proposal",
+  "question",
+  "directive",
+  "answer",
+  "veto",
+  "report",
+  "tick_log",
+  "error",
+]);
+export type MessageType = z.infer<typeof MessageTypeSchema>;
+
+export type DirectorMessage = {
+  id: number;
+  repoId: number;
+  ts: string;
+  role: MessageRole;
+  type: MessageType;
+  body: string;
+  metadata: Record<string, unknown> | null;
+  parentId: number | null;
+  decisionId: number | null;
+};
+
+export type NewDirectorMessage = {
+  repoId: number;
+  role: MessageRole;
+  type: MessageType;
+  body: string;
+  metadata?: Record<string, unknown> | null;
+  parentId?: number | null;
+  decisionId?: number | null;
+};
+
+// ── Decisions ────────────────────────────────────────────────────────────
+// Structured output the LLM produces each tick. Each decision is persisted
+// before any side-effect, so the audit trail is complete even if the
+// service crashes mid-execution.
+export const DecisionTypeSchema = z.enum([
+  "no_op", // tick produced nothing actionable
+  "create_issue",
+  "comment_on_issue",
+  "comment_on_pr",
+  "label_issue",
+  "label_pr",
+  "close_issue", // requires authority.can_close_issues
+  "approve_pr", // approves via review (no merge)
+  "merge_pr", // merges (gated by mode + authority.can_merge)
+  "ask_user", // post a question into the chat, expect answer
+  "amend_charter", // requires authority.can_modify_charter
+]);
+export type DecisionType = z.infer<typeof DecisionTypeSchema>;
+
+export const DecisionOutcomeSchema = z.enum([
+  "pending",
+  "executed",
+  "rejected", // human said no in chat
+  "expired", // sat in queue too long
+  "failed", // tried to execute, side-effect blew up
+  "dry_run", // mode was dry_run, decision logged but never attempted
+  "skipped", // gated out by authority/budget/charter
+]);
+export type DecisionOutcome = z.infer<typeof DecisionOutcomeSchema>;
+
+export type Decision = {
+  id: number;
+  repoId: number;
+  ts: string;
+  decisionType: DecisionType;
+  rationale: string;
+  charterVersion: number | null;
+  stateSnapshot: unknown;
+  payload: unknown;
+  outcome: DecisionOutcome;
+  outcomeTs: string | null;
+  outcomeDetails: string | null;
+  costUsd: number;
+};
+
+export type NewDecision = {
+  repoId: number;
+  decisionType: DecisionType;
+  rationale: string;
+  charterVersion?: number | null;
+  stateSnapshot?: unknown;
+  payload?: unknown;
+  outcome?: DecisionOutcome;
+  costUsd?: number;
+};
+
+// ── Tick result ──────────────────────────────────────────────────────────
+export type TickReason =
+  | "scheduled"
+  | "manual"
+  | "user_message"
+  | "pr_event"
+  | "issue_event";
+
+export type TickContext = {
+  reason: TickReason;
+  triggeredBy?: string;
+};
+
+export type TickResult = {
+  status: "ok" | "skipped" | "paused" | "error";
+  detail: string;
+  decisionsLogged: number;
+  costUsd: number;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,14 @@ async function main(): Promise<void> {
   const argv = process.argv.slice(2);
   const cmd = argv[0];
 
+  // Director runs as a separate systemd unit but ships in the same bundle.
+  // It's a long-running process like `server`, not a one-shot CLI command.
+  if (cmd === "director:run") {
+    const { runDirectorService } = await import("./director/index.js");
+    await runDirectorService();
+    return;
+  }
+
   const isServerMode = !cmd || cmd === "server";
   if (!isServerMode) {
     const result = await runCli(argv);

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -106,7 +106,11 @@ function renderMessage(m: DirectorMessage): TrustedHtml {
         ${badge({ label: m.type, tone: messageTypeBadgeTone(m.type) })}
         <span>${time(m.ts)}</span>
       </div>
-      <div class="rounded-md border border-[var(--border)] ${bubble} p-3 text-sm whitespace-pre-wrap">${m.body}</div>
+      <div
+        class="rounded-md border border-[var(--border)] ${bubble} p-3 text-sm whitespace-pre-wrap"
+      >
+        ${m.body}
+      </div>
     </div>
   `;
 }
@@ -125,10 +129,14 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
               body: html`
                 <p class="text-sm text-[var(--text-2)]">
                   Enable the Director on a repo by setting
-                  <code class="code-inline">director.enabled: true</code> and providing
-                  a <code class="code-inline">director.charter</code> in its YAML config
-                  under <code class="code-inline">$OPENRONIN_DATA_DIR/config/repos/</code>.
-                  See <a href="https://github.com/openronin/openronin/blob/main/docs/DIRECTOR.md" class="link">docs/DIRECTOR.md</a>.
+                  <code class="code-inline">director.enabled: true</code> and providing a
+                  <code class="code-inline">director.charter</code> in its YAML config under
+                  <code class="code-inline">$OPENRONIN_DATA_DIR/config/repos/</code>. See
+                  <a
+                    href="https://github.com/openronin/openronin/blob/main/docs/DIRECTOR.md"
+                    class="link"
+                    >docs/DIRECTOR.md</a
+                  >.
                 </p>
               `,
             })
@@ -136,7 +144,10 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
               <div class="grid gap-3">
                 ${entries.map(
                   (e) => html`
-                    <a href="/admin/director/${e.slug}" class="card hover:border-[var(--border-strong)]">
+                    <a
+                      href="/admin/director/${e.slug}"
+                      class="card hover:border-[var(--border-strong)]"
+                    >
                       <div class="flex items-center justify-between">
                         <div class="flex flex-col">
                           <div class="font-medium">${e.owner}/${e.name}</div>
@@ -197,7 +208,11 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
                 <div class="text-xs text-[var(--text-2)]">Priorities</div>
                 <ul class="text-sm list-disc pl-5">
                   ${charter.charter.priorities.map(
-                    (p) => html`<li><code class="code-inline">${p.id}</code> (${p.weight.toFixed(2)}) — ${p.rubric}</li>`,
+                    (p) =>
+                      html`<li>
+                        <code class="code-inline">${p.id}</code> (${p.weight.toFixed(2)}) —
+                        ${p.rubric}
+                      </li>`,
                   )}
                 </ul>
               </div>
@@ -221,13 +236,47 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
       body: html`
         <table class="data-table text-sm w-full">
           <tbody>
-            <tr><td>Mode</td><td>${badge({ label: entry.mode, tone: modeBadgeTone(entry.mode) })}</td></tr>
-            <tr><td>Cadence</td><td>${repo.director.cadence_hours}h</td></tr>
-            <tr><td>Daily cap</td><td>$${budgetState.dailyCapUsd.toFixed(2)} (spent $${budgetState.spentTodayUsd.toFixed(2)})</td></tr>
-            <tr><td>Weekly cap</td><td>$${budgetState.weeklyCapUsd.toFixed(2)} (spent $${budgetState.spentWeekUsd.toFixed(2)})</td></tr>
-            <tr><td>Think today</td><td>$${budgetState.spentTodayThinkUsd.toFixed(4)} / $${repo.director.budget.think_daily_usd.toFixed(2)}</td></tr>
-            <tr><td>Failure streak</td><td>${budgetState.failureStreak}</td></tr>
-            <tr><td>Status</td><td>${gate.ok ? badge({ label: "ok", tone: "success" }) : badge({ label: gate.reason, tone: "warning" })}</td></tr>
+            <tr>
+              <td>Mode</td>
+              <td>${badge({ label: entry.mode, tone: modeBadgeTone(entry.mode) })}</td>
+            </tr>
+            <tr>
+              <td>Cadence</td>
+              <td>${repo.director.cadence_hours}h</td>
+            </tr>
+            <tr>
+              <td>Daily cap</td>
+              <td>
+                $${budgetState.dailyCapUsd.toFixed(2)} (spent
+                $${budgetState.spentTodayUsd.toFixed(2)})
+              </td>
+            </tr>
+            <tr>
+              <td>Weekly cap</td>
+              <td>
+                $${budgetState.weeklyCapUsd.toFixed(2)} (spent
+                $${budgetState.spentWeekUsd.toFixed(2)})
+              </td>
+            </tr>
+            <tr>
+              <td>Think today</td>
+              <td>
+                $${budgetState.spentTodayThinkUsd.toFixed(4)} /
+                $${repo.director.budget.think_daily_usd.toFixed(2)}
+              </td>
+            </tr>
+            <tr>
+              <td>Failure streak</td>
+              <td>${budgetState.failureStreak}</td>
+            </tr>
+            <tr>
+              <td>Status</td>
+              <td>
+                ${gate.ok
+                  ? badge({ label: "ok", tone: "success" })
+                  : badge({ label: gate.reason, tone: "warning" })}
+              </td>
+            </tr>
           </tbody>
         </table>
       `,
@@ -237,12 +286,10 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
       title: `Chat — ${messages.length} message(s)`,
       body:
         messages.length === 0
-          ? html`<p class="text-sm text-[var(--text-2)]">Empty thread. The director will start posting here once it ticks.</p>`
-          : html`
-              <div class="flex flex-col gap-2">
-                ${messages.map(renderMessage)}
-              </div>
-            `,
+          ? html`<p class="text-sm text-[var(--text-2)]">
+              Empty thread. The director will start posting here once it ticks.
+            </p>`
+          : html` <div class="flex flex-col gap-2">${messages.map(renderMessage)}</div> `,
     });
 
     const decisionsCard = card({
@@ -253,7 +300,13 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
           : html`
               <table class="data-table text-sm w-full">
                 <thead>
-                  <tr><th>Time</th><th>Type</th><th>Outcome</th><th>Charter</th><th>Rationale</th></tr>
+                  <tr>
+                    <th>Time</th>
+                    <th>Type</th>
+                    <th>Outcome</th>
+                    <th>Charter</th>
+                    <th>Rationale</th>
+                  </tr>
                 </thead>
                 <tbody>
                   ${decisions.map(
@@ -261,7 +314,17 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
                       <tr>
                         <td>${time(d.ts)}</td>
                         <td><code class="code-inline">${d.decisionType}</code></td>
-                        <td>${badge({ label: d.outcome, tone: d.outcome === "executed" ? "success" : d.outcome === "failed" ? "danger" : "neutral" })}</td>
+                        <td>
+                          ${badge({
+                            label: d.outcome,
+                            tone:
+                              d.outcome === "executed"
+                                ? "success"
+                                : d.outcome === "failed"
+                                  ? "danger"
+                                  : "neutral",
+                          })}
+                        </td>
                         <td>${d.charterVersion ? `v${d.charterVersion}` : "—"}</td>
                         <td>${d.rationale}</td>
                       </tr>
@@ -274,14 +337,8 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
 
     const body = html`
       <div class="grid gap-4 lg:grid-cols-3">
-        <div class="lg:col-span-1 flex flex-col gap-4">
-          ${charterCard}
-          ${budgetCard}
-        </div>
-        <div class="lg:col-span-2 flex flex-col gap-4">
-          ${chatCard}
-          ${decisionsCard}
-        </div>
+        <div class="lg:col-span-1 flex flex-col gap-4">${charterCard} ${budgetCard}</div>
+        <div class="lg:col-span-2 flex flex-col gap-4">${chatCard} ${decisionsCard}</div>
       </div>
     `;
     return c.html(
@@ -290,7 +347,10 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
         section: "director",
         body,
         isHtmx: isHtmx(c.req.raw.headers),
-        breadcrumb: [{ label: "Director", href: "/admin/director" }, { label: `${entry.owner}/${entry.name}` }],
+        breadcrumb: [
+          { label: "Director", href: "/admin/director" },
+          { label: `${entry.owner}/${entry.name}` },
+        ],
       }),
     );
   });

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -1,0 +1,299 @@
+// Admin UI for the Director (read-only in foundation phase).
+//
+// Mounts at /admin/director — list of director-enabled repos — and
+// /admin/director/:slug — the chat thread + recent decisions for one repo.
+// Two-way chat (HTMX message form, approval buttons) lands in PR #23.
+
+import { Hono } from "hono";
+import type { Db } from "../storage/db.js";
+import type { RuntimeConfig } from "../config/schema.js";
+import { repoKey } from "../config/schema.js";
+import { html, isHtmx, page, t as time, type TrustedHtml } from "./layout.js";
+import { card } from "./components/card.js";
+import { badge, type BadgeTone } from "./components/badge.js";
+import { recentMessages } from "../director/chat.js";
+import { recentDecisions } from "../director/decisions.js";
+import { ensureBudgetState, checkBudgetGate } from "../director/budget.js";
+import { latestCharterVersion } from "../director/charter.js";
+import type { DirectorMessage, MessageType } from "../director/types.js";
+
+interface Args {
+  db: Db;
+  getConfig: () => RuntimeConfig;
+}
+
+type RepoEntry = {
+  repoId: number;
+  slug: string;
+  owner: string;
+  name: string;
+  mode: string;
+  enabled: boolean;
+  hasCharter: boolean;
+};
+
+function listEntries(db: Db, getConfig: () => RuntimeConfig): RepoEntry[] {
+  const config = getConfig();
+  const idByKey = new Map<string, number>();
+  const rows = db
+    .prepare(`SELECT id, provider, owner, name FROM repos WHERE watched = 1`)
+    .all() as { id: number; provider: string; owner: string; name: string }[];
+  for (const r of rows) idByKey.set(`${r.provider}--${r.owner}--${r.name}`, r.id);
+  const out: RepoEntry[] = [];
+  for (const repo of config.repos) {
+    const d = repo.director;
+    if (!d || !d.enabled) continue;
+    const id = idByKey.get(repoKey(repo));
+    if (id === undefined) continue;
+    out.push({
+      repoId: id,
+      slug: repoKey(repo),
+      owner: repo.owner,
+      name: repo.name,
+      mode: d.mode,
+      enabled: d.enabled,
+      hasCharter: !!d.charter,
+    });
+  }
+  return out;
+}
+
+function modeBadgeTone(mode: string): BadgeTone {
+  switch (mode) {
+    case "full_auto":
+      return "danger";
+    case "semi_auto":
+      return "warning";
+    case "propose":
+      return "info";
+    case "dry_run":
+      return "neutral";
+    default:
+      return "neutral";
+  }
+}
+
+function messageTypeBadgeTone(type: MessageType): BadgeTone {
+  switch (type) {
+    case "proposal":
+      return "info";
+    case "directive":
+    case "veto":
+      return "warning";
+    case "error":
+      return "danger";
+    case "report":
+      return "success";
+    default:
+      return "neutral";
+  }
+}
+
+function renderMessage(m: DirectorMessage): TrustedHtml {
+  const isDirector = m.role === "director";
+  const isUser = m.role === "user";
+  const align = isUser ? "ml-auto" : "";
+  const bubble = isDirector
+    ? "bg-[var(--surface-2)]"
+    : isUser
+      ? "bg-[var(--accent-soft)]"
+      : "bg-[var(--surface-3)]";
+  const speaker = isDirector ? "👔 director" : isUser ? "👤 you" : "⚙️ system";
+  return html`
+    <div class="flex flex-col gap-1 max-w-[80ch] ${align}">
+      <div class="flex items-center gap-2 text-xs text-[var(--text-2)]">
+        <span class="font-mono">${speaker}</span>
+        ${badge({ label: m.type, tone: messageTypeBadgeTone(m.type) })}
+        <span>${time(m.ts)}</span>
+      </div>
+      <div class="rounded-md border border-[var(--border)] ${bubble} p-3 text-sm whitespace-pre-wrap">${m.body}</div>
+    </div>
+  `;
+}
+
+export function directorAdminRoute({ db, getConfig }: Args): Hono {
+  const app = new Hono();
+
+  // Index — list of director-enabled repos.
+  app.get("/", (c) => {
+    const entries = listEntries(db, getConfig);
+    const body = html`
+      <div class="flex flex-col gap-4">
+        ${entries.length === 0
+          ? card({
+              title: "No director-enabled repos",
+              body: html`
+                <p class="text-sm text-[var(--text-2)]">
+                  Enable the Director on a repo by setting
+                  <code class="code-inline">director.enabled: true</code> and providing
+                  a <code class="code-inline">director.charter</code> in its YAML config
+                  under <code class="code-inline">$OPENRONIN_DATA_DIR/config/repos/</code>.
+                  See <a href="https://github.com/openronin/openronin/blob/main/docs/DIRECTOR.md" class="link">docs/DIRECTOR.md</a>.
+                </p>
+              `,
+            })
+          : html`
+              <div class="grid gap-3">
+                ${entries.map(
+                  (e) => html`
+                    <a href="/admin/director/${e.slug}" class="card hover:border-[var(--border-strong)]">
+                      <div class="flex items-center justify-between">
+                        <div class="flex flex-col">
+                          <div class="font-medium">${e.owner}/${e.name}</div>
+                          <div class="text-xs text-[var(--text-2)]">${e.slug}</div>
+                        </div>
+                        <div class="flex items-center gap-2">
+                          ${badge({ label: e.mode, tone: modeBadgeTone(e.mode) })}
+                          ${e.hasCharter
+                            ? badge({ label: "charter", tone: "success" })
+                            : badge({ label: "no charter", tone: "warning" })}
+                        </div>
+                      </div>
+                    </a>
+                  `,
+                )}
+              </div>
+            `}
+      </div>
+    `;
+    return c.html(
+      page({
+        title: "Director",
+        section: "director",
+        body,
+        isHtmx: isHtmx(c.req.raw.headers),
+        breadcrumb: [{ label: "Director" }],
+      }),
+    );
+  });
+
+  // Detail — chat + decisions for one repo.
+  app.get("/:slug", (c) => {
+    const slug = c.req.param("slug");
+    const entries = listEntries(db, getConfig);
+    const entry = entries.find((e) => e.slug === slug);
+    if (!entry) return c.notFound();
+
+    const config = getConfig();
+    const repo = config.repos.find((r) => repoKey(r) === slug);
+    if (!repo || !repo.director) return c.notFound();
+
+    const messages = recentMessages(db, entry.repoId, 100);
+    const decisions = recentDecisions(db, entry.repoId, 20);
+    const charter = latestCharterVersion(db, entry.repoId);
+    const budgetState = ensureBudgetState(db, entry.repoId, repo.director.budget);
+    const gate = checkBudgetGate(budgetState, repo.director.budget);
+
+    const charterCard = card({
+      title: `Charter${charter ? ` (v${charter.version})` : ""}`,
+      body: charter
+        ? html`
+            <div class="flex flex-col gap-2">
+              <div>
+                <div class="text-xs text-[var(--text-2)]">Vision</div>
+                <div class="text-sm whitespace-pre-wrap">${charter.charter.vision}</div>
+              </div>
+              <div>
+                <div class="text-xs text-[var(--text-2)]">Priorities</div>
+                <ul class="text-sm list-disc pl-5">
+                  ${charter.charter.priorities.map(
+                    (p) => html`<li><code class="code-inline">${p.id}</code> (${p.weight.toFixed(2)}) — ${p.rubric}</li>`,
+                  )}
+                </ul>
+              </div>
+              ${charter.charter.out_of_bounds.length > 0
+                ? html`
+                    <div>
+                      <div class="text-xs text-[var(--text-2)]">Out of bounds</div>
+                      <ul class="text-sm list-disc pl-5">
+                        ${charter.charter.out_of_bounds.map((b) => html`<li>${b}</li>`)}
+                      </ul>
+                    </div>
+                  `
+                : ""}
+            </div>
+          `
+        : html`<p class="text-sm text-[var(--text-2)]">No charter version captured yet.</p>`,
+    });
+
+    const budgetCard = card({
+      title: "Budget",
+      body: html`
+        <table class="data-table text-sm w-full">
+          <tbody>
+            <tr><td>Mode</td><td>${badge({ label: entry.mode, tone: modeBadgeTone(entry.mode) })}</td></tr>
+            <tr><td>Cadence</td><td>${repo.director.cadence_hours}h</td></tr>
+            <tr><td>Daily cap</td><td>$${budgetState.dailyCapUsd.toFixed(2)} (spent $${budgetState.spentTodayUsd.toFixed(2)})</td></tr>
+            <tr><td>Weekly cap</td><td>$${budgetState.weeklyCapUsd.toFixed(2)} (spent $${budgetState.spentWeekUsd.toFixed(2)})</td></tr>
+            <tr><td>Think today</td><td>$${budgetState.spentTodayThinkUsd.toFixed(4)} / $${repo.director.budget.think_daily_usd.toFixed(2)}</td></tr>
+            <tr><td>Failure streak</td><td>${budgetState.failureStreak}</td></tr>
+            <tr><td>Status</td><td>${gate.ok ? badge({ label: "ok", tone: "success" }) : badge({ label: gate.reason, tone: "warning" })}</td></tr>
+          </tbody>
+        </table>
+      `,
+    });
+
+    const chatCard = card({
+      title: `Chat — ${messages.length} message(s)`,
+      body:
+        messages.length === 0
+          ? html`<p class="text-sm text-[var(--text-2)]">Empty thread. The director will start posting here once it ticks.</p>`
+          : html`
+              <div class="flex flex-col gap-2">
+                ${messages.map(renderMessage)}
+              </div>
+            `,
+    });
+
+    const decisionsCard = card({
+      title: `Recent decisions — ${decisions.length}`,
+      body:
+        decisions.length === 0
+          ? html`<p class="text-sm text-[var(--text-2)]">No decisions logged yet.</p>`
+          : html`
+              <table class="data-table text-sm w-full">
+                <thead>
+                  <tr><th>Time</th><th>Type</th><th>Outcome</th><th>Charter</th><th>Rationale</th></tr>
+                </thead>
+                <tbody>
+                  ${decisions.map(
+                    (d) => html`
+                      <tr>
+                        <td>${time(d.ts)}</td>
+                        <td><code class="code-inline">${d.decisionType}</code></td>
+                        <td>${badge({ label: d.outcome, tone: d.outcome === "executed" ? "success" : d.outcome === "failed" ? "danger" : "neutral" })}</td>
+                        <td>${d.charterVersion ? `v${d.charterVersion}` : "—"}</td>
+                        <td>${d.rationale}</td>
+                      </tr>
+                    `,
+                  )}
+                </tbody>
+              </table>
+            `,
+    });
+
+    const body = html`
+      <div class="grid gap-4 lg:grid-cols-3">
+        <div class="lg:col-span-1 flex flex-col gap-4">
+          ${charterCard}
+          ${budgetCard}
+        </div>
+        <div class="lg:col-span-2 flex flex-col gap-4">
+          ${chatCard}
+          ${decisionsCard}
+        </div>
+      </div>
+    `;
+    return c.html(
+      page({
+        title: `Director — ${entry.owner}/${entry.name}`,
+        section: "director",
+        body,
+        isHtmx: isHtmx(c.req.raw.headers),
+        breadcrumb: [{ label: "Director", href: "/admin/director" }, { label: `${entry.owner}/${entry.name}` }],
+      }),
+    );
+  });
+
+  return app;
+}

--- a/src/server/admin.ts
+++ b/src/server/admin.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { basicAuth } from "hono/basic-auth";
 import { styleguideRoute } from "./styleguide.js";
+import { directorAdminRoute } from "./admin-director.js";
 import { existsSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { randomBytes } from "node:crypto";
@@ -58,6 +59,7 @@ export function adminRoute({ db, getConfig, scheduler, startedAt }: Args): Hono 
   }
 
   app.route("", styleguideRoute());
+  app.route("/director", directorAdminRoute({ db, getConfig }));
 
   // Serve the brand icon used in the header.
   app.get("/_assets/icon.png", (c) => {

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -224,4 +224,73 @@ function applyMigrations(db: Db): void {
       "INSERT INTO schema_version (version, applied_at) VALUES (11, datetime('now'))",
     ).run();
   }
+
+  // v12 — Director (autonomous PM layer). Adds:
+  //   • director_messages   — chat thread (director ↔ user) per repo
+  //   • director_decisions  — every decision the director made, with rationale
+  //   • director_charter_versions — versioned charter snapshots per repo
+  //   • director_budget_state — adaptive budget + failure-streak per repo
+  // None of this affects the existing scheduler/lanes; the director runs as a
+  // separate systemd unit that shares this DB. See src/director/.
+  if (current < 12) {
+    db.exec(`
+      CREATE TABLE director_messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        repo_id INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+        ts TEXT NOT NULL DEFAULT (datetime('now')),
+        role TEXT NOT NULL CHECK (role IN ('director','user','system')),
+        type TEXT NOT NULL CHECK (type IN (
+          'status','proposal','question','directive','answer','veto','report','tick_log','error'
+        )),
+        body TEXT NOT NULL,
+        metadata TEXT,
+        parent_id INTEGER REFERENCES director_messages(id) ON DELETE SET NULL,
+        decision_id INTEGER
+      );
+      CREATE INDEX idx_director_messages_repo_ts ON director_messages(repo_id, ts DESC);
+
+      CREATE TABLE director_decisions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        repo_id INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+        ts TEXT NOT NULL DEFAULT (datetime('now')),
+        decision_type TEXT NOT NULL,
+        rationale TEXT NOT NULL,
+        charter_version INTEGER,
+        state_snapshot TEXT,
+        payload TEXT,
+        outcome TEXT NOT NULL DEFAULT 'pending',
+        outcome_ts TEXT,
+        outcome_details TEXT,
+        cost_usd REAL NOT NULL DEFAULT 0
+      );
+      CREATE INDEX idx_director_decisions_repo_ts ON director_decisions(repo_id, ts DESC);
+      CREATE INDEX idx_director_decisions_pending ON director_decisions(outcome) WHERE outcome = 'pending';
+
+      CREATE TABLE director_charter_versions (
+        repo_id INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+        version INTEGER NOT NULL,
+        charter_yaml TEXT NOT NULL,
+        effective_from TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (repo_id, version)
+      );
+
+      CREATE TABLE director_budget_state (
+        repo_id INTEGER PRIMARY KEY REFERENCES repos(id) ON DELETE CASCADE,
+        daily_cap_usd REAL NOT NULL DEFAULT 2.0,
+        weekly_cap_usd REAL NOT NULL DEFAULT 10.0,
+        spent_today_usd REAL NOT NULL DEFAULT 0,
+        spent_week_usd REAL NOT NULL DEFAULT 0,
+        spent_today_think_usd REAL NOT NULL DEFAULT 0,
+        failure_streak INTEGER NOT NULL DEFAULT 0,
+        last_tick_at TEXT,
+        last_reset_day TEXT,
+        paused INTEGER NOT NULL DEFAULT 0,
+        pause_reason TEXT,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+    db.prepare(
+      "INSERT INTO schema_version (version, applied_at) VALUES (12, datetime('now'))",
+    ).run();
+  }
 }

--- a/test/director.test.mjs
+++ b/test/director.test.mjs
@@ -275,9 +275,9 @@ test("budget gate: think and project spend caps", () => {
     assert.match(gate1.reason, /think budget/);
 
     // Reset by pretending day rolled over (manual hack: zero the column)
-    db.prepare(
-      `UPDATE director_budget_state SET spent_today_think_usd = 0 WHERE repo_id = ?`,
-    ).run(repoId);
+    db.prepare(`UPDATE director_budget_state SET spent_today_think_usd = 0 WHERE repo_id = ?`).run(
+      repoId,
+    );
     recordProjectSpend(db, repoId, 5.0); // exceeds initial_daily
     state = ensureBudgetState(db, repoId, cfg);
     const gate2 = checkBudgetGate(state, cfg);

--- a/test/director.test.mjs
+++ b/test/director.test.mjs
@@ -1,0 +1,289 @@
+// Foundation tests for the Director.
+//
+// These exercise: schema migration v12 lands cleanly, charter parsing
+// roundtrips, charter versioning is content-addressed, the chat append +
+// recent + since helpers behave, and the budget gate trips on the right
+// thresholds. No LLM calls — that lands in #22.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import {
+  appendMessage,
+  recentMessages,
+  messagesSince,
+  unansweredUserDirectives,
+} from "../dist/director/chat.js";
+import {
+  parseCharter,
+  charterHash,
+  captureCharterVersion,
+  latestCharterVersion,
+} from "../dist/director/charter.js";
+import {
+  recordDecision,
+  setDecisionOutcome,
+  recentDecisions,
+  pendingDecisions,
+} from "../dist/director/decisions.js";
+import {
+  ensureBudgetState,
+  checkBudgetGate,
+  recordThinkSpend,
+  recordProjectSpend,
+  bumpFailureStreak,
+  resetFailureStreak,
+  pause,
+  unpause,
+} from "../dist/director/budget.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-director-test-"));
+  const db = initDb(dir);
+  // Need a repo to satisfy FK constraints on director_* tables.
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+const sampleCharter = {
+  vision: "Reliable, observable AI dev agent.",
+  priorities: [
+    { id: "reliability", weight: 0.5, rubric: "graceful failure" },
+    { id: "observability", weight: 0.5, rubric: "debuggable without SSH" },
+  ],
+  out_of_bounds: ["no schema changes without migration"],
+  out_of_bounds_paths: ["src/storage/db.ts"],
+  definition_of_done: ["pnpm run check green"],
+};
+
+test("migration v12 creates director tables", () => {
+  const { db, dir } = freshDb();
+  try {
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all()
+      .map((r) => r.name);
+    for (const expected of [
+      "director_messages",
+      "director_decisions",
+      "director_charter_versions",
+      "director_budget_state",
+    ]) {
+      assert.ok(tables.includes(expected), `missing table ${expected}`);
+    }
+    const v = db.prepare("SELECT MAX(version) AS v FROM schema_version").get().v;
+    assert.ok(v >= 12, `schema version >= 12, got ${v}`);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("parseCharter accepts well-formed and rejects malformed", () => {
+  assert.ok(parseCharter(sampleCharter));
+  assert.equal(parseCharter(null), null);
+  assert.equal(parseCharter({ vision: "x" }), null); // no priorities
+  assert.equal(parseCharter({ vision: "x", priorities: [] }), null); // empty
+});
+
+test("charterHash is stable and content-addressed", () => {
+  const h1 = charterHash(parseCharter(sampleCharter));
+  const h2 = charterHash(parseCharter({ ...sampleCharter }));
+  assert.equal(h1, h2);
+  const h3 = charterHash(parseCharter({ ...sampleCharter, vision: "different" }));
+  assert.notEqual(h1, h3);
+});
+
+test("captureCharterVersion deduplicates identical content", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const charter = parseCharter(sampleCharter);
+    const v1 = captureCharterVersion(db, repoId, charter);
+    const v2 = captureCharterVersion(db, repoId, charter);
+    assert.equal(v1, v2, "same charter → same version");
+    const altered = parseCharter({ ...sampleCharter, vision: "v2" });
+    const v3 = captureCharterVersion(db, repoId, altered);
+    assert.equal(v3, v1 + 1);
+
+    const latest = latestCharterVersion(db, repoId);
+    assert.equal(latest.version, v3);
+    assert.equal(latest.charter.vision, "v2");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("chat append + recent ordering", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    appendMessage(db, { repoId, role: "director", type: "tick_log", body: "first" });
+    appendMessage(db, { repoId, role: "user", type: "directive", body: "focus on tests" });
+    appendMessage(db, { repoId, role: "director", type: "report", body: "done" });
+    const msgs = recentMessages(db, repoId, 50);
+    assert.equal(msgs.length, 3);
+    assert.equal(msgs[0].body, "first");
+    assert.equal(msgs[2].body, "done");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("messagesSince returns only newer messages", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const m1 = appendMessage(db, { repoId, role: "director", type: "tick_log", body: "a" });
+    appendMessage(db, { repoId, role: "director", type: "tick_log", body: "b" });
+    appendMessage(db, { repoId, role: "user", type: "directive", body: "c" });
+    const newer = messagesSince(db, repoId, m1.id);
+    assert.equal(newer.length, 2);
+    assert.equal(newer[0].body, "b");
+    assert.equal(newer[1].body, "c");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("unansweredUserDirectives finds messages after last director reply", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    appendMessage(db, { repoId, role: "director", type: "status", body: "tick" });
+    appendMessage(db, { repoId, role: "user", type: "directive", body: "do X" });
+    appendMessage(db, { repoId, role: "user", type: "answer", body: "and Y" });
+    const open = unansweredUserDirectives(db, repoId);
+    assert.equal(open.length, 2);
+    appendMessage(db, { repoId, role: "director", type: "report", body: "ok" });
+    const stillOpen = unansweredUserDirectives(db, repoId);
+    assert.equal(stillOpen.length, 0);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("decision lifecycle: record → set outcome → query", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const d = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "addresses observability gap",
+      payload: { title: "Add /metrics" },
+    });
+    assert.equal(d.outcome, "pending");
+    assert.deepEqual(d.payload, { title: "Add /metrics" });
+
+    const pending = pendingDecisions(db, repoId);
+    assert.equal(pending.length, 1);
+
+    setDecisionOutcome(db, d.id, "executed", "issue #42 created");
+    const updated = recentDecisions(db, repoId, 10);
+    assert.equal(updated[0].outcome, "executed");
+    assert.equal(updated[0].outcomeDetails, "issue #42 created");
+    assert.equal(pendingDecisions(db, repoId).length, 0);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("budget gate: paused → blocked", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const cfg = {
+      initial_daily_usd: 2.0,
+      initial_weekly_usd: 10.0,
+      max_daily_usd: 10.0,
+      max_weekly_usd: 50.0,
+      think_daily_usd: 1.0,
+      pause_on_failure_streak: 3,
+      good_outcome_quarantine_days: 7,
+    };
+    let state = ensureBudgetState(db, repoId, cfg);
+    assert.equal(checkBudgetGate(state, cfg).ok, true);
+
+    pause(db, repoId, "manual test pause");
+    state = ensureBudgetState(db, repoId, cfg);
+    const gate = checkBudgetGate(state, cfg);
+    assert.equal(gate.ok, false);
+    assert.match(gate.reason, /paused/);
+
+    unpause(db, repoId);
+    state = ensureBudgetState(db, repoId, cfg);
+    assert.equal(checkBudgetGate(state, cfg).ok, true);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("budget gate: failure_streak >= threshold → blocked", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const cfg = {
+      initial_daily_usd: 2.0,
+      initial_weekly_usd: 10.0,
+      max_daily_usd: 10.0,
+      max_weekly_usd: 50.0,
+      think_daily_usd: 1.0,
+      pause_on_failure_streak: 3,
+      good_outcome_quarantine_days: 7,
+    };
+    ensureBudgetState(db, repoId, cfg);
+    bumpFailureStreak(db, repoId);
+    bumpFailureStreak(db, repoId);
+    let state = ensureBudgetState(db, repoId, cfg);
+    assert.equal(checkBudgetGate(state, cfg).ok, true, "2 < 3, still ok");
+    bumpFailureStreak(db, repoId);
+    state = ensureBudgetState(db, repoId, cfg);
+    assert.equal(checkBudgetGate(state, cfg).ok, false, "3 trips the gate");
+
+    resetFailureStreak(db, repoId);
+    state = ensureBudgetState(db, repoId, cfg);
+    assert.equal(checkBudgetGate(state, cfg).ok, true);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("budget gate: think and project spend caps", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const cfg = {
+      initial_daily_usd: 2.0,
+      initial_weekly_usd: 10.0,
+      max_daily_usd: 10.0,
+      max_weekly_usd: 50.0,
+      think_daily_usd: 1.0,
+      pause_on_failure_streak: 3,
+      good_outcome_quarantine_days: 7,
+    };
+    ensureBudgetState(db, repoId, cfg);
+    recordThinkSpend(db, repoId, 1.5); // exceeds think cap
+    let state = ensureBudgetState(db, repoId, cfg);
+    const gate1 = checkBudgetGate(state, cfg);
+    assert.equal(gate1.ok, false);
+    assert.match(gate1.reason, /think budget/);
+
+    // Reset by pretending day rolled over (manual hack: zero the column)
+    db.prepare(
+      `UPDATE director_budget_state SET spent_today_think_usd = 0 WHERE repo_id = ?`,
+    ).run(repoId);
+    recordProjectSpend(db, repoId, 5.0); // exceeds initial_daily
+    state = ensureBudgetState(db, repoId, cfg);
+    const gate2 = checkBudgetGate(state, cfg);
+    assert.equal(gate2.ok, false);
+    assert.match(gate2.reason, /daily project budget/);
+  } finally {
+    cleanup(dir);
+  }
+});


### PR DESCRIPTION
## Summary

Adds the scaffolding for an autonomous PM layer (the **Director**) that runs as a separate systemd service alongside the main openronin daemon.

This is **PR #1 of 5** for the director rollout — foundation only. Service starts, ticks per cadence, writes a no-op entry to its chat table, captures the charter version, gates on adaptive budget. The LLM-driven planning tick lands in PR #22.

The director is opt-in per-repo via YAML (\`director.enabled: true\` + \`director.charter\`). Without both, the service silently skips the repo. Nothing in the existing scheduler/lanes code path changes — safe to merge even if you're not ready to enable it.

## What's in this PR

- **Schema migration v12** — four new tables:
  - \`director_messages\` (chat thread per repo)
  - \`director_decisions\` (audit trail with rationale, charter version)
  - \`director_charter_versions\` (versioned charter snapshots, content-deduplicated)
  - \`director_budget_state\` (adaptive budget + failure-streak gate)
- **\`src/director/\`** — types, charter loader, chat data layer, decision data layer, adaptive budget tracker (think + project caps, failure-streak pause), service entry point.
- **\`src/config/schema.ts\`** — per-repo \`director:\` block (Zod). Default \`enabled: false\`.
- **\`src/index.ts\`** — \`director:run\` mode dispatches to \`runDirectorService()\`.
- **\`src/server/admin-director.ts\`** — read-only timeline at \`/admin/director\` and \`/admin/director/:slug\`.
- **\`deploy/openronin-director.service\`** — systemd unit template (separate \`director.env\` for director-specific secrets like the upcoming Telegram bridge).
- **\`.env.example\`** — documents \`OPENRONIN_DIRECTOR_DISABLED\` kill switch and the upcoming Telegram bridge env vars.
- **\`test/director.test.mjs\`** — 11 tests covering migration, charter parsing/versioning/dedup, chat append/recent/since, decision lifecycle, budget gate (paused/streak/think/daily/weekly).

## Architecture in one paragraph

Three layers: **Director** (proactive, decides what to work on) → **Supervisor** (MIMO, routes lanes) → **Worker** (Claude Code, writes code). The director never edits source files directly — code mutations stay with the worker. Director only emits decisions (create issue, comment, approve merge), persisted with rationale and charter-version pinning before any side-effect runs. Adaptive budget keeps cost bounded; failure-streak gate (3 consecutive failures by default) auto-pauses with a chat message asking for human directive.

## What's NOT here (next PRs)

- PR #22 — actual LLM-driven tick (replaces the no-op)
- PR #23 — execution gates: mode toggle (\`dry_run\` → \`propose\` → \`semi_auto\` → \`full_auto\`), HTMX approval buttons
- PR #24 — Telegram bridge for the chat thread
- PR #25 — adaptive budget that actually adapts based on outcomes; enable on second repo

## Test plan

- [x] \`pnpm run check\` green (build + lint + 53 unit tests + format)
- [x] 11 new director-specific tests pass: migration, charter dedup, chat ordering, decisions, budget gate
- [ ] After merge: install systemd unit on 0srv, start in \`dry_run\` for openronin/openronin, verify chat shows \`tick fired (mode=dry_run, charter v1)\` after first cadence