### PR TITLE
[openronin] deploy lane: robust against non-main checkout in target dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to **openronin** are documented here. The format follows [Ke
 
 ## [Unreleased]
 
+### Fixed — deploy lane: robust against non-trigger-branch checkout
+
+Deploy documentation and the admin UI config example now use `git checkout <branch> && git pull --ff-only` instead of a bare `git pull --ff-only`. This prevents failures when the target directory is checked out on a branch other than `trigger_branch` (e.g. after a squash-merge deletes the feature branch that the directory happened to be on).
+
 ### Added — Director (autonomous PM layer), foundation
 
 A new optional service, `openronin-director.service`, adds a third architectural layer above the existing supervisor/worker split. The Director runs as a separate systemd unit but shares this codebase, the SQLite DB, and `OPENRONIN_DATA_DIR`. It's the source of intent — what the project should work on next — where the existing daemon is purely reactive to events.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -257,7 +257,7 @@ deploy:
   bot_login: openronin-bot       # whatever your bot's GitHub username is
   require_bot_push: true
   commands:
-    - cd /opt/openronin && git pull --ff-only
+    - cd /opt/openronin && git checkout main && git pull --ff-only
     - cd /opt/openronin && pnpm install --frozen-lockfile
     - cd /opt/openronin && pnpm build
     - sudo /bin/systemctl --no-block restart openronin

--- a/src/server/admin.ts
+++ b/src/server/admin.ts
@@ -4100,7 +4100,7 @@ deploy:
   commands:
     # Each command runs in a fresh \`bash -c\` on the openronin host.
     # Use absolute paths — there's no implicit cwd.
-    - cd /opt/myapp && git pull --ff-only
+    - cd /opt/myapp && git checkout main && git pull --ff-only
     - cd /opt/myapp && pnpm install --frozen-lockfile
     - cd /opt/myapp && pnpm build
     # --no-block is critical for self-restart: returns immediately so the
@@ -4131,7 +4131,7 @@ deploy:
   commands:
     # Each command runs in a fresh remote shell. Use absolute paths.
     # No interactive prompts — sudo must be passwordless.
-    - cd /opt/myapp && git pull --ff-only
+    - cd /opt/myapp && git checkout main && git pull --ff-only
     - cd /opt/myapp && npm ci --omit=dev
     - cd /opt/myapp && npm run build
     - sudo /bin/systemctl --no-block restart myapp`;


### PR DESCRIPTION
🤖 openronin: автоматический PR.

Closes #22.

This PR was opened automatically by [openronin](https://github.com/openronin/openronin) in response to issue #22.

## Agent summary

## Summary

**What changed:**

Three files, four occurrences of the fragile bare `git pull --ff-only` replaced with `git checkout <branch> && git pull --ff-only`:

| File | Location |
|---|---|
| `docs/DEPLOYMENT.md` | §9 self-deploy per-repo config YAML example |
| `src/server/admin.ts` | Admin UI "local mode" deploy config example panel |
| `src/server/admin.ts` | Admin UI "SSH mode" deploy config example panel |
| `CHANGELOG.md` | New `[Unreleased]` entry documenting the doc fix |

**Why:** A bare `git pull --ff-only` fails with a tracking-ref error when the target directory is checked out on any branch other than `trigger_branch`. This was hit in production (deploy id=18, directory left on `feat/director-foundation` after the squash-merge of #21 deleted that branch on origin). Prepending `git checkout main` is a no-op when already on the right branch and recovers silently when not — approach (1) from the issue.

**Tests/lint:** `pnpm run check` passed — 53 unit tests green, 0 lint errors, format clean.

## Diff stats

- Files changed: 3
- Lines: +7 / -3

---
*Marked as draft for human review. The agent (claude_code) wrote this; please review before merging.*