### PR TITLE
feat(director): real LLM-driven dry_run tick

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,9 +90,10 @@ TELEGRAM_BOT_TOKEN=
 # never in this file.
 # OPENRONIN_DIRECTOR_TELEGRAM_TOKEN=
 
-# Anthropic API model used for director planning ticks. Defaults to a
-# reasoning-capable model; the supervisor's MIMO is too thin for this role.
-# OPENRONIN_DIRECTOR_THINK_MODEL=claude-sonnet-4-5
+# Anthropic API model used for director planning ticks. Defaults to
+# claude-sonnet-4-6; the supervisor's MIMO is too thin for this role.
+# Director also reads ANTHROPIC_API_KEY (above) — same key, different model.
+# OPENRONIN_DIRECTOR_THINK_MODEL=claude-sonnet-4-6
 
 # ── Backups (optional) ─────────────────────────────────────────────────────
 # rsync destination for daily off-host backups. See deploy/openronin-backup-*

--- a/prompts/templates/director-tick.md
+++ b/prompts/templates/director-tick.md
@@ -1,0 +1,76 @@
+You are the **Director** for the open-source project `{{owner}}/{{name}}`. Your role is product-owner / project-manager: you watch the repo, decide what should be worked on next, and emit decisions that the existing automation will carry out. You **never** edit source files directly — code mutations stay with the code-writing agent (a separate engine). You only emit decisions like "create issue", "comment on PR", "approve PR", etc.
+
+## Your charter (the constitution for this repo)
+
+This is the source of truth for what "good" looks like. Cite specific priority IDs in your reasoning.
+
+```yaml
+{{charter_yaml}}
+```
+
+## Operating mode
+
+You are running in mode `{{mode}}`. The mode controls whether your decisions actually execute:
+
+- `dry_run` — your decisions are logged for human review but **never executed**. Be especially honest about uncertainty: this is the calibration phase.
+- `propose` — decisions are logged and posted into the chat thread for explicit human approval before execution.
+- `semi_auto` — decisions execute except merges (merges queue for human approval).
+- `full_auto` — all decisions execute; you are expected to escalate via `ask_user` when uncertain.
+
+In every mode, prefer fewer high-value decisions over many low-value ones. **An empty/no-op tick is a valid outcome** — say `no_op` and explain why, rather than inventing busywork.
+
+## Project state right now
+
+```json
+{{state_json}}
+```
+
+## Recent chat with the human (most recent last)
+
+```
+{{chat_transcript}}
+```
+
+If there are unanswered user `directive` or `answer` messages, **address them first** before any other planning. The chat is your highest-priority signal — it overrides standing charter priorities for this tick.
+
+## Hard constraints
+
+- Stay strictly inside the charter. Anything in `out_of_bounds` or `out_of_bounds_paths` is forbidden.
+- Don't propose work that already exists: check `recentDecisions`, `openPrs`, and the chat transcript before creating duplicates.
+- Don't propose changing the charter unless the human asked or the charter is provably broken — and even then, only via the `amend_charter` decision type, never silently.
+- Reserve `merge_pr` decisions for PRs that are clearly ready (CI green, no unresolved threads, addresses real charter priority). Default authority typically blocks this anyway.
+- If you are uncertain, prefer `ask_user` over guessing.
+- Cap output at **10 decisions** per tick. Quality over quantity.
+
+## Output contract
+
+Return **exactly one JSON object** matching this shape (no prose, no markdown fences — just the JSON):
+
+```json
+{
+  "observations": "2-3 sentences plainly describing the project state.",
+  "reasoning": "1-2 paragraphs explaining your plan, citing charter priority IDs.",
+  "decisions": [
+    {
+      "type": "create_issue" | "comment_on_issue" | "comment_on_pr" | "label_issue" | "label_pr" | "close_issue" | "approve_pr" | "merge_pr" | "ask_user" | "amend_charter" | "no_op",
+      "rationale": "Why this specific decision; cite a charter priority by id when applicable.",
+      "priority_id": "(optional) id of the charter priority this serves",
+      "payload": { /* type-specific; see schemas below */ }
+    }
+  ]
+}
+```
+
+### Payloads by decision type
+
+- **create_issue** — `{"title":"<5-200 chars>", "body":"<full markdown body>", "labels":[<string>], "priority":"low"|"normal"|"high"}`. Body should follow the issue template style: ## Problem, ## Proposed approach, ## Acceptance, ## Out of scope. Include the trigger label `openronin:do-it` only if the issue is well-specified enough to start work immediately.
+- **comment_on_issue / comment_on_pr** — `{"issue_number"|"pr_number":<n>, "body":"<markdown>"}`. Be specific and actionable.
+- **label_issue / label_pr** — `{"issue_number"|"pr_number":<n>, "add":[<string>], "remove":[<string>]}`.
+- **close_issue** — `{"issue_number":<n>, "reason":"<why>"}`. Conservative: only close stale or duplicate or won't-do.
+- **approve_pr** — `{"pr_number":<n>, "body":"<optional review body>"}`. Approves; doesn't merge.
+- **merge_pr** — `{"pr_number":<n>, "strategy":"merge"|"squash"|"rebase"}`. Default `squash`.
+- **ask_user** — `{"question":"<the question>", "context":"<optional context>"}`. Use when the charter is ambiguous and you need a directive.
+- **amend_charter** — `{"proposed_changes":"<full text of what to change>", "rationale":"<why>"}`. Suggest only.
+- **no_op** — no payload. Use when nothing is worth doing this tick.
+
+If your output cannot be parsed against the schema, this tick will be discarded and an error will be logged — be careful with the JSON.

--- a/src/director/decision-schema.ts
+++ b/src/director/decision-schema.ts
@@ -144,9 +144,7 @@ export const TickOutputSchema = z.object({
   reasoning: z
     .string()
     .min(20)
-    .describe(
-      "Why these decisions, citing which charter priorities they serve. 1-2 paragraphs.",
-    ),
+    .describe("Why these decisions, citing which charter priorities they serve. 1-2 paragraphs."),
   decisions: z
     .array(DecisionSchema)
     .min(1)

--- a/src/director/decision-schema.ts
+++ b/src/director/decision-schema.ts
@@ -1,0 +1,166 @@
+// Zod schemas for the structured output the Director's LLM tick produces.
+//
+// The LLM is instructed to emit a single JSON object matching `TickOutputSchema`.
+// Each `decision` carries a discriminated `type` plus a type-specific `payload`
+// shape. Anything that fails validation is rejected — the tick falls back to
+// a no_op + an `error`-typed message in chat, so the audit trail stays clean.
+
+import { z } from "zod";
+
+// ── Per-decision payloads ────────────────────────────────────────────────
+
+const CreateIssuePayload = z.object({
+  title: z.string().min(5).max(200),
+  body: z.string().min(20),
+  labels: z.array(z.string()).default([]),
+  priority: z.enum(["low", "normal", "high"]).default("normal"),
+});
+export type CreateIssuePayload = z.infer<typeof CreateIssuePayload>;
+
+const CommentOnIssuePayload = z.object({
+  issue_number: z.number().int().positive(),
+  body: z.string().min(10),
+});
+
+const CommentOnPrPayload = z.object({
+  pr_number: z.number().int().positive(),
+  body: z.string().min(10),
+});
+
+const LabelIssuePayload = z.object({
+  issue_number: z.number().int().positive(),
+  add: z.array(z.string()).default([]),
+  remove: z.array(z.string()).default([]),
+});
+
+const LabelPrPayload = z.object({
+  pr_number: z.number().int().positive(),
+  add: z.array(z.string()).default([]),
+  remove: z.array(z.string()).default([]),
+});
+
+const CloseIssuePayload = z.object({
+  issue_number: z.number().int().positive(),
+  reason: z.string().min(10),
+});
+
+const ApprovePrPayload = z.object({
+  pr_number: z.number().int().positive(),
+  body: z.string().optional(),
+});
+
+const MergePrPayload = z.object({
+  pr_number: z.number().int().positive(),
+  strategy: z.enum(["merge", "squash", "rebase"]).default("squash"),
+});
+
+const AskUserPayload = z.object({
+  question: z.string().min(10),
+  context: z.string().optional(),
+});
+
+const AmendCharterPayload = z.object({
+  proposed_changes: z.string().min(20),
+  rationale: z.string().min(20),
+});
+
+// ── Decision union (discriminated by `type`) ─────────────────────────────
+
+const DecisionSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("no_op"),
+    rationale: z.string().min(10),
+  }),
+  z.object({
+    type: z.literal("create_issue"),
+    rationale: z.string().min(10),
+    priority_id: z.string().optional(),
+    payload: CreateIssuePayload,
+  }),
+  z.object({
+    type: z.literal("comment_on_issue"),
+    rationale: z.string().min(10),
+    priority_id: z.string().optional(),
+    payload: CommentOnIssuePayload,
+  }),
+  z.object({
+    type: z.literal("comment_on_pr"),
+    rationale: z.string().min(10),
+    priority_id: z.string().optional(),
+    payload: CommentOnPrPayload,
+  }),
+  z.object({
+    type: z.literal("label_issue"),
+    rationale: z.string().min(10),
+    priority_id: z.string().optional(),
+    payload: LabelIssuePayload,
+  }),
+  z.object({
+    type: z.literal("label_pr"),
+    rationale: z.string().min(10),
+    priority_id: z.string().optional(),
+    payload: LabelPrPayload,
+  }),
+  z.object({
+    type: z.literal("close_issue"),
+    rationale: z.string().min(10),
+    priority_id: z.string().optional(),
+    payload: CloseIssuePayload,
+  }),
+  z.object({
+    type: z.literal("approve_pr"),
+    rationale: z.string().min(10),
+    priority_id: z.string().optional(),
+    payload: ApprovePrPayload,
+  }),
+  z.object({
+    type: z.literal("merge_pr"),
+    rationale: z.string().min(10),
+    priority_id: z.string().optional(),
+    payload: MergePrPayload,
+  }),
+  z.object({
+    type: z.literal("ask_user"),
+    rationale: z.string().min(10),
+    priority_id: z.string().optional(),
+    payload: AskUserPayload,
+  }),
+  z.object({
+    type: z.literal("amend_charter"),
+    rationale: z.string().min(10),
+    priority_id: z.string().optional(),
+    payload: AmendCharterPayload,
+  }),
+]);
+export type ParsedDecision = z.infer<typeof DecisionSchema>;
+
+// ── Top-level tick output ────────────────────────────────────────────────
+
+export const TickOutputSchema = z.object({
+  observations: z
+    .string()
+    .min(20)
+    .describe("Plain-text summary of the project state. 2-3 sentences."),
+  reasoning: z
+    .string()
+    .min(20)
+    .describe(
+      "Why these decisions, citing which charter priorities they serve. 1-2 paragraphs.",
+    ),
+  decisions: z
+    .array(DecisionSchema)
+    .min(1)
+    .max(10)
+    .describe("0-10 actions to take. Use a single no_op when nothing is worth doing."),
+});
+export type TickOutput = z.infer<typeof TickOutputSchema>;
+
+export function parseTickOutput(
+  raw: unknown,
+): { ok: true; value: TickOutput } | { ok: false; error: string } {
+  const parsed = TickOutputSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { ok: false, error: parsed.error.message };
+  }
+  return { ok: true, value: parsed.data };
+}

--- a/src/director/index.ts
+++ b/src/director/index.ts
@@ -15,10 +15,9 @@ import type { RepoConfig, RuntimeConfig } from "../config/schema.js";
 import { repoKey } from "../config/schema.js";
 import { initDb, type Db } from "../storage/db.js";
 import { syncReposFromConfig } from "../storage/repos.js";
-import { ensureBudgetState, rolloverDayIfNeeded, markTick, checkBudgetGate } from "./budget.js";
+import { ensureBudgetState, rolloverDayIfNeeded } from "./budget.js";
 import { appendMessage } from "./chat.js";
-import { captureCharterVersion } from "./charter.js";
-import { recordDecision } from "./decisions.js";
+import { runTick } from "./tick.js";
 import type { DirectorConfig } from "./types.js";
 
 const SERVICE_LOOP_INTERVAL_MS = 60_000; // wake up every minute
@@ -63,56 +62,19 @@ function shouldTickNow(state: { lastTickAt: string | null }, cadenceHours: numbe
   return elapsedMs >= cadenceHours * 3600_000;
 }
 
-async function tickNoOp(db: Db, target: RepoLookup): Promise<void> {
-  const { repoId, repo, director } = target;
-  if (!director.charter) return;
-
-  rolloverDayIfNeeded(db, repoId);
-  const state = ensureBudgetState(db, repoId, director.budget);
-
-  const gate = checkBudgetGate(state, director.budget);
-  if (!gate.ok) {
-    appendMessage(db, {
-      repoId,
-      role: "system",
-      type: "tick_log",
-      body: `tick skipped: ${gate.reason}`,
-      metadata: { repo: repoKey(repo), mode: director.mode },
-    });
-    return;
-  }
-
-  const charterVersion = captureCharterVersion(db, repoId, director.charter);
-
-  const decision = recordDecision(db, {
-    repoId,
-    decisionType: "no_op",
-    rationale:
-      "Foundation tick: scheduler+chat+charter+budget infrastructure is wired. " +
-      "Real LLM-driven planning lands in PR #22. This entry confirms the loop " +
-      "ran end-to-end (charter parsed, budget gate passed, message appended).",
-    charterVersion,
-    stateSnapshot: {
-      mode: director.mode,
-      cadenceHours: director.cadence_hours,
-      charterVersion,
-      spentTodayUsd: state.spentTodayUsd,
-      spentTodayThinkUsd: state.spentTodayThinkUsd,
-      failureStreak: state.failureStreak,
-    },
-    outcome: "dry_run",
+async function executeTick(db: Db, target: RepoLookup, dataDir: string): Promise<void> {
+  const result = await runTick({
+    db,
+    repoId: target.repoId,
+    repo: target.repo,
+    director: target.director,
+    dataDir,
   });
-
-  appendMessage(db, {
-    repoId,
-    role: "director",
-    type: "tick_log",
-    body: `tick fired (mode=${director.mode}, charter v${charterVersion}). Foundation phase: no planning yet.`,
-    metadata: { repo: repoKey(repo), decisionId: decision.id },
-    decisionId: decision.id,
-  });
-
-  markTick(db, repoId);
+  // eslint-disable-next-line no-console
+  console.log(
+    `[director] tick on ${repoKey(target.repo)}: ${result.status} — ${result.detail} ` +
+      `(${result.decisionsLogged} decisions, $${result.costUsd.toFixed(4)})`,
+  );
 }
 
 let stopping = false;
@@ -129,7 +91,7 @@ async function loopOnce(db: Db, config: RuntimeConfig): Promise<void> {
     const state = ensureBudgetState(db, t.repoId, t.director.budget);
     if (!shouldTickNow(state, t.director.cadence_hours)) continue;
     try {
-      await tickNoOp(db, t);
+      await executeTick(db, t, config.dataDir);
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       try {

--- a/src/director/prompt.ts
+++ b/src/director/prompt.ts
@@ -1,0 +1,70 @@
+// Prompt builder for the Director's planning tick.
+//
+// We compose a system+user prompt from:
+//   • the prompt template (lives in prompts/templates/director-tick.md
+//     so it's overridable per-repo via the same mechanism as other lanes)
+//   • the captured charter YAML (so the LLM is reasoning over exactly what
+//     the human wrote, not a paraphrase)
+//   • the state snapshot (counts, recent runs/PRs/merges, open issues)
+//   • a transcript of the recent chat thread so user directives are honoured
+//
+// Token budget is the main constraint: with cadence_hours=6 and
+// think_daily_usd=$1, we can spend ~$0.25 per tick at most. Keep state
+// summaries terse, cap chat to ~25 messages, cap each message body to ~400
+// chars in state.ts.
+
+import { loadTemplate, renderTemplate } from "../prompts/registry.js";
+import type { RepoConfig } from "../config/schema.js";
+import type { StateSnapshot } from "./state.js";
+
+export type PromptInputs = {
+  ownerName: string;
+  repoName: string;
+  charterYaml: string;
+  mode: string;
+  state: StateSnapshot;
+  dataDir: string;
+  repoConfig: RepoConfig;
+};
+
+export type ComposedPrompt = {
+  systemPrompt: string;
+  userPrompt: string;
+  approxTokensIn: number; // rough — for budget pre-check
+};
+
+const DIRECTOR_SYSTEM = [
+  "You are the Director for an open-source project — a product-owner / project-manager",
+  "running on a 6-hour cadence. You emit machine-readable decisions in strict JSON.",
+  "You never edit source files; the code-writing agent does that. You decide what should",
+  "be worked on, comment on PRs, approve when ready. Stay strictly within the charter.",
+  "When in doubt, ask the user instead of guessing.",
+].join(" ");
+
+export function composePrompt(inputs: PromptInputs): ComposedPrompt {
+  const template = loadTemplate("director-tick", inputs.repoConfig, inputs.dataDir);
+  const userPrompt = renderTemplate(template, {
+    owner: inputs.ownerName,
+    name: inputs.repoName,
+    charter_yaml: inputs.charterYaml.trim(),
+    mode: inputs.mode,
+    state_json: JSON.stringify(inputs.state, null, 2),
+    chat_transcript: renderChatTranscript(inputs.state.recentChat),
+  });
+
+  return {
+    systemPrompt: DIRECTOR_SYSTEM,
+    userPrompt,
+    approxTokensIn: Math.ceil((DIRECTOR_SYSTEM.length + userPrompt.length) / 4),
+  };
+}
+
+function renderChatTranscript(messages: StateSnapshot["recentChat"]): string {
+  if (messages.length === 0) return "(empty thread — first tick on this repo)";
+  return messages
+    .map((m) => {
+      const speaker = m.role === "director" ? "DIRECTOR" : m.role === "user" ? "USER" : "SYSTEM";
+      return `[${m.ts}] ${speaker} (${m.type}): ${m.body}`;
+    })
+    .join("\n\n");
+}

--- a/src/director/state.ts
+++ b/src/director/state.ts
@@ -1,0 +1,190 @@
+// Project-state snapshot for the Director's planning prompt.
+//
+// We don't dump everything in the DB — we curate. The LLM gets a focused
+// view of "what's happening on this repo right now" so its decisions are
+// grounded in reality, not hallucinated.
+//
+// Kept lean on purpose: a 6-hour cadence × 1 charter × 1 prompt at maybe
+// 30k input tokens needs to stay under the think budget ($1/day default).
+
+import type { Db } from "../storage/db.js";
+
+export type StateSnapshot = {
+  repo: { id: number; owner: string; name: string };
+  capturedAt: string;
+  // Counts give the LLM a scale, lists give it concrete handles.
+  counts: {
+    openIssues: number;
+    openPrs: number;
+    pendingTasks: number;
+    recent24hRuns: number;
+    recent24hCostUsd: number;
+    recent24hMerges: number;
+  };
+  recentRuns: RunSummary[];
+  recentMerges: DeploySummary[];
+  openPrs: PrSummary[];
+  recentChat: MessageSummary[];
+  recentDecisions: DecisionSummary[];
+  pendingDecisionCount: number;
+};
+
+export type RunSummary = {
+  ts: string;
+  lane: string;
+  engine: string;
+  status: string;
+  costUsd: number;
+};
+
+export type DeploySummary = {
+  ts: string;
+  sha: string;
+  status: string;
+};
+
+export type PrSummary = {
+  prNumber: number;
+  status: string;
+  iterations: number;
+  branch: string;
+  updatedAt: string | null;
+};
+
+export type MessageSummary = {
+  ts: string;
+  role: string;
+  type: string;
+  body: string;
+};
+
+export type DecisionSummary = {
+  ts: string;
+  type: string;
+  outcome: string;
+  rationale: string;
+};
+
+export function captureStateSnapshot(
+  db: Db,
+  repoId: number,
+  owner: string,
+  name: string,
+): StateSnapshot {
+  const counts = {
+    openIssues: scalar<number>(
+      db,
+      `SELECT COUNT(*) AS n FROM tasks WHERE repo_id = ? AND kind = 'issue' AND status NOT IN ('done','error')`,
+      [repoId],
+    ),
+    openPrs: scalar<number>(
+      db,
+      `SELECT COUNT(DISTINCT pb.id) AS n FROM pr_branches pb
+       JOIN tasks t ON t.id = pb.task_id
+       WHERE t.repo_id = ? AND pb.status IN ('created','open')`,
+      [repoId],
+    ),
+    pendingTasks: scalar<number>(
+      db,
+      `SELECT COUNT(*) AS n FROM tasks WHERE repo_id = ? AND status = 'pending'`,
+      [repoId],
+    ),
+    recent24hRuns: scalar<number>(
+      db,
+      `SELECT COUNT(*) AS n FROM runs r
+       JOIN tasks t ON t.id = r.task_id
+       WHERE t.repo_id = ? AND r.started_at > datetime('now','-24 hours')`,
+      [repoId],
+    ),
+    recent24hCostUsd: scalar<number>(
+      db,
+      `SELECT COALESCE(SUM(r.cost_usd), 0) AS n FROM runs r
+       JOIN tasks t ON t.id = r.task_id
+       WHERE t.repo_id = ? AND r.started_at > datetime('now','-24 hours')`,
+      [repoId],
+    ),
+    recent24hMerges: scalar<number>(
+      db,
+      `SELECT COUNT(*) AS n FROM deploys
+       WHERE repo_id = ? AND status = 'ok' AND started_at > datetime('now','-24 hours')`,
+      [repoId],
+    ),
+  };
+
+  const recentRuns = (
+    db
+      .prepare(
+        `SELECT r.started_at AS ts, r.lane, r.engine, r.status, COALESCE(r.cost_usd,0) AS cost_usd
+         FROM runs r JOIN tasks t ON t.id = r.task_id
+         WHERE t.repo_id = ?
+         ORDER BY r.id DESC LIMIT 15`,
+      )
+      .all(repoId) as { ts: string; lane: string; engine: string; status: string; cost_usd: number }[]
+  ).map((r) => ({ ts: r.ts, lane: r.lane, engine: r.engine, status: r.status, costUsd: r.cost_usd }));
+
+  const recentMerges = (
+    db
+      .prepare(
+        `SELECT started_at AS ts, sha, status FROM deploys
+         WHERE repo_id = ? AND status = 'ok'
+         ORDER BY id DESC LIMIT 5`,
+      )
+      .all(repoId) as { ts: string; sha: string; status: string }[]
+  ).map((d) => ({ ts: d.ts, sha: d.sha.slice(0, 7), status: d.status }));
+
+  const openPrs = (
+    db
+      .prepare(
+        `SELECT pb.pr_number AS prNumber, pb.status, pb.iterations, pb.branch, pb.updated_at AS updatedAt
+         FROM pr_branches pb JOIN tasks t ON t.id = pb.task_id
+         WHERE t.repo_id = ? AND pb.status IN ('created','open')
+         ORDER BY pb.updated_at DESC NULLS LAST LIMIT 10`,
+      )
+      .all(repoId) as PrSummary[]
+  );
+
+  const recentChat = (
+    db
+      .prepare(
+        `SELECT ts, role, type, substr(body,1,400) AS body
+         FROM director_messages
+         WHERE repo_id = ?
+         ORDER BY id DESC LIMIT 25`,
+      )
+      .all(repoId) as { ts: string; role: string; type: string; body: string }[]
+  ).reverse();
+
+  const recentDecisions = (
+    db
+      .prepare(
+        `SELECT ts, decision_type AS type, outcome, substr(rationale,1,300) AS rationale
+         FROM director_decisions
+         WHERE repo_id = ?
+         ORDER BY id DESC LIMIT 15`,
+      )
+      .all(repoId) as { ts: string; type: string; outcome: string; rationale: string }[]
+  ).reverse();
+
+  const pendingDecisionCount = scalar<number>(
+    db,
+    `SELECT COUNT(*) AS n FROM director_decisions WHERE repo_id = ? AND outcome = 'pending'`,
+    [repoId],
+  );
+
+  return {
+    repo: { id: repoId, owner, name },
+    capturedAt: new Date().toISOString(),
+    counts,
+    recentRuns,
+    recentMerges,
+    openPrs,
+    recentChat,
+    recentDecisions,
+    pendingDecisionCount,
+  };
+}
+
+function scalar<T>(db: Db, sql: string, params: unknown[]): T {
+  const row = db.prepare(sql).get(...(params as never[])) as { n: T } | undefined;
+  return (row?.n ?? 0) as T;
+}

--- a/src/director/state.ts
+++ b/src/director/state.ts
@@ -119,8 +119,20 @@ export function captureStateSnapshot(
          WHERE t.repo_id = ?
          ORDER BY r.id DESC LIMIT 15`,
       )
-      .all(repoId) as { ts: string; lane: string; engine: string; status: string; cost_usd: number }[]
-  ).map((r) => ({ ts: r.ts, lane: r.lane, engine: r.engine, status: r.status, costUsd: r.cost_usd }));
+      .all(repoId) as {
+      ts: string;
+      lane: string;
+      engine: string;
+      status: string;
+      cost_usd: number;
+    }[]
+  ).map((r) => ({
+    ts: r.ts,
+    lane: r.lane,
+    engine: r.engine,
+    status: r.status,
+    costUsd: r.cost_usd,
+  }));
 
   const recentMerges = (
     db
@@ -132,16 +144,14 @@ export function captureStateSnapshot(
       .all(repoId) as { ts: string; sha: string; status: string }[]
   ).map((d) => ({ ts: d.ts, sha: d.sha.slice(0, 7), status: d.status }));
 
-  const openPrs = (
-    db
-      .prepare(
-        `SELECT pb.pr_number AS prNumber, pb.status, pb.iterations, pb.branch, pb.updated_at AS updatedAt
+  const openPrs = db
+    .prepare(
+      `SELECT pb.pr_number AS prNumber, pb.status, pb.iterations, pb.branch, pb.updated_at AS updatedAt
          FROM pr_branches pb JOIN tasks t ON t.id = pb.task_id
          WHERE t.repo_id = ? AND pb.status IN ('created','open')
          ORDER BY pb.updated_at DESC NULLS LAST LIMIT 10`,
-      )
-      .all(repoId) as PrSummary[]
-  );
+    )
+    .all(repoId) as PrSummary[];
 
   const recentChat = (
     db

--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -205,7 +205,8 @@ function recordTickDecisions(
     const slice = each + remainder;
     remainder = 0; // only first row gets the leftover
     ids.push(
-      recordDirectorDecision(db, args.repoId, args.charterVersion, args.mode, d, args.tick, slice).id,
+      recordDirectorDecision(db, args.repoId, args.charterVersion, args.mode, d, args.tick, slice)
+        .id,
     );
   }
   return ids;

--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -1,0 +1,308 @@
+// The real Director tick — replaces the foundation no-op.
+//
+// Flow:
+//   1. Pre-flight: rollover-day, ensure budget state, check budget gate.
+//   2. Capture state snapshot (open issues, recent runs/PRs, chat).
+//   3. Capture (or reuse) the charter version.
+//   4. Build prompt (system + user) and call the LLM.
+//   5. Parse JSON output against TickOutputSchema.
+//   6. Record each decision into director_decisions; in dry_run mode mark
+//      outcome=dry_run; in propose/semi_auto/full_auto mark outcome=pending
+//      (execution lands in PR #23). For now, every decision is dry_run-ed
+//      regardless of mode — execution is opt-in with the next PR.
+//   7. Append a status message to the chat with the LLM's observations +
+//      reasoning + decision summary.
+//
+// LLM-call costs are charged to the think-budget; if a tick somehow blows
+// the daily think cap, the gate will refuse next ticks until rollover.
+
+import type { Db } from "../storage/db.js";
+import type { RepoConfig } from "../config/schema.js";
+import { repoKey } from "../config/schema.js";
+import { AnthropicEngine } from "../engines/anthropic.js";
+import type { Engine } from "../engines/types.js";
+import { appendMessage } from "./chat.js";
+import { captureCharterVersion } from "./charter.js";
+import {
+  ensureBudgetState,
+  rolloverDayIfNeeded,
+  checkBudgetGate,
+  recordThinkSpend,
+  markTick,
+} from "./budget.js";
+import { recordDecision } from "./decisions.js";
+import { captureStateSnapshot } from "./state.js";
+import { composePrompt } from "./prompt.js";
+import { parseTickOutput, type ParsedDecision, type TickOutput } from "./decision-schema.js";
+import type { DecisionType, DirectorConfig } from "./types.js";
+import YAML from "yaml";
+
+const DEFAULT_THINK_MODEL = "claude-sonnet-4-6";
+const TICK_TIMEOUT_MS = 120_000; // 2 min — generous for a 30k-token thinking call
+
+export type TickRunOptions = {
+  db: Db;
+  repoId: number;
+  repo: RepoConfig;
+  director: DirectorConfig;
+  dataDir: string;
+  // Engine factory (overridable for tests).
+  engineFactory?: () => Engine;
+};
+
+export type TickRunResult = {
+  status: "ok" | "skipped" | "paused" | "error";
+  detail: string;
+  decisionsLogged: number;
+  costUsd: number;
+};
+
+export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
+  const { db, repoId, repo, director, dataDir } = opts;
+  if (!director.charter) {
+    return { status: "skipped", detail: "no charter", decisionsLogged: 0, costUsd: 0 };
+  }
+
+  rolloverDayIfNeeded(db, repoId);
+  const budget = ensureBudgetState(db, repoId, director.budget);
+  const gate = checkBudgetGate(budget, director.budget);
+  if (!gate.ok) {
+    appendMessage(db, {
+      repoId,
+      role: "system",
+      type: "tick_log",
+      body: `tick skipped: ${gate.reason}`,
+      metadata: { repo: repoKey(repo), mode: director.mode },
+    });
+    return {
+      status: "paused",
+      detail: gate.reason,
+      decisionsLogged: 0,
+      costUsd: 0,
+    };
+  }
+
+  const charterVersion = captureCharterVersion(db, repoId, director.charter);
+  const state = captureStateSnapshot(db, repoId, repo.owner, repo.name);
+  const charterYaml = YAML.stringify(director.charter);
+  const prompt = composePrompt({
+    ownerName: repo.owner,
+    repoName: repo.name,
+    charterYaml,
+    mode: director.mode,
+    state,
+    dataDir,
+    repoConfig: repo,
+  });
+
+  const engine = opts.engineFactory ? opts.engineFactory() : defaultEngineFactory();
+  const model = process.env.OPENRONIN_DIRECTOR_THINK_MODEL ?? DEFAULT_THINK_MODEL;
+
+  let llmResult;
+  try {
+    llmResult = await engine.run({
+      systemPrompt: prompt.systemPrompt,
+      userPrompt: prompt.userPrompt,
+      timeoutMs: TICK_TIMEOUT_MS,
+      model,
+      expectJson: true,
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    appendMessage(db, {
+      repoId,
+      role: "system",
+      type: "error",
+      body: `LLM call failed: ${detail}`,
+      metadata: { repo: repoKey(repo), mode: director.mode, charterVersion },
+    });
+    markTick(db, repoId);
+    return { status: "error", detail, decisionsLogged: 0, costUsd: 0 };
+  }
+
+  const cost = llmResult.usage.costUsd ?? 0;
+  recordThinkSpend(db, repoId, cost);
+
+  const parsed = parseTickOutput(llmResult.json);
+  if (!parsed.ok) {
+    appendMessage(db, {
+      repoId,
+      role: "system",
+      type: "error",
+      body: `tick output failed schema validation: ${parsed.error.slice(0, 500)}\n\nraw content (truncated): ${llmResult.content.slice(0, 1000)}`,
+      metadata: {
+        repo: repoKey(repo),
+        mode: director.mode,
+        charterVersion,
+        tokensIn: llmResult.usage.tokensIn,
+        tokensOut: llmResult.usage.tokensOut,
+        costUsd: cost,
+      },
+    });
+    markTick(db, repoId);
+    return { status: "error", detail: "schema-invalid", decisionsLogged: 0, costUsd: cost };
+  }
+
+  const tick = parsed.value;
+  const decisionIds = recordTickDecisions(db, {
+    repoId,
+    tick,
+    charterVersion,
+    mode: director.mode,
+    cost,
+  });
+
+  appendMessage(db, {
+    repoId,
+    role: "director",
+    type: "status",
+    body: renderChatPost(tick, director.mode, charterVersion, llmResult.usage),
+    metadata: {
+      repo: repoKey(repo),
+      mode: director.mode,
+      charterVersion,
+      decisionIds,
+      costUsd: cost,
+      tokensIn: llmResult.usage.tokensIn,
+      tokensOut: llmResult.usage.tokensOut,
+      durationMs: llmResult.durationMs,
+    },
+  });
+
+  markTick(db, repoId);
+
+  return {
+    status: "ok",
+    detail: `${tick.decisions.length} decision(s)`,
+    decisionsLogged: decisionIds.length,
+    costUsd: cost,
+  };
+}
+
+function defaultEngineFactory(): Engine {
+  return new AnthropicEngine({
+    defaultModel: process.env.OPENRONIN_DIRECTOR_THINK_MODEL ?? DEFAULT_THINK_MODEL,
+  });
+}
+
+function recordTickDecisions(
+  db: Db,
+  args: {
+    repoId: number;
+    tick: TickOutput;
+    charterVersion: number;
+    mode: DirectorConfig["mode"];
+    cost: number;
+  },
+): number[] {
+  const ids: number[] = [];
+  // Spread think cost across decisions for a rough per-decision audit, but
+  // round-down rest goes to first row to keep the sum exactly equal.
+  const n = args.tick.decisions.length;
+  const each = n > 0 ? Math.floor((args.cost / n) * 1e6) / 1e6 : 0;
+  let remainder = args.cost - each * n;
+  for (const d of args.tick.decisions) {
+    const slice = each + remainder;
+    remainder = 0; // only first row gets the leftover
+    ids.push(
+      recordDirectorDecision(db, args.repoId, args.charterVersion, args.mode, d, args.tick, slice).id,
+    );
+  }
+  return ids;
+}
+
+function recordDirectorDecision(
+  db: Db,
+  repoId: number,
+  charterVersion: number,
+  mode: DirectorConfig["mode"],
+  d: ParsedDecision,
+  tick: TickOutput,
+  costUsd: number,
+) {
+  // In dry_run we never execute. In other modes execution is gated and
+  // implemented in PR #23 — until then, the safe behaviour is to mark
+  // pending and let the human review.
+  const outcome = mode === "dry_run" ? "dry_run" : "pending";
+  return recordDecision(db, {
+    repoId,
+    decisionType: d.type as DecisionType,
+    rationale: d.rationale,
+    charterVersion,
+    stateSnapshot: {
+      observations: tick.observations,
+      reasoning: tick.reasoning,
+      priorityId: "priority_id" in d ? d.priority_id : undefined,
+    },
+    payload: "payload" in d ? d.payload : null,
+    outcome,
+    costUsd,
+  });
+}
+
+function renderChatPost(
+  tick: TickOutput,
+  mode: string,
+  charterVersion: number,
+  usage: { tokensIn?: number; tokensOut?: number; costUsd?: number },
+): string {
+  const lines: string[] = [];
+  lines.push(`**Tick** (mode=\`${mode}\`, charter v${charterVersion})`);
+  lines.push("");
+  lines.push("**Observations**");
+  lines.push(tick.observations);
+  lines.push("");
+  lines.push("**Reasoning**");
+  lines.push(tick.reasoning);
+  lines.push("");
+  if (tick.decisions.length === 1 && tick.decisions[0]?.type === "no_op") {
+    lines.push("**Decision:** no_op — " + (tick.decisions[0]?.rationale ?? ""));
+  } else {
+    lines.push(`**Decisions** (${tick.decisions.length}):`);
+    for (const [i, d] of tick.decisions.entries()) {
+      lines.push(`${i + 1}. \`${d.type}\` — ${d.rationale}`);
+      if ("payload" in d && d.payload) {
+        const summary = summarisePayload(d.type, d.payload as Record<string, unknown>);
+        if (summary) lines.push(`   ${summary}`);
+      }
+    }
+  }
+  lines.push("");
+  lines.push(
+    `_tokens in/out ${usage.tokensIn ?? "?"}/${usage.tokensOut ?? "?"}, cost $${(usage.costUsd ?? 0).toFixed(4)}_`,
+  );
+  return lines.join("\n");
+}
+
+function summarisePayload(type: string, payload: Record<string, unknown>): string {
+  switch (type) {
+    case "create_issue":
+      return `→ "${truncate(String(payload.title ?? ""), 80)}" [${(payload.labels as string[] | undefined)?.join(", ") ?? "no labels"}]`;
+    case "comment_on_issue":
+    case "comment_on_pr": {
+      const num = payload.issue_number ?? payload.pr_number;
+      return `→ #${num as number}: ${truncate(String(payload.body ?? ""), 80)}`;
+    }
+    case "label_issue":
+    case "label_pr": {
+      const num = payload.issue_number ?? payload.pr_number;
+      const add = (payload.add as string[] | undefined) ?? [];
+      const remove = (payload.remove as string[] | undefined) ?? [];
+      return `→ #${num as number}${add.length ? ` +[${add.join(",")}]` : ""}${remove.length ? ` -[${remove.join(",")}]` : ""}`;
+    }
+    case "approve_pr":
+    case "merge_pr":
+    case "close_issue":
+      return `→ #${(payload.pr_number ?? payload.issue_number) as number}`;
+    case "ask_user":
+      return `→ "${truncate(String(payload.question ?? ""), 100)}"`;
+    case "amend_charter":
+      return `→ ${truncate(String(payload.proposed_changes ?? ""), 100)}`;
+    default:
+      return "";
+  }
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + "…";
+}

--- a/test/director-tick.test.mjs
+++ b/test/director-tick.test.mjs
@@ -1,0 +1,328 @@
+// Tests for the LLM-driven Director tick.
+//
+// We mock the Anthropic engine so the test suite stays offline. The tick
+// is treated as a pure-ish function: input = (state, charter, mode), output
+// = (decisions in DB, chat message in DB, budget delta). We assert each
+// of those rather than poking at the LLM call itself.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import { runTick } from "../dist/director/tick.js";
+import { recentMessages } from "../dist/director/chat.js";
+import { recentDecisions, pendingDecisions } from "../dist/director/decisions.js";
+import { ensureBudgetState } from "../dist/director/budget.js";
+import { parseTickOutput } from "../dist/director/decision-schema.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-tick-test-"));
+  const db = initDb(dir);
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+const sampleCharter = {
+  vision: "Reliable, observable AI dev agent.",
+  priorities: [
+    { id: "reliability", weight: 0.5, rubric: "graceful failure" },
+    { id: "observability", weight: 0.5, rubric: "debuggable without SSH" },
+  ],
+  out_of_bounds: ["no schema changes without migration"],
+  out_of_bounds_paths: ["src/storage/db.ts"],
+  definition_of_done: ["pnpm run check green"],
+};
+
+const sampleBudget = {
+  initial_daily_usd: 2.0,
+  initial_weekly_usd: 10.0,
+  max_daily_usd: 10.0,
+  max_weekly_usd: 50.0,
+  think_daily_usd: 1.0,
+  pause_on_failure_streak: 3,
+  good_outcome_quarantine_days: 7,
+};
+
+const sampleDirector = {
+  enabled: true,
+  mode: "dry_run",
+  cadence_hours: 6,
+  bot_prefix: "👔 director:",
+  charter: sampleCharter,
+  budget: sampleBudget,
+  authority: {
+    can_create_issues: true,
+    can_label: true,
+    can_close_issues: false,
+    can_comment: true,
+    can_approve_pr: true,
+    can_merge: false,
+    can_modify_charter: false,
+  },
+};
+
+const sampleRepo = {
+  provider: "github",
+  owner: "openronin",
+  name: "openronin",
+  watched: true,
+  lanes: ["triage"],
+  director: sampleDirector,
+};
+
+function mockEngine(responseJson) {
+  return () => ({
+    id: "mock",
+    defaultModel: "mock-model",
+    async run() {
+      const content = JSON.stringify(responseJson);
+      return {
+        content,
+        json: responseJson,
+        usage: { tokensIn: 8000, tokensOut: 500, costUsd: 0.0315 },
+        finishReason: "end_turn",
+        durationMs: 1234,
+      };
+    },
+  });
+}
+
+test("decision-schema: TickOutput parses a well-formed payload", () => {
+  const out = parseTickOutput({
+    observations: "Project is in foundation phase. Director just landed.",
+    reasoning: "Nothing material to do this tick. The reliability priority is well-served already.",
+    decisions: [{ type: "no_op", rationale: "Foundation is fresh; let humans drive a few cycles." }],
+  });
+  assert.equal(out.ok, true);
+  if (out.ok) {
+    assert.equal(out.value.decisions.length, 1);
+    assert.equal(out.value.decisions[0].type, "no_op");
+  }
+});
+
+test("decision-schema: rejects missing required fields", () => {
+  const out = parseTickOutput({
+    observations: "x",
+    decisions: [],
+  });
+  assert.equal(out.ok, false);
+});
+
+test("decision-schema: rejects unknown decision types", () => {
+  const out = parseTickOutput({
+    observations: "Lots of words to satisfy minimum length.",
+    reasoning: "Lots more words to satisfy minimum length too.",
+    decisions: [{ type: "delete_repo", rationale: "haha" }],
+  });
+  assert.equal(out.ok, false);
+});
+
+test("decision-schema: validates create_issue payload", () => {
+  const out = parseTickOutput({
+    observations: "Project lacks observability into engine costs per repo.",
+    reasoning: "Per-repo cost view is missing — observability priority is at 0.5 in the charter.",
+    decisions: [
+      {
+        type: "create_issue",
+        rationale: "Charter priority observability is underserved",
+        priority_id: "observability",
+        payload: {
+          title: "Add per-repo cost view to admin dashboard",
+          body: "## Problem\n\nThe cost dashboard groups by lane and engine but not by repo, so it's hard to see which watched repo is the most expensive. ## Acceptance\n\n- [ ] /admin/cost has a per-repo row breakdown",
+          labels: ["openronin:do-it"],
+          priority: "normal",
+        },
+      },
+    ],
+  });
+  assert.equal(out.ok, true);
+});
+
+test("runTick: dry_run records decisions with outcome=dry_run, posts status to chat", async () => {
+  const { db, dir, repoId } = freshDb();
+  // Install our test prompt template at the path loadTemplate() expects.
+  // Since our test imports from dist/, the templates path resolves to
+  // <repo>/prompts/templates which already has director-tick.md after the build.
+  try {
+    const llmJson = {
+      observations: "Project healthy. 3 open PRs, 0 errors in last 24h, charter v1 just captured.",
+      reasoning:
+        "Reliability priority (0.5) is currently well-served by recent crash-recovery work. " +
+        "Observability priority (0.5) shows a gap — there's no /metrics endpoint exposed.",
+      decisions: [
+        {
+          type: "create_issue",
+          rationale: "observability priority is uncovered; add Prometheus /metrics",
+          priority_id: "observability",
+          payload: {
+            title: "Add Prometheus /metrics endpoint",
+            body: "## Problem\n\nNo machine-readable metrics today.\n\n## Acceptance\n- /metrics endpoint with cost_usd_total, runs_total, lane_duration_seconds",
+            labels: ["openronin:do-it"],
+            priority: "normal",
+          },
+        },
+      ],
+    };
+    const result = await runTick({
+      db,
+      repoId,
+      repo: sampleRepo,
+      director: sampleDirector,
+      dataDir: dir,
+      engineFactory: mockEngine(llmJson),
+    });
+
+    assert.equal(result.status, "ok");
+    assert.equal(result.decisionsLogged, 1);
+    assert.ok(result.costUsd > 0);
+
+    const decisions = recentDecisions(db, repoId, 5);
+    assert.equal(decisions.length, 1);
+    assert.equal(decisions[0].decisionType, "create_issue");
+    assert.equal(decisions[0].outcome, "dry_run");
+    assert.match(decisions[0].rationale, /observability/);
+    assert.equal(pendingDecisions(db, repoId).length, 0); // dry_run is not pending
+
+    const messages = recentMessages(db, repoId, 5);
+    // 1 director status message
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].role, "director");
+    assert.equal(messages[0].type, "status");
+    assert.match(messages[0].body, /charter v1/);
+    assert.match(messages[0].body, /create_issue/);
+
+    const budget = ensureBudgetState(db, repoId, sampleBudget);
+    assert.ok(budget.spentTodayThinkUsd > 0);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("runTick: propose mode marks decisions pending, not dry_run", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const propose = { ...sampleDirector, mode: "propose" };
+    await runTick({
+      db,
+      repoId,
+      repo: { ...sampleRepo, director: propose },
+      director: propose,
+      dataDir: dir,
+      engineFactory: mockEngine({
+        observations: "Project healthy. Nothing urgent. Just one observability gap.",
+        reasoning: "Want to add a metrics endpoint to serve the observability charter priority.",
+        decisions: [
+          {
+            type: "create_issue",
+            rationale: "observability priority needs more coverage",
+            payload: {
+              title: "Surface tail latency metric",
+              body: "## Problem\n\nNo p99 tracking.\n\n## Acceptance\n- [ ] add p99 to runs",
+              labels: [],
+              priority: "low",
+            },
+          },
+        ],
+      }),
+    });
+    const decisions = recentDecisions(db, repoId, 5);
+    assert.equal(decisions[0].outcome, "pending");
+    assert.equal(pendingDecisions(db, repoId).length, 1);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("runTick: invalid LLM JSON logs error message, no decisions", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const result = await runTick({
+      db,
+      repoId,
+      repo: sampleRepo,
+      director: sampleDirector,
+      dataDir: dir,
+      engineFactory: mockEngine({
+        // Missing observations and reasoning + bad decision type
+        decisions: [{ type: "delete_universe", rationale: "lol" }],
+      }),
+    });
+    assert.equal(result.status, "error");
+    assert.equal(result.decisionsLogged, 0);
+    const messages = recentMessages(db, repoId, 5);
+    assert.equal(messages.length, 1);
+    assert.equal(messages[0].role, "system");
+    assert.equal(messages[0].type, "error");
+    assert.equal(recentDecisions(db, repoId, 5).length, 0);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("runTick: paused budget skips the tick without LLM call", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    ensureBudgetState(db, repoId, sampleBudget);
+    db.prepare(
+      `UPDATE director_budget_state SET paused = 1, pause_reason = 'test' WHERE repo_id = ?`,
+    ).run(repoId);
+    let llmCalls = 0;
+    const result = await runTick({
+      db,
+      repoId,
+      repo: sampleRepo,
+      director: sampleDirector,
+      dataDir: dir,
+      engineFactory: () => ({
+        id: "mock",
+        defaultModel: "mock",
+        async run() {
+          llmCalls++;
+          return { content: "{}", json: {}, usage: {}, finishReason: "x", durationMs: 0 };
+        },
+      }),
+    });
+    assert.equal(result.status, "paused");
+    assert.equal(llmCalls, 0, "must not call LLM when paused");
+    const messages = recentMessages(db, repoId, 5);
+    assert.equal(messages[0].type, "tick_log");
+    assert.match(messages[0].body, /paused/);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("runTick: no-op tick is logged but doesn't blow up rendering", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: sampleRepo,
+      director: sampleDirector,
+      dataDir: dir,
+      engineFactory: mockEngine({
+        observations: "Project is in steady state. No urgent work.",
+        reasoning: "All charter priorities currently well-served. No new gaps surfaced.",
+        decisions: [{ type: "no_op", rationale: "Nothing material to do this tick." }],
+      }),
+    });
+    const messages = recentMessages(db, repoId, 5);
+    assert.match(messages[0].body, /no_op/);
+  } finally {
+    cleanup(dir);
+  }
+});

--- a/test/director-tick.test.mjs
+++ b/test/director-tick.test.mjs
@@ -104,7 +104,9 @@ test("decision-schema: TickOutput parses a well-formed payload", () => {
   const out = parseTickOutput({
     observations: "Project is in foundation phase. Director just landed.",
     reasoning: "Nothing material to do this tick. The reliability priority is well-served already.",
-    decisions: [{ type: "no_op", rationale: "Foundation is fresh; let humans drive a few cycles." }],
+    decisions: [
+      { type: "no_op", rationale: "Foundation is fresh; let humans drive a few cycles." },
+    ],
   });
   assert.equal(out.ok, true);
   if (out.ok) {


### PR DESCRIPTION
## Summary

PR #2 of 5 in the Director rollout. Replaces the foundation no-op tick from #21 with a real Anthropic API call producing structured decisions. In `dry_run` (the default and current mode for openronin/openronin), every decision is logged with `outcome=dry_run` and posted to the chat — but never executed. This PR's goal is **calibration**: read what the Director would do for a few days, adjust the charter, then graduate to `propose` mode in PR #23.

## What's new

- **`src/director/decision-schema.ts`** — Zod schemas for the LLM's structured output. Discriminated union over 11 decision types (`create_issue`, `comment_on_*`, `label_*`, `close_issue`, `approve_pr`, `merge_pr`, `ask_user`, `amend_charter`, `no_op`). Type-specific payload validation.
- **`src/director/state.ts`** — captures a curated project-state snapshot for the prompt: counts (open issues / PRs / pending tasks / 24h runs / 24h cost / 24h merges), recent runs (15), recent merges (5), open PRs (10), recent chat (25), recent decisions (15). Bodies trimmed to keep prompt token count bounded.
- **`src/director/prompt.ts`** — composes system + user prompt from the charter YAML, the state snapshot, and the chat transcript. Uses the existing `prompts/registry` so per-repo overrides work.
- **`src/director/tick.ts`** — the real tick. Pre-flight (rollover, budget gate), capture state + charter version, build prompt, call LLM with `expectJson=true`, parse against `TickOutputSchema`, persist each decision (`outcome=dry_run` in dry_run mode, `pending` in others — execution is opt-in, lands in PR #23), append a director status message to the chat with observations + reasoning + decision summary + token usage + cost.
- **`prompts/templates/director-tick.md`** — the prompt template, overridable per-repo via `$OPENRONIN_DATA_DIR/prompts/overrides/`.
- **6 new tests in `test/director-tick.test.mjs`** — schema validation (good and bad inputs), end-to-end dry_run tick, propose mode `outcome=pending`, invalid LLM JSON → error message, paused budget short-circuits without LLM call, no_op rendering.

## Cost expectations

~30k tokens in / ~500 tokens out per tick at the current state-snapshot size; ≈\$0.10–\$0.15 per tick. With cadence 6h that's ≈\$0.40–\$0.60/day — well under the \$1/day think-budget cap.

## What's NOT here (next PRs)

- **PR #23** — execution gates: `propose` mode actually queues for human approval, HTMX approve/reject buttons in the admin chat UI.
- **PR #24** — Telegram bridge (chat mirror + commands).
- **PR #25** — adaptive budget (climbs on good outcomes, shrinks on bad ones; 7-day quarantine).

## Test plan

- [x] \`pnpm run check\` green (62 unit tests, 0 lint, format clean)
- [x] All 6 new tick tests cover happy path + 4 failure modes
- [ ] After merge: deploy + restart \`openronin-director\` + observe first real tick produces a structured chat message in \`/admin/director/github--openronin--openronin\`