### PR TITLE
fix(director): engine fallback (Anthropic→MIMO) + failure-streak on errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,9 +90,14 @@ TELEGRAM_BOT_TOKEN=
 # never in this file.
 # OPENRONIN_DIRECTOR_TELEGRAM_TOKEN=
 
-# Anthropic API model used for director planning ticks. Defaults to
-# claude-sonnet-4-6; the supervisor's MIMO is too thin for this role.
-# Director also reads ANTHROPIC_API_KEY (above) — same key, different model.
+# Engine the director uses for its planning tick. Auto-detected by default:
+# anthropic if ANTHROPIC_API_KEY is set, else mimo if XIAOMI_MIMO_API_KEY is
+# set. Set explicitly to force one or the other.
+# OPENRONIN_DIRECTOR_THINK_ENGINE=anthropic   # or: mimo
+
+# Model for the director's planning tick. Defaults are engine-specific:
+#   anthropic → claude-sonnet-4-6
+#   mimo      → mimo-v2.5-pro
 # OPENRONIN_DIRECTOR_THINK_MODEL=claude-sonnet-4-6
 
 # ── Backups (optional) ─────────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to **openronin** are documented here. The format follows [Ke
 
 ## [Unreleased]
 
+### Fixed — director: engine fallback and failure-streak hardening
+
+The director's LLM-tick previously assumed `ANTHROPIC_API_KEY` was always available, throwing on construction when it wasn't and looping on the same error every minute (because the construction-failure path didn't mark the tick or bump the failure streak). Now:
+
+- Engine selection auto-detects: **Anthropic** if `ANTHROPIC_API_KEY` is set, else **MIMO** if `XIAOMI_MIMO_API_KEY` is set, else fail with an actionable error message.
+- Override via `OPENRONIN_DIRECTOR_THINK_ENGINE=anthropic|mimo`.
+- Engine-construction errors and schema-invalid LLM output now both `markTick` + `bumpFailureStreak` — so transient errors don't infinite-loop and the existing `pause_on_failure_streak` gate (default 3) actually trips.
+- Successful ticks `resetFailureStreak` so a few intermittent failures don't permanently pause the director.
+- Per-engine model defaults: `claude-sonnet-4-6` for Anthropic, `mimo-v2.5-pro` for MIMO.
+
+
 ### Fixed — deploy lane: robust against non-trigger-branch checkout
 
 Deploy documentation and the admin UI config example now use `git checkout <branch> && git pull --ff-only` instead of a bare `git pull --ff-only`. This prevents failures when the target directory is checked out on a branch other than `trigger_branch` (e.g. after a squash-merge deletes the feature branch that the directory happened to be on).

--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -20,15 +20,18 @@ import type { Db } from "../storage/db.js";
 import type { RepoConfig } from "../config/schema.js";
 import { repoKey } from "../config/schema.js";
 import { AnthropicEngine } from "../engines/anthropic.js";
+import { MimoEngine } from "../engines/mimo.js";
 import type { Engine } from "../engines/types.js";
 import { appendMessage } from "./chat.js";
 import { captureCharterVersion } from "./charter.js";
 import {
-  ensureBudgetState,
-  rolloverDayIfNeeded,
+  bumpFailureStreak,
   checkBudgetGate,
-  recordThinkSpend,
+  ensureBudgetState,
   markTick,
+  recordThinkSpend,
+  resetFailureStreak,
+  rolloverDayIfNeeded,
 } from "./budget.js";
 import { recordDecision } from "./decisions.js";
 import { captureStateSnapshot } from "./state.js";
@@ -37,7 +40,8 @@ import { parseTickOutput, type ParsedDecision, type TickOutput } from "./decisio
 import type { DecisionType, DirectorConfig } from "./types.js";
 import YAML from "yaml";
 
-const DEFAULT_THINK_MODEL = "claude-sonnet-4-6";
+const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
+const DEFAULT_MIMO_MODEL = "mimo-v2.5-pro";
 const TICK_TIMEOUT_MS = 120_000; // 2 min — generous for a 30k-token thinking call
 
 export type TickRunOptions = {
@@ -95,8 +99,27 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
     repoConfig: repo,
   });
 
-  const engine = opts.engineFactory ? opts.engineFactory() : defaultEngineFactory();
-  const model = process.env.OPENRONIN_DIRECTOR_THINK_MODEL ?? DEFAULT_THINK_MODEL;
+  let engine: Engine;
+  let model: string;
+  try {
+    ({ engine, model } = opts.engineFactory
+      ? { engine: opts.engineFactory(), model: process.env.OPENRONIN_DIRECTOR_THINK_MODEL ?? "" }
+      : selectThinkEngine());
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    appendMessage(db, {
+      repoId,
+      role: "system",
+      type: "error",
+      body: `director cannot start: ${detail}\n\nSet OPENRONIN_DIRECTOR_THINK_ENGINE (anthropic | mimo) and the matching API key in $OPENRONIN_DATA_DIR/director.env (or secrets.env).`,
+      metadata: { repo: repoKey(repo), mode: director.mode, charterVersion },
+    });
+    // Treat construction failure as a regular tick failure so we don't loop:
+    // mark the tick + bump the streak. The streak gate will pause us after N.
+    markTick(db, repoId);
+    bumpFailureStreak(db, repoId);
+    return { status: "error", detail, decisionsLogged: 0, costUsd: 0 };
+  }
 
   let llmResult;
   try {
@@ -114,9 +137,10 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
       role: "system",
       type: "error",
       body: `LLM call failed: ${detail}`,
-      metadata: { repo: repoKey(repo), mode: director.mode, charterVersion },
+      metadata: { repo: repoKey(repo), mode: director.mode, charterVersion, engine: engine.id },
     });
     markTick(db, repoId);
+    bumpFailureStreak(db, repoId);
     return { status: "error", detail, decisionsLogged: 0, costUsd: 0 };
   }
 
@@ -140,6 +164,7 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
       },
     });
     markTick(db, repoId);
+    bumpFailureStreak(db, repoId);
     return { status: "error", detail: "schema-invalid", decisionsLogged: 0, costUsd: cost };
   }
 
@@ -170,6 +195,10 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
   });
 
   markTick(db, repoId);
+  // Successful tick clears any prior failure streak — next failure starts
+  // counting fresh, so a run of intermittent errors doesn't permanently
+  // pause the director after the first 3 transient hiccups.
+  resetFailureStreak(db, repoId);
 
   return {
     status: "ok",
@@ -179,10 +208,38 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
   };
 }
 
-function defaultEngineFactory(): Engine {
-  return new AnthropicEngine({
-    defaultModel: process.env.OPENRONIN_DIRECTOR_THINK_MODEL ?? DEFAULT_THINK_MODEL,
-  });
+// Pick which engine to use for the planning tick. Priority:
+//   1. Explicit override via OPENRONIN_DIRECTOR_THINK_ENGINE env (anthropic | mimo)
+//   2. Anthropic if ANTHROPIC_API_KEY is set
+//   3. MIMO if XIAOMI_MIMO_API_KEY is set
+//   4. Throw — caller surfaces this to the chat as an actionable error
+//
+// The model can be overridden via OPENRONIN_DIRECTOR_THINK_MODEL; defaults
+// are engine-specific. MIMO's quality is lower than Sonnet but its JSON-mode
+// is solid and the cost is ~10x cheaper, so it's a fine fallback for a
+// dry_run-mode director that's still being calibrated.
+export function selectThinkEngine(): { engine: Engine; model: string } {
+  const override = (process.env.OPENRONIN_DIRECTOR_THINK_ENGINE ?? "").toLowerCase();
+  const userModel = process.env.OPENRONIN_DIRECTOR_THINK_MODEL;
+  const haveAnthropic = !!process.env.ANTHROPIC_API_KEY;
+  const haveMimo = !!process.env.XIAOMI_MIMO_API_KEY;
+
+  if (override === "anthropic") {
+    if (!haveAnthropic) throw new Error("OPENRONIN_DIRECTOR_THINK_ENGINE=anthropic but ANTHROPIC_API_KEY not set");
+    return { engine: new AnthropicEngine({}), model: userModel ?? DEFAULT_ANTHROPIC_MODEL };
+  }
+  if (override === "mimo") {
+    if (!haveMimo) throw new Error("OPENRONIN_DIRECTOR_THINK_ENGINE=mimo but XIAOMI_MIMO_API_KEY not set");
+    return { engine: new MimoEngine({}), model: userModel ?? DEFAULT_MIMO_MODEL };
+  }
+
+  if (haveAnthropic) {
+    return { engine: new AnthropicEngine({}), model: userModel ?? DEFAULT_ANTHROPIC_MODEL };
+  }
+  if (haveMimo) {
+    return { engine: new MimoEngine({}), model: userModel ?? DEFAULT_MIMO_MODEL };
+  }
+  throw new Error("no LLM API key found (ANTHROPIC_API_KEY or XIAOMI_MIMO_API_KEY required)");
 }
 
 function recordTickDecisions(

--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -225,11 +225,13 @@ export function selectThinkEngine(): { engine: Engine; model: string } {
   const haveMimo = !!process.env.XIAOMI_MIMO_API_KEY;
 
   if (override === "anthropic") {
-    if (!haveAnthropic) throw new Error("OPENRONIN_DIRECTOR_THINK_ENGINE=anthropic but ANTHROPIC_API_KEY not set");
+    if (!haveAnthropic)
+      throw new Error("OPENRONIN_DIRECTOR_THINK_ENGINE=anthropic but ANTHROPIC_API_KEY not set");
     return { engine: new AnthropicEngine({}), model: userModel ?? DEFAULT_ANTHROPIC_MODEL };
   }
   if (override === "mimo") {
-    if (!haveMimo) throw new Error("OPENRONIN_DIRECTOR_THINK_ENGINE=mimo but XIAOMI_MIMO_API_KEY not set");
+    if (!haveMimo)
+      throw new Error("OPENRONIN_DIRECTOR_THINK_ENGINE=mimo but XIAOMI_MIMO_API_KEY not set");
     return { engine: new MimoEngine({}), model: userModel ?? DEFAULT_MIMO_MODEL };
   }
 

--- a/test/director-tick.test.mjs
+++ b/test/director-tick.test.mjs
@@ -17,6 +17,7 @@ import { recentMessages } from "../dist/director/chat.js";
 import { recentDecisions, pendingDecisions } from "../dist/director/decisions.js";
 import { ensureBudgetState } from "../dist/director/budget.js";
 import { parseTickOutput } from "../dist/director/decision-schema.js";
+import { selectThinkEngine } from "../dist/director/tick.js";
 
 function freshDb() {
   const dir = mkdtempSync(join(tmpdir(), "openronin-tick-test-"));
@@ -302,6 +303,104 @@ test("runTick: paused budget skips the tick without LLM call", async () => {
     const messages = recentMessages(db, repoId, 5);
     assert.equal(messages[0].type, "tick_log");
     assert.match(messages[0].body, /paused/);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("selectThinkEngine: prefers Anthropic when both keys are set", () => {
+  const orig = { ant: process.env.ANTHROPIC_API_KEY, mimo: process.env.XIAOMI_MIMO_API_KEY };
+  process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+  process.env.XIAOMI_MIMO_API_KEY = "xm-test";
+  try {
+    const { engine } = selectThinkEngine();
+    assert.equal(engine.id, "anthropic");
+  } finally {
+    if (orig.ant === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = orig.ant;
+    if (orig.mimo === undefined) delete process.env.XIAOMI_MIMO_API_KEY;
+    else process.env.XIAOMI_MIMO_API_KEY = orig.mimo;
+  }
+});
+
+test("selectThinkEngine: falls back to MIMO when only MIMO key is set", () => {
+  const orig = { ant: process.env.ANTHROPIC_API_KEY, mimo: process.env.XIAOMI_MIMO_API_KEY };
+  delete process.env.ANTHROPIC_API_KEY;
+  process.env.XIAOMI_MIMO_API_KEY = "xm-test";
+  try {
+    const { engine } = selectThinkEngine();
+    assert.equal(engine.id, "mimo");
+  } finally {
+    if (orig.ant !== undefined) process.env.ANTHROPIC_API_KEY = orig.ant;
+    if (orig.mimo === undefined) delete process.env.XIAOMI_MIMO_API_KEY;
+    else process.env.XIAOMI_MIMO_API_KEY = orig.mimo;
+  }
+});
+
+test("selectThinkEngine: throws when no key is set", () => {
+  const orig = { ant: process.env.ANTHROPIC_API_KEY, mimo: process.env.XIAOMI_MIMO_API_KEY };
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.XIAOMI_MIMO_API_KEY;
+  try {
+    assert.throws(() => selectThinkEngine(), /no LLM API key/);
+  } finally {
+    if (orig.ant !== undefined) process.env.ANTHROPIC_API_KEY = orig.ant;
+    if (orig.mimo !== undefined) process.env.XIAOMI_MIMO_API_KEY = orig.mimo;
+  }
+});
+
+test("selectThinkEngine: explicit override respected", () => {
+  const orig = {
+    ant: process.env.ANTHROPIC_API_KEY,
+    mimo: process.env.XIAOMI_MIMO_API_KEY,
+    eng: process.env.OPENRONIN_DIRECTOR_THINK_ENGINE,
+  };
+  process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+  process.env.XIAOMI_MIMO_API_KEY = "xm-test";
+  process.env.OPENRONIN_DIRECTOR_THINK_ENGINE = "mimo";
+  try {
+    const { engine } = selectThinkEngine();
+    assert.equal(engine.id, "mimo", "override forces mimo even when anthropic key is present");
+  } finally {
+    if (orig.ant === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = orig.ant;
+    if (orig.mimo === undefined) delete process.env.XIAOMI_MIMO_API_KEY;
+    else process.env.XIAOMI_MIMO_API_KEY = orig.mimo;
+    if (orig.eng === undefined) delete process.env.OPENRONIN_DIRECTOR_THINK_ENGINE;
+    else process.env.OPENRONIN_DIRECTOR_THINK_ENGINE = orig.eng;
+  }
+});
+
+test("runTick: failure-streak bumps on error and resets on success", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    // First a failed tick (invalid JSON)
+    await runTick({
+      db,
+      repoId,
+      repo: sampleRepo,
+      director: sampleDirector,
+      dataDir: dir,
+      engineFactory: mockEngine({ decisions: [{ type: "bogus", rationale: "x" }] }),
+    });
+    let bs = ensureBudgetState(db, repoId, sampleBudget);
+    assert.equal(bs.failureStreak, 1);
+
+    // Now a successful tick
+    await runTick({
+      db,
+      repoId,
+      repo: sampleRepo,
+      director: sampleDirector,
+      dataDir: dir,
+      engineFactory: mockEngine({
+        observations: "Project state is steady; nothing urgent in the queue right now.",
+        reasoning: "Reliability and observability priorities both have recent coverage.",
+        decisions: [{ type: "no_op", rationale: "Nothing actionable this tick." }],
+      }),
+    });
+    bs = ensureBudgetState(db, repoId, sampleBudget);
+    assert.equal(bs.failureStreak, 0, "successful tick must reset streak");
   } finally {
     cleanup(dir);
   }


### PR DESCRIPTION
## Bug discovered live

After merging #24, the director failed on every tick because production had no \`ANTHROPIC_API_KEY\` (the host uses Claude Code CLI subscription auth + MIMO; no native Anthropic API key). Two compounding issues:

1. \`defaultEngineFactory\` hard-coded \`new AnthropicEngine()\`, which throws on construction when no key is set. The thrown error escaped \`runTick\`, was caught by the service \`loopOnce\` wrapper which logged \"tick threw\" and posted an error message — **but never marked the tick or bumped the failure streak**.
2. As a result the next minute another error was posted, and the next minute another, accumulating identical chat spam until human intervention.

Three identical chat error rows from this in production (cleaned up post-hoc): see \`director_messages\` ids 13/14/15 on repo 233.

## Fix

- New \`selectThinkEngine()\` exported from \`tick.ts\`: prefers Anthropic if its API key is set, else MIMO if its key is set, else throws a clear actionable error. Overridable via \`OPENRONIN_DIRECTOR_THINK_ENGINE=anthropic|mimo\`.
- All three error paths (engine construction failure, LLM call failure, schema validation failure) now \`markTick\` + \`bumpFailureStreak\`. So the existing \`pause_on_failure_streak\` gate (default 3) actually engages after a few consecutive errors instead of looping forever.
- Successful ticks call \`resetFailureStreak\` so transient errors don't permanently pause the director after a streak of 2-3 hiccups.
- Per-engine model defaults: \`claude-sonnet-4-6\` (anthropic), \`mimo-v2.5-pro\` (mimo).
- \`.env.example\` documents the new \`OPENRONIN_DIRECTOR_THINK_ENGINE\` selector.

## Tests added

- 4 \`selectThinkEngine\` tests: prefers anthropic when both keys present, falls back to mimo when only mimo, throws when no key, explicit override forces choice.
- 1 \`runTick\` test: failure-streak bumps on schema-invalid output, resets on success.

## Test plan

- [x] \`pnpm run check\` green
- [ ] After merge: deploy fires, director restarts, new tick picks MIMO automatically; first real LLM-driven proposal lands in chat