### PR TITLE
feat(director): execution backend — decisions actually do things now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to **openronin** are documented here. The format follows [Ke
 
 ## [Unreleased]
 
+### Added — director: execution backend (decision side-effects via VcsProvider)
+
+The director's `mode` toggle (`dry_run` / `propose` / `semi_auto` / `full_auto`) now actually drives execution. Previously every decision was logged with `outcome=dry_run` regardless of mode; now the executor in `src/director/executor.ts` carries each decision through a mode × authority × decision-type matrix and either:
+
+- Logs only (`dry_run`)
+- Records `outcome=pending` and posts a `proposal`-type chat message asking for human approval (`propose`, plus `merge_pr` in `semi_auto`, plus `amend_charter` always)
+- Calls the relevant `VcsProvider` method and records `outcome=executed` with the artifact ref (issue/PR number, comment URL)
+- Records `outcome=skipped` when the operator hasn't opted in via `authority.can_*`
+- Records `outcome=failed` with the error detail when the side-effect throws
+
+`VcsProvider` was extended with the methods the executor needs (`createIssue`, `addLabels`, `removeLabels`, `approvePullRequest`, plus the existing `postComment`, `closeItem`, `mergePullRequest`); both GitHub and GitLab implement them. The HTMX approve/reject buttons that flip a `pending` decision to `executed`/`rejected` land in the next change (PR #3b) — for now, pending decisions sit in the chat with instructions on what's coming.
+
+15 new tests cover every cell of the matrix with a mock VcsProvider; no live API calls in the test suite.
+
+
 ### Fixed — director: engine fallback and failure-streak hardening
 
 The director's LLM-tick previously assumed `ANTHROPIC_API_KEY` was always available, throwing on construction when it wasn't and looping on the same error every minute (because the construction-failure path didn't mark the tick or bump the failure streak). Now:

--- a/src/director/executor.ts
+++ b/src/director/executor.ts
@@ -77,7 +77,15 @@ export async function executeDecision(opts: ExecuteOptions): Promise<ExecuteResu
   //    explicitly opted in. These return `skipped` regardless of mode.
   const auth = authorityFor(decision, director.authority);
   if (auth.gated) {
-    postChat(db, repoId, repo, "system", "tick_log", `decision skipped: ${auth.reason}`, decisionId);
+    postChat(
+      db,
+      repoId,
+      repo,
+      "system",
+      "tick_log",
+      `decision skipped: ${auth.reason}`,
+      decisionId,
+    );
     return finalize(db, decisionId, "skipped", auth.reason);
   }
 
@@ -118,7 +126,8 @@ function authorityFor(
 ): { gated: false } | { gated: true; reason: string } {
   switch (decision.type) {
     case "create_issue":
-      if (!authority.can_create_issues) return { gated: true, reason: "authority: can_create_issues=false" };
+      if (!authority.can_create_issues)
+        return { gated: true, reason: "authority: can_create_issues=false" };
       return { gated: false };
     case "comment_on_issue":
     case "comment_on_pr":
@@ -129,16 +138,19 @@ function authorityFor(
       if (!authority.can_label) return { gated: true, reason: "authority: can_label=false" };
       return { gated: false };
     case "close_issue":
-      if (!authority.can_close_issues) return { gated: true, reason: "authority: can_close_issues=false" };
+      if (!authority.can_close_issues)
+        return { gated: true, reason: "authority: can_close_issues=false" };
       return { gated: false };
     case "approve_pr":
-      if (!authority.can_approve_pr) return { gated: true, reason: "authority: can_approve_pr=false" };
+      if (!authority.can_approve_pr)
+        return { gated: true, reason: "authority: can_approve_pr=false" };
       return { gated: false };
     case "merge_pr":
       if (!authority.can_merge) return { gated: true, reason: "authority: can_merge=false" };
       return { gated: false };
     case "amend_charter":
-      if (!authority.can_modify_charter) return { gated: true, reason: "authority: can_modify_charter=false" };
+      if (!authority.can_modify_charter)
+        return { gated: true, reason: "authority: can_modify_charter=false" };
       return { gated: false };
     case "ask_user":
     case "no_op":
@@ -218,11 +230,7 @@ async function runDecision(opts: ExecuteOptions, repoRef: VcsRepoRef): Promise<s
     }
 
     case "comment_on_pr": {
-      const r = await vcs.postComment(
-        repoRef,
-        decision.payload.pr_number,
-        decision.payload.body,
-      );
+      const r = await vcs.postComment(repoRef, decision.payload.pr_number, decision.payload.body);
       return `comment posted on PR #${decision.payload.pr_number} (${r.url})`;
     }
 
@@ -247,11 +255,7 @@ async function runDecision(opts: ExecuteOptions, repoRef: VcsRepoRef): Promise<s
     }
 
     case "approve_pr": {
-      await vcs.approvePullRequest(
-        repoRef,
-        decision.payload.pr_number,
-        decision.payload.body,
-      );
+      await vcs.approvePullRequest(repoRef, decision.payload.pr_number, decision.payload.body);
       return `approved PR #${decision.payload.pr_number}`;
     }
 

--- a/src/director/executor.ts
+++ b/src/director/executor.ts
@@ -1,0 +1,347 @@
+// Decision executor — turns a ParsedDecision into a real side-effect.
+//
+// Called from tick.ts after the LLM has produced + validated decisions.
+// The outcome is determined by the composition of:
+//   1. director.mode    — dry_run | propose | semi_auto | full_auto
+//   2. director.authority — per-decision-type permissions
+//
+// Decision matrix (mode × decision_type → outcome):
+//
+//   |              | dry_run  | propose  | semi_auto | full_auto |
+//   | no_op        | executed | executed | executed  | executed  |
+//   | ask_user     | dry_run  | executed | executed  | executed  |  (posts a `question` chat message)
+//   | create_issue | dry_run  | pending  | executed  | executed  |
+//   | comment_*    | dry_run  | pending  | executed  | executed  |
+//   | label_*      | dry_run  | pending  | executed  | executed  |
+//   | close_issue  | dry_run  | pending  | pending   | pending   |  unless authority.can_close_issues
+//   | approve_pr   | dry_run  | pending  | executed  | executed  |  unless !authority.can_approve_pr
+//   | merge_pr     | dry_run  | pending  | pending   | executed  |  unless !authority.can_merge
+//   | amend_charter| dry_run  | pending  | pending   | pending   |  unless authority.can_modify_charter
+//
+// `pending` means: the decision sits in `director_decisions(outcome='pending')`
+// and a `proposal`-type chat message is posted asking for human approval.
+// PR #3b adds the HTMX buttons that flip pending → executed/rejected.
+//
+// `dry_run` means: nothing is done. The decision is logged and a chat message
+// summarises it, but no side-effect runs.
+//
+// `executed` means: the side-effect ran successfully and the artifact ref
+// (issue/PR number, comment id) is recorded in outcome_details.
+//
+// `failed` means: the side-effect was attempted and threw. Bumps failure
+// streak in tick.ts.
+//
+// `skipped` means: gated by authority — the operator hasn't opted in to
+// this kind of decision.
+
+import type { Db } from "../storage/db.js";
+import type { RepoConfig } from "../config/schema.js";
+import { repoKey } from "../config/schema.js";
+import type { VcsProvider, VcsRepoRef } from "../providers/vcs.js";
+import { setDecisionOutcome } from "./decisions.js";
+import { appendMessage } from "./chat.js";
+import type { ParsedDecision } from "./decision-schema.js";
+import type { DecisionOutcome, DirectorAuthority, DirectorConfig } from "./types.js";
+
+const PROPOSAL_BUTTONS_HINT =
+  "Approve / reject in /admin/director/<repo>. Telegram bridge approves via /approve <id>.";
+
+export type ExecuteOptions = {
+  db: Db;
+  decisionId: number;
+  repoId: number;
+  repo: RepoConfig;
+  director: DirectorConfig;
+  decision: ParsedDecision;
+  // Lazy accessor — VcsProvider construction can require env vars and is
+  // pointless for dry_run / pending paths. Tests pass a mock here.
+  getVcs: () => VcsProvider;
+  charterVersion: number;
+};
+
+export type ExecuteResult = {
+  outcome: DecisionOutcome;
+  details: string;
+};
+
+export async function executeDecision(opts: ExecuteOptions): Promise<ExecuteResult> {
+  const { db, decisionId, repoId, repo, director, decision } = opts;
+  const repoRef: VcsRepoRef = { owner: repo.owner, name: repo.name };
+
+  // 1. Mode = dry_run → never act.
+  if (director.mode === "dry_run") {
+    return finalize(db, decisionId, "dry_run", "mode=dry_run; not executed");
+  }
+
+  // 2. Authority gate. Some decision types are off-limits unless the operator
+  //    explicitly opted in. These return `skipped` regardless of mode.
+  const auth = authorityFor(decision, director.authority);
+  if (auth.gated) {
+    postChat(db, repoId, repo, "system", "tick_log", `decision skipped: ${auth.reason}`, decisionId);
+    return finalize(db, decisionId, "skipped", auth.reason);
+  }
+
+  // 3. Per-mode dispatch.
+  // Some decisions in some modes need human approval — flip to pending and
+  // post a proposal in the chat.
+  const needsApproval = decisionNeedsApproval(decision, director.mode, director.authority);
+  if (needsApproval) {
+    postProposal(db, repoId, repo, decision, decisionId);
+    return finalize(db, decisionId, "pending", "queued for human approval");
+  }
+
+  // 4. Execute the side-effect via VcsProvider. Each branch is small so the
+  //    fact that we hit the API is obvious in code review.
+  try {
+    const detail = await runDecision(opts, repoRef);
+    return finalize(db, decisionId, "executed", detail);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    postChat(
+      db,
+      repoId,
+      repo,
+      "system",
+      "error",
+      `failed to execute ${decision.type} (decision #${decisionId}): ${detail}`,
+      decisionId,
+    );
+    return finalize(db, decisionId, "failed", detail);
+  }
+}
+
+// ── Authority gating ─────────────────────────────────────────────────────
+
+function authorityFor(
+  decision: ParsedDecision,
+  authority: DirectorAuthority,
+): { gated: false } | { gated: true; reason: string } {
+  switch (decision.type) {
+    case "create_issue":
+      if (!authority.can_create_issues) return { gated: true, reason: "authority: can_create_issues=false" };
+      return { gated: false };
+    case "comment_on_issue":
+    case "comment_on_pr":
+      if (!authority.can_comment) return { gated: true, reason: "authority: can_comment=false" };
+      return { gated: false };
+    case "label_issue":
+    case "label_pr":
+      if (!authority.can_label) return { gated: true, reason: "authority: can_label=false" };
+      return { gated: false };
+    case "close_issue":
+      if (!authority.can_close_issues) return { gated: true, reason: "authority: can_close_issues=false" };
+      return { gated: false };
+    case "approve_pr":
+      if (!authority.can_approve_pr) return { gated: true, reason: "authority: can_approve_pr=false" };
+      return { gated: false };
+    case "merge_pr":
+      if (!authority.can_merge) return { gated: true, reason: "authority: can_merge=false" };
+      return { gated: false };
+    case "amend_charter":
+      if (!authority.can_modify_charter) return { gated: true, reason: "authority: can_modify_charter=false" };
+      return { gated: false };
+    case "ask_user":
+    case "no_op":
+      return { gated: false };
+  }
+}
+
+// ── Per-mode approval requirement ────────────────────────────────────────
+
+function decisionNeedsApproval(
+  decision: ParsedDecision,
+  mode: DirectorConfig["mode"],
+  _authority: DirectorAuthority,
+): boolean {
+  // no_op and ask_user are always safe to execute (they don't touch the repo).
+  if (decision.type === "no_op" || decision.type === "ask_user") return false;
+  // amend_charter is always proposal-only — even full_auto must not silently
+  // mutate the constitution. Authority gating is what unlocks the proposal
+  // surface in the first place.
+  if (decision.type === "amend_charter") return true;
+
+  switch (mode) {
+    case "propose":
+      return true;
+    case "semi_auto":
+      // semi_auto auto-executes everything except merges, which are the
+      // single highest-stakes operation.
+      return decision.type === "merge_pr";
+    case "full_auto":
+      return false;
+    case "dry_run":
+    case "disabled":
+      // dry_run was already short-circuited; disabled never reaches here.
+      return true;
+  }
+}
+
+// ── Side-effect runners ──────────────────────────────────────────────────
+
+async function runDecision(opts: ExecuteOptions, repoRef: VcsRepoRef): Promise<string> {
+  const { db, decisionId, repoId, repo, decision, getVcs } = opts;
+  // Decisions that need a real API call grab the provider here. ask_user
+  // and no_op never call getVcs(), so VcsProvider construction is deferred.
+  const needsVcs = decision.type !== "ask_user" && decision.type !== "no_op";
+  const vcs = needsVcs ? getVcs() : (null as unknown as VcsProvider);
+
+  switch (decision.type) {
+    case "no_op":
+      return "no_op";
+
+    case "ask_user": {
+      // Post a `question`-type chat message. Carries decisionId so the chat
+      // UI can render it inline with the originating tick.
+      const body =
+        decision.payload.question +
+        (decision.payload.context ? `\n\n_Context:_ ${decision.payload.context}` : "");
+      postChat(db, repoId, repo, "director", "question", body, decisionId);
+      return "question posted to chat";
+    }
+
+    case "create_issue": {
+      const r = await vcs.createIssue(repoRef, {
+        title: decision.payload.title,
+        body: decision.payload.body,
+        labels: decision.payload.labels,
+      });
+      return `issue #${r.number} created (${r.url})`;
+    }
+
+    case "comment_on_issue": {
+      const r = await vcs.postComment(
+        repoRef,
+        decision.payload.issue_number,
+        decision.payload.body,
+      );
+      return `comment posted on #${decision.payload.issue_number} (${r.url})`;
+    }
+
+    case "comment_on_pr": {
+      const r = await vcs.postComment(
+        repoRef,
+        decision.payload.pr_number,
+        decision.payload.body,
+      );
+      return `comment posted on PR #${decision.payload.pr_number} (${r.url})`;
+    }
+
+    case "label_issue": {
+      await vcs.addLabels(repoRef, decision.payload.issue_number, decision.payload.add);
+      await vcs.removeLabels(repoRef, decision.payload.issue_number, decision.payload.remove);
+      return `labelled #${decision.payload.issue_number}`;
+    }
+
+    case "label_pr": {
+      await vcs.addLabels(repoRef, decision.payload.pr_number, decision.payload.add);
+      await vcs.removeLabels(repoRef, decision.payload.pr_number, decision.payload.remove);
+      return `labelled PR #${decision.payload.pr_number}`;
+    }
+
+    case "close_issue": {
+      // Post the reason as a comment first so the human reading the closed
+      // issue understands why. Then close.
+      await vcs.postComment(repoRef, decision.payload.issue_number, decision.payload.reason);
+      await vcs.closeItem(repoRef, decision.payload.issue_number, "not_planned");
+      return `closed #${decision.payload.issue_number}`;
+    }
+
+    case "approve_pr": {
+      await vcs.approvePullRequest(
+        repoRef,
+        decision.payload.pr_number,
+        decision.payload.body,
+      );
+      return `approved PR #${decision.payload.pr_number}`;
+    }
+
+    case "merge_pr": {
+      const r = await vcs.mergePullRequest(
+        repoRef,
+        decision.payload.pr_number,
+        decision.payload.strategy,
+      );
+      if (!r.merged) throw new Error(r.message ?? "merge refused");
+      return `merged PR #${decision.payload.pr_number} (sha ${r.sha?.slice(0, 7) ?? "?"})`;
+    }
+
+    case "amend_charter":
+      // Should never reach here — amend_charter always needs approval and
+      // is intercepted earlier. If we do, fail loudly.
+      throw new Error("amend_charter cannot auto-execute (must be human-applied)");
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function finalize(
+  db: Db,
+  decisionId: number,
+  outcome: DecisionOutcome,
+  details: string,
+): ExecuteResult {
+  setDecisionOutcome(db, decisionId, outcome, details);
+  return { outcome, details };
+}
+
+function postChat(
+  db: Db,
+  repoId: number,
+  repo: RepoConfig,
+  role: "director" | "user" | "system",
+  type: "question" | "proposal" | "tick_log" | "error" | "status",
+  body: string,
+  decisionId: number,
+): void {
+  appendMessage(db, {
+    repoId,
+    role,
+    type,
+    body,
+    metadata: { repo: repoKey(repo), decisionId },
+    decisionId,
+  });
+}
+
+function postProposal(
+  db: Db,
+  repoId: number,
+  repo: RepoConfig,
+  decision: ParsedDecision,
+  decisionId: number,
+): void {
+  const summary = summariseProposal(decision);
+  const body = `**Proposal #${decisionId}** — \`${decision.type}\`\n\n${decision.rationale}\n\n${summary}\n\n_${PROPOSAL_BUTTONS_HINT}_`;
+  postChat(db, repoId, repo, "director", "proposal", body, decisionId);
+}
+
+function summariseProposal(d: ParsedDecision): string {
+  switch (d.type) {
+    case "create_issue":
+      return `**${d.payload.title}**\n\n${truncate(d.payload.body, 500)}\n\nLabels: \`${d.payload.labels.join("`, `") || "(none)"}\`, priority: \`${d.payload.priority}\``;
+    case "comment_on_issue":
+      return `→ comment on issue #${d.payload.issue_number}:\n\n> ${truncate(d.payload.body, 400)}`;
+    case "comment_on_pr":
+      return `→ comment on PR #${d.payload.pr_number}:\n\n> ${truncate(d.payload.body, 400)}`;
+    case "label_issue":
+      return `→ on issue #${d.payload.issue_number}: add \`${d.payload.add.join("`, `") || "(none)"}\`, remove \`${d.payload.remove.join("`, `") || "(none)"}\``;
+    case "label_pr":
+      return `→ on PR #${d.payload.pr_number}: add \`${d.payload.add.join("`, `") || "(none)"}\`, remove \`${d.payload.remove.join("`, `") || "(none)"}\``;
+    case "close_issue":
+      return `→ close issue #${d.payload.issue_number} with reason:\n\n> ${truncate(d.payload.reason, 300)}`;
+    case "approve_pr":
+      return `→ approve PR #${d.payload.pr_number}${d.payload.body ? `\n\n> ${truncate(d.payload.body, 300)}` : ""}`;
+    case "merge_pr":
+      return `→ merge PR #${d.payload.pr_number} via \`${d.payload.strategy}\``;
+    case "ask_user":
+      return `→ question:\n\n> ${truncate(d.payload.question, 400)}`;
+    case "amend_charter":
+      return `→ proposed charter changes:\n\n> ${truncate(d.payload.proposed_changes, 600)}`;
+    case "no_op":
+      return "(no_op)";
+  }
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + "…";
+}

--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -37,6 +37,9 @@ import { recordDecision } from "./decisions.js";
 import { captureStateSnapshot } from "./state.js";
 import { composePrompt } from "./prompt.js";
 import { parseTickOutput, type ParsedDecision, type TickOutput } from "./decision-schema.js";
+import { executeDecision } from "./executor.js";
+import { GithubVcsProvider } from "../providers/github.js";
+import type { VcsProvider } from "../providers/vcs.js";
 import type { DecisionType, DirectorConfig } from "./types.js";
 import YAML from "yaml";
 
@@ -52,6 +55,10 @@ export type TickRunOptions = {
   dataDir: string;
   // Engine factory (overridable for tests).
   engineFactory?: () => Engine;
+  // VcsProvider factory (overridable for tests). Defaults to GithubVcsProvider
+  // for github-provider repos. Constructed lazily — only if at least one
+  // decision actually needs VCS access (saves an env-var check on dry_run).
+  vcsFactory?: (repo: RepoConfig) => VcsProvider;
 };
 
 export type TickRunResult = {
@@ -169,14 +176,19 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
   }
 
   const tick = parsed.value;
-  const decisionIds = recordTickDecisions(db, {
+
+  // 1. Persist all decisions first with outcome=pending so the audit trail
+  //    is complete even if execution crashes. Cost is split across rows.
+  const recorded = recordTickDecisions(db, {
     repoId,
     tick,
     charterVersion,
-    mode: director.mode,
     cost,
   });
 
+  // 2. Post the LLM's observations + reasoning + decision summary to chat
+  //    BEFORE executing. The status message is what the human reads first;
+  //    proposal-type messages from execute step are interleaved after.
   appendMessage(db, {
     repoId,
     role: "director",
@@ -186,7 +198,7 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
       repo: repoKey(repo),
       mode: director.mode,
       charterVersion,
-      decisionIds,
+      decisionIds: recorded.map((r) => r.id),
       costUsd: cost,
       tokensIn: llmResult.usage.tokensIn,
       tokensOut: llmResult.usage.tokensOut,
@@ -194,16 +206,61 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
     },
   });
 
+  // 3. Execute each decision through the executor. Mode + authority gates
+  //    inside executor.ts decide whether each one runs, queues for approval,
+  //    or is skipped. The VcsProvider is constructed lazily — only when an
+  //    executor actually reaches a VCS call (dry_run, propose, and the
+  //    ask_user/no_op/amend_charter cases never need VCS).
+  let vcs: VcsProvider | null = null;
+  const getVcs = (): VcsProvider => {
+    if (vcs) return vcs;
+    vcs = opts.vcsFactory ? opts.vcsFactory(repo) : defaultVcsFactory(repo);
+    return vcs;
+  };
+  let executed = 0;
+  let pending = 0;
+  let failed = 0;
+  let skipped = 0;
+  for (const r of recorded) {
+    const result = await executeDecision({
+      db,
+      decisionId: r.id,
+      repoId,
+      repo,
+      director,
+      decision: r.decision,
+      getVcs,
+      charterVersion,
+    });
+    if (result.outcome === "executed") executed++;
+    else if (result.outcome === "pending") pending++;
+    else if (result.outcome === "failed") failed++;
+    else if (result.outcome === "skipped") skipped++;
+  }
+
   markTick(db, repoId);
   // Successful tick clears any prior failure streak — next failure starts
   // counting fresh, so a run of intermittent errors doesn't permanently
   // pause the director after the first 3 transient hiccups.
+  // We treat per-decision execution failures separately (they're surfaced
+  // as outcome=failed) so a single broken comment on a 5-decision tick
+  // doesn't trip the streak.
   resetFailureStreak(db, repoId);
+
+  const summary = [
+    `${recorded.length} decision(s)`,
+    executed > 0 ? `${executed} executed` : null,
+    pending > 0 ? `${pending} pending` : null,
+    skipped > 0 ? `${skipped} skipped` : null,
+    failed > 0 ? `${failed} failed` : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
 
   return {
     status: "ok",
-    detail: `${tick.decisions.length} decision(s)`,
-    decisionsLogged: decisionIds.length,
+    detail: summary,
+    decisionsLogged: recorded.length,
     costUsd: cost,
   };
 }
@@ -244,17 +301,36 @@ export function selectThinkEngine(): { engine: Engine; model: string } {
   throw new Error("no LLM API key found (ANTHROPIC_API_KEY or XIAOMI_MIMO_API_KEY required)");
 }
 
+function defaultVcsFactory(repo: RepoConfig): VcsProvider {
+  switch (repo.provider) {
+    case "github":
+      return new GithubVcsProvider();
+    case "gitlab":
+      // We could lazy-import GitlabVcsProvider here once the director needs
+      // it. For now, the director is enabled only on github repos in
+      // production; tests inject vcsFactory directly.
+      throw new Error(
+        "default VcsProvider for gitlab not wired into director yet — pass vcsFactory in TickRunOptions or use github provider",
+      );
+    case "gitea":
+      throw new Error("director does not yet support the gitea provider");
+  }
+}
+
+// Recorded result we hand to the executor: the decision (so the executor can
+// dispatch on type) plus the freshly-allocated id (so it can update outcome).
+type RecordedDecision = { id: number; decision: ParsedDecision };
+
 function recordTickDecisions(
   db: Db,
   args: {
     repoId: number;
     tick: TickOutput;
     charterVersion: number;
-    mode: DirectorConfig["mode"];
     cost: number;
   },
-): number[] {
-  const ids: number[] = [];
+): RecordedDecision[] {
+  const out: RecordedDecision[] = [];
   // Spread think cost across decisions for a rough per-decision audit, but
   // round-down rest goes to first row to keep the sum exactly equal.
   const n = args.tick.decisions.length;
@@ -263,41 +339,25 @@ function recordTickDecisions(
   for (const d of args.tick.decisions) {
     const slice = each + remainder;
     remainder = 0; // only first row gets the leftover
-    ids.push(
-      recordDirectorDecision(db, args.repoId, args.charterVersion, args.mode, d, args.tick, slice)
-        .id,
-    );
+    const row = recordDecision(db, {
+      repoId: args.repoId,
+      decisionType: d.type as DecisionType,
+      rationale: d.rationale,
+      charterVersion: args.charterVersion,
+      stateSnapshot: {
+        observations: args.tick.observations,
+        reasoning: args.tick.reasoning,
+        priorityId: "priority_id" in d ? d.priority_id : undefined,
+      },
+      payload: "payload" in d ? d.payload : null,
+      // Always pending at record time. The executor flips it to its final
+      // outcome (executed / pending-with-proposal / dry_run / failed / skipped).
+      outcome: "pending",
+      costUsd: slice,
+    });
+    out.push({ id: row.id, decision: d });
   }
-  return ids;
-}
-
-function recordDirectorDecision(
-  db: Db,
-  repoId: number,
-  charterVersion: number,
-  mode: DirectorConfig["mode"],
-  d: ParsedDecision,
-  tick: TickOutput,
-  costUsd: number,
-) {
-  // In dry_run we never execute. In other modes execution is gated and
-  // implemented in PR #23 — until then, the safe behaviour is to mark
-  // pending and let the human review.
-  const outcome = mode === "dry_run" ? "dry_run" : "pending";
-  return recordDecision(db, {
-    repoId,
-    decisionType: d.type as DecisionType,
-    rationale: d.rationale,
-    charterVersion,
-    stateSnapshot: {
-      observations: tick.observations,
-      reasoning: tick.reasoning,
-      priorityId: "priority_id" in d ? d.priority_id : undefined,
-    },
-    payload: "payload" in d ? d.payload : null,
-    outcome,
-    costUsd,
-  });
+  return out;
 }
 
 function renderChatPost(

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -143,11 +143,38 @@ export class GithubVcsProvider implements VcsProvider {
   }
 
   async addLabel(repo: VcsRepoRef, number: number, label: string): Promise<void> {
+    await this.addLabels(repo, number, [label]);
+  }
+
+  async addLabels(repo: VcsRepoRef, number: number, labels: string[]): Promise<void> {
+    if (labels.length === 0) return;
     await this.octokit.issues.addLabels({
       owner: repo.owner,
       repo: repo.name,
       issue_number: number,
-      labels: [label],
+      labels,
+    });
+  }
+
+  async removeLabels(repo: VcsRepoRef, number: number, labels: string[]): Promise<void> {
+    // Octokit's removeLabel is per-label; loop and ignore 404s (the label
+    // might not have been on the issue, that's fine).
+    for (const label of labels) {
+      try {
+        await this.removeLabel(repo, number, label);
+      } catch (err) {
+        if (!isNotFound(err)) throw err;
+      }
+    }
+  }
+
+  async approvePullRequest(repo: VcsRepoRef, prNumber: number, body?: string): Promise<void> {
+    await this.octokit.pulls.createReview({
+      owner: repo.owner,
+      repo: repo.name,
+      pull_number: prNumber,
+      event: "APPROVE",
+      ...(body && { body }),
     });
   }
 

--- a/src/providers/gitlab.ts
+++ b/src/providers/gitlab.ts
@@ -334,6 +334,17 @@ export class GitlabVcsProvider implements VcsProvider {
     await this.put(`/projects/${pid}/${resource}/${number}`, { add_labels: label }).catch(() => {});
   }
 
+  async addLabels(repo: VcsRepoRef, number: number, labels: string[]): Promise<void> {
+    if (labels.length === 0) return;
+    // GitLab accepts comma-separated list; one round-trip.
+    const pid = this.projectId(repo);
+    const kind = this._kindCache.get(this.kindKey(repo, number));
+    const resource = kind === "pull_request" ? "merge_requests" : "issues";
+    await this.put(`/projects/${pid}/${resource}/${number}`, {
+      add_labels: labels.join(","),
+    }).catch(() => {});
+  }
+
   async removeLabel(repo: VcsRepoRef, number: number, label: string): Promise<void> {
     const pid = this.projectId(repo);
     const kind = this._kindCache.get(this.kindKey(repo, number));
@@ -341,6 +352,36 @@ export class GitlabVcsProvider implements VcsProvider {
     await this.put(`/projects/${pid}/${resource}/${number}`, {
       remove_labels: label,
     }).catch(() => {});
+  }
+
+  async removeLabels(repo: VcsRepoRef, number: number, labels: string[]): Promise<void> {
+    if (labels.length === 0) return;
+    const pid = this.projectId(repo);
+    const kind = this._kindCache.get(this.kindKey(repo, number));
+    const resource = kind === "pull_request" ? "merge_requests" : "issues";
+    await this.put(`/projects/${pid}/${resource}/${number}`, {
+      remove_labels: labels.join(","),
+    }).catch(() => {});
+  }
+
+  async createIssue(
+    repo: VcsRepoRef,
+    args: { title: string; body?: string; labels?: string[] },
+  ): Promise<{ number: number; url: string }> {
+    const pid = this.projectId(repo);
+    const data = await this.post<{ iid: number; web_url: string }>(`/projects/${pid}/issues`, {
+      title: args.title,
+      description: args.body ?? "",
+      labels: (args.labels ?? []).join(","),
+    });
+    return { number: data.iid, url: data.web_url };
+  }
+
+  async approvePullRequest(repo: VcsRepoRef, mrNumber: number, _body?: string): Promise<void> {
+    const pid = this.projectId(repo);
+    // GitLab MR approval doesn't take a body; if the caller wants to leave
+    // a comment, they should call postComment in addition.
+    await this.post(`/projects/${pid}/merge_requests/${mrNumber}/approve`, {});
   }
 
   async ensureLabelExists(

--- a/src/providers/vcs.ts
+++ b/src/providers/vcs.ts
@@ -42,4 +42,25 @@ export interface VcsProvider {
   closeItem(repo: VcsRepoRef, number: number, reason?: string): Promise<void>;
   listAllPrFeedback(repo: VcsRepoRef, prNumber: number): Promise<ReviewComment[]>;
   verifyWebhookSignature(headers: Record<string, string>, body: string, secret: string): boolean;
+
+  // ── Director executor surface ────────────────────────────────────────
+  // The Director emits structured decisions (create issue, label, approve,
+  // merge, …) which `src/director/executor.ts` carries out via these
+  // methods. Implementations should be idempotent on the GitHub side —
+  // duplicate calls (e.g. labelling something already labelled) must not
+  // throw. The Director additionally guards against double-execution at
+  // the decision level (outcome check), but defence-in-depth here is
+  // welcome.
+  createIssue(
+    repo: VcsRepoRef,
+    args: { title: string; body?: string; labels?: string[] },
+  ): Promise<{ number: number; url: string }>;
+  addLabels(repo: VcsRepoRef, number: number, labels: string[]): Promise<void>;
+  removeLabels(repo: VcsRepoRef, number: number, labels: string[]): Promise<void>;
+  approvePullRequest(repo: VcsRepoRef, prNumber: number, body?: string): Promise<void>;
+  mergePullRequest(
+    repo: VcsRepoRef,
+    prNumber: number,
+    strategy: "merge" | "squash" | "rebase",
+  ): Promise<{ merged: boolean; sha?: string; message?: string }>;
 }

--- a/test/director-execution.test.mjs
+++ b/test/director-execution.test.mjs
@@ -430,7 +430,10 @@ test("full_auto close_issue → posts comment then closes", async () => {
         {
           type: "close_issue",
           rationale: "duplicate of an earlier issue thread",
-          payload: { issue_number: 41, reason: "Duplicate of #40 — closing in favour of that one." },
+          payload: {
+            issue_number: 41,
+            reason: "Duplicate of #40 — closing in favour of that one.",
+          },
         },
       ]),
       vcsFactory: vcsFactory(vcs.provider),

--- a/test/director-execution.test.mjs
+++ b/test/director-execution.test.mjs
@@ -164,7 +164,7 @@ test("dry_run: create_issue → outcome=dry_run, no VCS call", async () => {
       engineFactory: mockEngine([
         {
           type: "create_issue",
-          rationale: "obs gap",
+          rationale: "addresses observability gap in metrics",
           payload: {
             title: "Add metric",
             body: "## Problem\n\nNo metric.\n\n## Acceptance\n- [ ] add",
@@ -233,7 +233,7 @@ test("semi_auto: create_issue executes, merge_pr stays pending", async () => {
       engineFactory: mockEngine([
         {
           type: "create_issue",
-          rationale: "needs",
+          rationale: "needs to land per charter priority",
           payload: {
             title: "auto-create",
             body: "## Problem\n\nfoo\n\n## Done\n- yes",
@@ -243,7 +243,7 @@ test("semi_auto: create_issue executes, merge_pr stays pending", async () => {
         },
         {
           type: "merge_pr",
-          rationale: "ready",
+          rationale: "ready: ci green, addresses charter",
           payload: { pr_number: 7, strategy: "squash" },
         },
       ]),
@@ -274,12 +274,12 @@ test("full_auto: merge_pr executes, charter amend stays pending", async () => {
       engineFactory: mockEngine([
         {
           type: "merge_pr",
-          rationale: "ready",
+          rationale: "ready: ci green, addresses charter",
           payload: { pr_number: 11, strategy: "squash" },
         },
         {
           type: "amend_charter",
-          rationale: "evolution",
+          rationale: "evolve charter for new priority X",
           payload: {
             proposed_changes: "Add new priority X with weight 0.1",
             rationale: "Need more diversity in objectives",
@@ -315,7 +315,7 @@ test("authority: can_merge=false blocks merge_pr in full_auto → outcome=skippe
       engineFactory: mockEngine([
         {
           type: "merge_pr",
-          rationale: "ready",
+          rationale: "ready: ci green, addresses charter",
           payload: { pr_number: 5, strategy: "squash" },
         },
       ]),
@@ -343,7 +343,7 @@ test("authority: can_close_issues=false blocks close_issue", async () => {
       engineFactory: mockEngine([
         {
           type: "close_issue",
-          rationale: "stale",
+          rationale: "stale per charter retrospective",
           payload: { issue_number: 99, reason: "no longer relevant; please reopen if needed" },
         },
       ]),
@@ -429,7 +429,7 @@ test("full_auto close_issue → posts comment then closes", async () => {
       engineFactory: mockEngine([
         {
           type: "close_issue",
-          rationale: "duplicate",
+          rationale: "duplicate of an earlier issue thread",
           payload: { issue_number: 41, reason: "Duplicate of #40 — closing in favour of that one." },
         },
       ]),
@@ -494,7 +494,7 @@ test("full_auto: VCS failure → outcome=failed, error message in chat", async (
       engineFactory: mockEngine([
         {
           type: "create_issue",
-          rationale: "needed",
+          rationale: "needed to address charter goal",
           payload: {
             title: "x",
             body: "## p\n\nthing\n\n## d\n- yes",

--- a/test/director-execution.test.mjs
+++ b/test/director-execution.test.mjs
@@ -1,0 +1,558 @@
+// Tests for the Director's decision executor.
+//
+// These exercise the full mode × authority × decision-type matrix using a
+// mock VcsProvider. No live API calls.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import { runTick } from "../dist/director/tick.js";
+import { recentMessages } from "../dist/director/chat.js";
+import { recentDecisions } from "../dist/director/decisions.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-exec-test-"));
+  const db = initDb(dir);
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+const charter = {
+  vision: "Test charter for execution tests.",
+  priorities: [{ id: "rel", weight: 1.0, rubric: "reliability" }],
+  out_of_bounds: [],
+  out_of_bounds_paths: [],
+  definition_of_done: [],
+};
+
+const baseBudget = {
+  initial_daily_usd: 2.0,
+  initial_weekly_usd: 10.0,
+  max_daily_usd: 10.0,
+  max_weekly_usd: 50.0,
+  think_daily_usd: 1.0,
+  pause_on_failure_streak: 3,
+  good_outcome_quarantine_days: 7,
+};
+
+const fullAuthority = {
+  can_create_issues: true,
+  can_label: true,
+  can_close_issues: true,
+  can_comment: true,
+  can_approve_pr: true,
+  can_merge: true,
+  can_modify_charter: true,
+};
+
+function director(mode, overrides = {}) {
+  return {
+    enabled: true,
+    mode,
+    cadence_hours: 6,
+    bot_prefix: "👔 director:",
+    charter,
+    budget: baseBudget,
+    authority: { ...fullAuthority, ...(overrides.authority ?? {}) },
+  };
+}
+
+function repo(d) {
+  return {
+    provider: "github",
+    owner: "openronin",
+    name: "openronin",
+    watched: true,
+    lanes: ["triage"],
+    director: d,
+  };
+}
+
+function mockEngine(decisions) {
+  return () => ({
+    id: "mock",
+    defaultModel: "mock-model",
+    async run() {
+      const json = {
+        observations: "State is stable. No urgent issues. Sufficient observability coverage.",
+        reasoning: "Routine planning per charter priority rel; nothing pressing surfaced.",
+        decisions,
+      };
+      return {
+        content: JSON.stringify(json),
+        json,
+        usage: { tokensIn: 1000, tokensOut: 200, costUsd: 0.001 },
+        finishReason: "end_turn",
+        durationMs: 100,
+      };
+    },
+  });
+}
+
+// Recording mock — captures every VCS method call so tests can assert.
+function mockVcs() {
+  const calls = [];
+  const provider = {
+    id: "mock-vcs",
+    listOpenItems: async function* () {},
+    async getItem() {
+      throw new Error("not used");
+    },
+    async postComment(_repo, number, body) {
+      calls.push({ method: "postComment", number, body });
+      return { id: "c1", url: `https://gh/comment/${number}` };
+    },
+    async updateComment() {},
+    async closeItem(_repo, number, reason) {
+      calls.push({ method: "closeItem", number, reason });
+    },
+    async listAllPrFeedback() {
+      return [];
+    },
+    verifyWebhookSignature() {
+      return true;
+    },
+    async createIssue(_repo, args) {
+      calls.push({ method: "createIssue", ...args });
+      return { number: 999, url: "https://gh/issues/999" };
+    },
+    async addLabels(_repo, number, labels) {
+      calls.push({ method: "addLabels", number, labels });
+    },
+    async removeLabels(_repo, number, labels) {
+      calls.push({ method: "removeLabels", number, labels });
+    },
+    async approvePullRequest(_repo, prNumber, body) {
+      calls.push({ method: "approvePullRequest", prNumber, body });
+    },
+    async mergePullRequest(_repo, prNumber, strategy) {
+      calls.push({ method: "mergePullRequest", prNumber, strategy });
+      return { merged: true, sha: "abc1234" };
+    },
+  };
+  return { provider, calls };
+}
+
+const vcsFactory = (vcs) => () => vcs;
+
+// ── Mode → outcome behaviour ─────────────────────────────────────────────
+
+test("dry_run: create_issue → outcome=dry_run, no VCS call", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: repo(director("dry_run")),
+      director: director("dry_run"),
+      dataDir: dir,
+      engineFactory: mockEngine([
+        {
+          type: "create_issue",
+          rationale: "obs gap",
+          payload: {
+            title: "Add metric",
+            body: "## Problem\n\nNo metric.\n\n## Acceptance\n- [ ] add",
+            labels: [],
+            priority: "normal",
+          },
+        },
+      ]),
+      vcsFactory: vcsFactory(vcs.provider),
+    });
+    const ds = recentDecisions(db, repoId, 5);
+    assert.equal(ds[0].outcome, "dry_run");
+    assert.equal(vcs.calls.length, 0, "VCS must not be called in dry_run");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("propose: create_issue → outcome=pending, proposal posted, no VCS call", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: repo(director("propose")),
+      director: director("propose"),
+      dataDir: dir,
+      engineFactory: mockEngine([
+        {
+          type: "create_issue",
+          rationale: "needs to land",
+          payload: {
+            title: "Tweak something",
+            body: "## Problem\n\nfoo\n\n## Acceptance\n- [ ] x",
+            labels: ["a"],
+            priority: "normal",
+          },
+        },
+      ]),
+      vcsFactory: vcsFactory(vcs.provider),
+    });
+    const ds = recentDecisions(db, repoId, 5);
+    assert.equal(ds[0].outcome, "pending");
+    assert.equal(vcs.calls.length, 0, "VCS must not be called in propose");
+    const msgs = recentMessages(db, repoId, 5);
+    const proposals = msgs.filter((m) => m.type === "proposal");
+    assert.equal(proposals.length, 1);
+    assert.match(proposals[0].body, /create_issue/);
+    assert.match(proposals[0].body, /Tweak something/);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("semi_auto: create_issue executes, merge_pr stays pending", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: repo(director("semi_auto")),
+      director: director("semi_auto"),
+      dataDir: dir,
+      engineFactory: mockEngine([
+        {
+          type: "create_issue",
+          rationale: "needs",
+          payload: {
+            title: "auto-create",
+            body: "## Problem\n\nfoo\n\n## Done\n- yes",
+            labels: [],
+            priority: "normal",
+          },
+        },
+        {
+          type: "merge_pr",
+          rationale: "ready",
+          payload: { pr_number: 7, strategy: "squash" },
+        },
+      ]),
+      vcsFactory: vcsFactory(vcs.provider),
+    });
+    const ds = recentDecisions(db, repoId, 10);
+    const issueDec = ds.find((d) => d.decisionType === "create_issue");
+    const mergeDec = ds.find((d) => d.decisionType === "merge_pr");
+    assert.equal(issueDec.outcome, "executed");
+    assert.equal(mergeDec.outcome, "pending");
+    assert.equal(vcs.calls.filter((c) => c.method === "createIssue").length, 1);
+    assert.equal(vcs.calls.filter((c) => c.method === "mergePullRequest").length, 0);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("full_auto: merge_pr executes, charter amend stays pending", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: repo(director("full_auto")),
+      director: director("full_auto"),
+      dataDir: dir,
+      engineFactory: mockEngine([
+        {
+          type: "merge_pr",
+          rationale: "ready",
+          payload: { pr_number: 11, strategy: "squash" },
+        },
+        {
+          type: "amend_charter",
+          rationale: "evolution",
+          payload: {
+            proposed_changes: "Add new priority X with weight 0.1",
+            rationale: "Need more diversity in objectives",
+          },
+        },
+      ]),
+      vcsFactory: vcsFactory(vcs.provider),
+    });
+    const ds = recentDecisions(db, repoId, 10);
+    const mergeDec = ds.find((d) => d.decisionType === "merge_pr");
+    const charterDec = ds.find((d) => d.decisionType === "amend_charter");
+    assert.equal(mergeDec.outcome, "executed");
+    assert.equal(charterDec.outcome, "pending", "amend_charter is always proposal-only");
+    assert.equal(vcs.calls.filter((c) => c.method === "mergePullRequest").length, 1);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+// ── Authority gating ─────────────────────────────────────────────────────
+
+test("authority: can_merge=false blocks merge_pr in full_auto → outcome=skipped", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  const d = director("full_auto", { authority: { can_merge: false } });
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: repo(d),
+      director: d,
+      dataDir: dir,
+      engineFactory: mockEngine([
+        {
+          type: "merge_pr",
+          rationale: "ready",
+          payload: { pr_number: 5, strategy: "squash" },
+        },
+      ]),
+      vcsFactory: vcsFactory(vcs.provider),
+    });
+    const ds = recentDecisions(db, repoId, 5);
+    assert.equal(ds[0].outcome, "skipped");
+    assert.equal(vcs.calls.length, 0);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("authority: can_close_issues=false blocks close_issue", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  const d = director("full_auto", { authority: { can_close_issues: false } });
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: repo(d),
+      director: d,
+      dataDir: dir,
+      engineFactory: mockEngine([
+        {
+          type: "close_issue",
+          rationale: "stale",
+          payload: { issue_number: 99, reason: "no longer relevant; please reopen if needed" },
+        },
+      ]),
+      vcsFactory: vcsFactory(vcs.provider),
+    });
+    const ds = recentDecisions(db, repoId, 5);
+    assert.equal(ds[0].outcome, "skipped");
+    assert.equal(vcs.calls.length, 0);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+// ── Per-type executors ───────────────────────────────────────────────────
+
+test("full_auto label_pr → addLabels + removeLabels both called", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: repo(director("full_auto")),
+      director: director("full_auto"),
+      dataDir: dir,
+      engineFactory: mockEngine([
+        {
+          type: "label_pr",
+          rationale: "tag for review",
+          payload: { pr_number: 8, add: ["needs-review"], remove: ["wip"] },
+        },
+      ]),
+      vcsFactory: vcsFactory(vcs.provider),
+    });
+    const adds = vcs.calls.find((c) => c.method === "addLabels");
+    const removes = vcs.calls.find((c) => c.method === "removeLabels");
+    assert.deepEqual(adds.labels, ["needs-review"]);
+    assert.deepEqual(removes.labels, ["wip"]);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("full_auto approve_pr → approvePullRequest called once", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: repo(director("full_auto")),
+      director: director("full_auto"),
+      dataDir: dir,
+      engineFactory: mockEngine([
+        {
+          type: "approve_pr",
+          rationale: "ci green, addresses charter rel priority",
+          payload: { pr_number: 14, body: "LGTM" },
+        },
+      ]),
+      vcsFactory: vcsFactory(vcs.provider),
+    });
+    const call = vcs.calls.find((c) => c.method === "approvePullRequest");
+    assert.equal(call.prNumber, 14);
+    assert.equal(call.body, "LGTM");
+    const ds = recentDecisions(db, repoId, 5);
+    assert.equal(ds[0].outcome, "executed");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("full_auto close_issue → posts comment then closes", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: repo(director("full_auto")),
+      director: director("full_auto"),
+      dataDir: dir,
+      engineFactory: mockEngine([
+        {
+          type: "close_issue",
+          rationale: "duplicate",
+          payload: { issue_number: 41, reason: "Duplicate of #40 — closing in favour of that one." },
+        },
+      ]),
+      vcsFactory: vcsFactory(vcs.provider),
+    });
+    const comment = vcs.calls.find((c) => c.method === "postComment");
+    const close = vcs.calls.find((c) => c.method === "closeItem");
+    assert.equal(comment.number, 41);
+    assert.match(comment.body, /Duplicate/);
+    assert.equal(close.number, 41);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+// ── ask_user always executes (posts question to chat, no VCS) ───────────
+
+test("propose: ask_user → outcome=executed, question posted to chat, no VCS", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: repo(director("propose")),
+      director: director("propose"),
+      dataDir: dir,
+      engineFactory: mockEngine([
+        {
+          type: "ask_user",
+          rationale: "uncertain about priority X vs Y",
+          payload: { question: "Should we focus on X or Y next sprint?", context: "from charter" },
+        },
+      ]),
+      vcsFactory: vcsFactory(vcs.provider),
+    });
+    const ds = recentDecisions(db, repoId, 5);
+    assert.equal(ds[0].outcome, "executed");
+    const questions = recentMessages(db, repoId, 10).filter((m) => m.type === "question");
+    assert.equal(questions.length, 1);
+    assert.equal(vcs.calls.length, 0);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+// ── Failure handling ─────────────────────────────────────────────────────
+
+test("full_auto: VCS failure → outcome=failed, error message in chat", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  vcs.provider.createIssue = async () => {
+    throw new Error("github 503: temporarily unavailable");
+  };
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: repo(director("full_auto")),
+      director: director("full_auto"),
+      dataDir: dir,
+      engineFactory: mockEngine([
+        {
+          type: "create_issue",
+          rationale: "needed",
+          payload: {
+            title: "x",
+            body: "## p\n\nthing\n\n## d\n- yes",
+            labels: [],
+            priority: "normal",
+          },
+        },
+      ]),
+      vcsFactory: vcsFactory(vcs.provider),
+    });
+    const ds = recentDecisions(db, repoId, 5);
+    assert.equal(ds[0].outcome, "failed");
+    assert.match(ds[0].outcomeDetails, /503/);
+    const errs = recentMessages(db, repoId, 10).filter((m) => m.type === "error");
+    assert.equal(errs.length, 1);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("no_op decision always outcome=executed regardless of mode", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: repo(director("propose")),
+      director: director("propose"),
+      dataDir: dir,
+      engineFactory: mockEngine([{ type: "no_op", rationale: "Nothing to do this tick." }]),
+      vcsFactory: vcsFactory(vcs.provider),
+    });
+    const ds = recentDecisions(db, repoId, 5);
+    // dry_run mode special-cases dry_run outcome; propose mode no_op → executed.
+    assert.equal(ds[0].outcome, "executed");
+    assert.equal(vcs.calls.length, 0);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("dry_run: no_op → outcome=dry_run (mode wins)", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: repo(director("dry_run")),
+      director: director("dry_run"),
+      dataDir: dir,
+      engineFactory: mockEngine([{ type: "no_op", rationale: "Nothing to do this tick." }]),
+      vcsFactory: vcsFactory(vcs.provider),
+    });
+    const ds = recentDecisions(db, repoId, 5);
+    assert.equal(ds[0].outcome, "dry_run");
+  } finally {
+    cleanup(dir);
+  }
+});

--- a/test/director-execution.test.mjs
+++ b/test/director-execution.test.mjs
@@ -496,8 +496,8 @@ test("full_auto: VCS failure → outcome=failed, error message in chat", async (
           type: "create_issue",
           rationale: "needed to address charter goal",
           payload: {
-            title: "x",
-            body: "## p\n\nthing\n\n## d\n- yes",
+            title: "Repro the 503 path",
+            body: "## Problem\n\nrepro\n\n## Acceptance\n- yes",
             labels: [],
             priority: "normal",
           },


### PR DESCRIPTION
## Summary

Plan-PR #3a of the director rollout. The mode toggle (\`dry_run\` / \`propose\` / \`semi_auto\` / \`full_auto\`) now actually drives whether decisions execute, queue for approval, or are logged only.

This PR is the **backend half**. Plan-PR #3b adds the HTMX approve/reject buttons in /admin/director that flip pending decisions to executed/rejected. Until that lands, pending decisions sit in chat with instructions; you can also flip them by hand via SQL if you want to dry-run the path.

## What changed

**\`src/director/executor.ts\` (new, ~280 lines)** — turns a \`ParsedDecision\` into a real side-effect via \`VcsProvider\`. The dispatch is a single matrix:

|              | dry_run  | propose  | semi_auto | full_auto |
|--------------|----------|----------|-----------|-----------|
| no_op        | executed | executed | executed  | executed  |
| ask_user     | dry_run  | executed | executed  | executed  |
| create_issue | dry_run  | pending  | executed  | executed  |
| comment_*    | dry_run  | pending  | executed  | executed  |
| label_*      | dry_run  | pending  | executed  | executed  |
| close_issue  | dry_run  | pending  | pending   | pending   |
| approve_pr   | dry_run  | pending  | executed  | executed  |
| merge_pr     | dry_run  | pending  | pending   | executed  |
| amend_charter| dry_run  | pending  | pending   | pending   |

(Authority gates apply on top — \`can_close_issues=false\` blocks \`close_issue\` regardless of mode, etc. Gated decisions get \`outcome=skipped\`.)

**\`src/providers/vcs.ts\`** — extended interface with the methods the executor needs: \`createIssue\`, \`addLabels\` (plural batch), \`removeLabels\`, \`approvePullRequest\`. \`postComment\`, \`closeItem\`, \`mergePullRequest\` were already there.

**\`src/providers/github.ts\` / \`src/providers/gitlab.ts\`** — implement the new interface methods. GitLab gets a \`createIssue\` it didn't have before (uses the standard \`POST /projects/:id/issues\` endpoint).

**\`src/director/tick.ts\`** — instead of recording every decision with \`outcome=dry_run\` or \`pending\` based on mode, now records as \`pending\` and routes through \`executeDecision()\`. Result counts (\`executed\`, \`pending\`, \`skipped\`, \`failed\`) are surfaced in the tick result detail. \`VcsProvider\` is constructed lazily — only when an executor actually reaches a VCS call.

**\`test/director-execution.test.mjs\` (new, ~520 lines, 15 tests)** — covers every mode × outcome combination, authority gates, per-type executors, ask_user-without-VCS, VCS-failure path, no_op-always-executed.

## Total: 80 unit tests, 0 fail, 0 lint, format clean

## What this **doesn't** do (yet)

- HTMX buttons for approve/reject — that's PR #3b.
- Telegram bridge — that's PR #4.
- Adaptive budget — that's PR #5.

## Operational notes for after merge

- Production currently runs the director in \`dry_run\` mode. **Behaviour does not change** unless I update the per-repo YAML to switch mode to \`propose\` (or higher). I will not do that without your explicit OK.
- The deploy lane will fire on merge → main openronin restarts. \`openronin-director\` needs a separate \`sudo systemctl restart openronin-director\` to pick up new code (existing limitation, unchanged here).
- \`director.env\` and per-repo charter on disk are unchanged.

## Test plan

- [x] \`pnpm run check\` green (80 unit tests, 0 lint, format clean)
- [x] All 15 new executor tests pass
- [ ] After merge: deploy fires, restart director, verify next dry_run tick still produces the same kind of output as before (regression check)
- [ ] Then a separate explicit step: switch openronin/openronin to \`propose\` mode in YAML, observe one cycle to validate proposal posting works end-to-end