### PR TITLE
feat(director): two-way admin chat — approve/reject + user messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to **openronin** are documented here. The format follows [Ke
 
 ## [Unreleased]
 
+### Added — director: two-way admin chat (approve/reject + user messages)
+
+The `/admin/director/<slug>` page is no longer read-only. Three new POST endpoints make it a control surface:
+
+- `POST /admin/director/:slug/messages` — operator posts a `directive`/`answer`/`veto` message into the chat thread. Picked up by the next tick.
+- `POST /admin/director/:slug/decisions/:id/approve` — re-runs authority gate, executes the side-effect via `VcsProvider`, flips outcome `pending → executed`/`failed`/`skipped`. Posts a report.
+- `POST /admin/director/:slug/decisions/:id/reject` — flips outcome `pending → rejected`, records optional reason as a `veto`-typed user message.
+
+The pending-proposal chat bubble grows inline `[✓ Approve]`/`[✗ Reject]` buttons (HTMX, no page reload). The thread also gains a `directive`/`answer`/`veto` form at the top.
+
+`approveDecision()` / `rejectDecision()` are exported from `src/director/executor.ts` so the upcoming Telegram bridge can use the same code-path. 5 new tests exercise the full lifecycle including authority re-checks, double-approve guard, and reject-after-execute.
+
+
 ### Added — director: execution backend (decision side-effects via VcsProvider)
 
 The director's `mode` toggle (`dry_run` / `propose` / `semi_auto` / `full_auto`) now actually drives execution. Previously every decision was logged with `outcome=dry_run` regardless of mode; now the executor in `src/director/executor.ts` carries each decision through a mode × authority × decision-type matrix and either:

--- a/src/director/decisions.ts
+++ b/src/director/decisions.ts
@@ -86,9 +86,9 @@ export function recentDecisions(db: Db, repoId: number, limit = 50): Decision[] 
 }
 
 export function getDecisionById(db: Db, decisionId: number): Decision | null {
-  const row = db
-    .prepare(`SELECT * FROM director_decisions WHERE id = ?`)
-    .get(decisionId) as DecisionRow | undefined;
+  const row = db.prepare(`SELECT * FROM director_decisions WHERE id = ?`).get(decisionId) as
+    | DecisionRow
+    | undefined;
   return row ? rowToDecision(row) : null;
 }
 

--- a/src/director/decisions.ts
+++ b/src/director/decisions.ts
@@ -85,6 +85,13 @@ export function recentDecisions(db: Db, repoId: number, limit = 50): Decision[] 
   return rows.map(rowToDecision);
 }
 
+export function getDecisionById(db: Db, decisionId: number): Decision | null {
+  const row = db
+    .prepare(`SELECT * FROM director_decisions WHERE id = ?`)
+    .get(decisionId) as DecisionRow | undefined;
+  return row ? rowToDecision(row) : null;
+}
+
 export function pendingDecisions(db: Db, repoId: number): Decision[] {
   const rows = db
     .prepare(

--- a/src/director/executor.ts
+++ b/src/director/executor.ts
@@ -38,7 +38,7 @@ import type { Db } from "../storage/db.js";
 import type { RepoConfig } from "../config/schema.js";
 import { repoKey } from "../config/schema.js";
 import type { VcsProvider, VcsRepoRef } from "../providers/vcs.js";
-import { setDecisionOutcome } from "./decisions.js";
+import { getDecisionById, setDecisionOutcome } from "./decisions.js";
 import { appendMessage } from "./chat.js";
 import type { ParsedDecision } from "./decision-schema.js";
 import type { DecisionOutcome, DirectorAuthority, DirectorConfig } from "./types.js";
@@ -348,4 +348,153 @@ function summariseProposal(d: ParsedDecision): string {
 
 function truncate(s: string, n: number): string {
   return s.length <= n ? s : s.slice(0, n - 1) + "…";
+}
+
+// ── Human approve / reject (from /admin/director or Telegram) ────────────
+//
+// `pending` decisions sit in the queue until a human acts. These two
+// functions are the single entry-points for that action — they live here
+// (not in admin.ts) so the same logic can be reused from the Telegram
+// bridge in PR #4 without duplication.
+
+export type ApproveOptions = {
+  db: Db;
+  decisionId: number;
+  repo: RepoConfig;
+  director: DirectorConfig;
+  actor: string; // "admin" | "telegram:<userId>" — for chat metadata
+  getVcs: () => VcsProvider;
+};
+
+export type ApproveResult =
+  | { ok: true; outcome: DecisionOutcome; details: string }
+  | { ok: false; reason: string };
+
+// Approve a pending decision: re-runs authority gating (operator might have
+// flipped a `can_*` since the decision was queued) then executes the
+// side-effect, just like `executeDecision` would in `full_auto` mode.
+export async function approveDecision(opts: ApproveOptions): Promise<ApproveResult> {
+  const { db, decisionId, repo, director, actor } = opts;
+  const decision = getDecisionById(db, decisionId);
+  if (!decision) return { ok: false, reason: `decision ${decisionId} not found` };
+  if (decision.outcome !== "pending") {
+    return { ok: false, reason: `decision ${decisionId} is ${decision.outcome}, not pending` };
+  }
+  if (decision.repoId !== getRepoIdForRepo(db, repo)) {
+    return { ok: false, reason: `decision ${decisionId} belongs to a different repo` };
+  }
+
+  // Reconstruct a ParsedDecision-shaped object from the stored row. The
+  // schema-validation already ran when the decision was first recorded;
+  // re-validating here is paranoia we'd pay on every approve. Skip it.
+  const parsed = {
+    type: decision.decisionType,
+    rationale: decision.rationale,
+    payload: decision.payload,
+  } as unknown as ParsedDecision;
+
+  // Re-check authority — operator may have flipped a `can_*` between the
+  // proposal and now.
+  const auth = authorityFor(parsed, director.authority);
+  if (auth.gated) {
+    setDecisionOutcome(db, decisionId, "skipped", auth.reason);
+    appendMessage(db, {
+      repoId: decision.repoId,
+      role: "system",
+      type: "tick_log",
+      body: `approval skipped: ${auth.reason}`,
+      metadata: { repo: repoKey(repo), actor, decisionId },
+      decisionId,
+    });
+    return { ok: true, outcome: "skipped", details: auth.reason };
+  }
+
+  appendMessage(db, {
+    repoId: decision.repoId,
+    role: "user",
+    type: "answer",
+    body: `Approved decision #${decisionId} (${decision.decisionType})`,
+    metadata: { repo: repoKey(repo), actor, decisionId, action: "approve" },
+    decisionId,
+  });
+
+  try {
+    const detail = await runDecision(
+      {
+        db,
+        decisionId,
+        repoId: decision.repoId,
+        repo,
+        director,
+        decision: parsed,
+        getVcs: opts.getVcs,
+        charterVersion: decision.charterVersion ?? 0,
+      },
+      { owner: repo.owner, name: repo.name },
+    );
+    setDecisionOutcome(db, decisionId, "executed", detail);
+    appendMessage(db, {
+      repoId: decision.repoId,
+      role: "director",
+      type: "report",
+      body: `Decision #${decisionId} executed: ${detail}`,
+      metadata: { repo: repoKey(repo), actor, decisionId },
+      decisionId,
+    });
+    return { ok: true, outcome: "executed", details: detail };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    setDecisionOutcome(db, decisionId, "failed", detail);
+    appendMessage(db, {
+      repoId: decision.repoId,
+      role: "system",
+      type: "error",
+      body: `Decision #${decisionId} failed on approval execute: ${detail}`,
+      metadata: { repo: repoKey(repo), actor, decisionId },
+      decisionId,
+    });
+    return { ok: true, outcome: "failed", details: detail };
+  }
+}
+
+export type RejectOptions = {
+  db: Db;
+  decisionId: number;
+  repo: RepoConfig;
+  actor: string;
+  reason?: string;
+};
+
+export function rejectDecision(opts: RejectOptions): ApproveResult {
+  const { db, decisionId, repo, actor, reason } = opts;
+  const decision = getDecisionById(db, decisionId);
+  if (!decision) return { ok: false, reason: `decision ${decisionId} not found` };
+  if (decision.outcome !== "pending") {
+    return { ok: false, reason: `decision ${decisionId} is ${decision.outcome}, not pending` };
+  }
+  if (decision.repoId !== getRepoIdForRepo(db, repo)) {
+    return { ok: false, reason: `decision ${decisionId} belongs to a different repo` };
+  }
+
+  const detail = reason ? `rejected: ${reason}` : "rejected by human";
+  setDecisionOutcome(db, decisionId, "rejected", detail);
+  appendMessage(db, {
+    repoId: decision.repoId,
+    role: "user",
+    type: "veto",
+    body: `Rejected decision #${decisionId} (${decision.decisionType})${reason ? `\n\n_Reason:_ ${reason}` : ""}`,
+    metadata: { repo: repoKey(repo), actor, decisionId, action: "reject" },
+    decisionId,
+  });
+  return { ok: true, outcome: "rejected", details: detail };
+}
+
+// Helper: look up our internal repo_id from a RepoConfig (provider/owner/name).
+// Defence-in-depth check that the decision being approved belongs to the
+// repo the request claimed it does.
+function getRepoIdForRepo(db: Db, repo: RepoConfig): number {
+  const row = db
+    .prepare(`SELECT id FROM repos WHERE provider = ? AND owner = ? AND name = ?`)
+    .get(repo.provider, repo.owner, repo.name) as { id: number } | undefined;
+  return row?.id ?? -1;
 }

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -1,20 +1,36 @@
-// Admin UI for the Director (read-only in foundation phase).
+// Admin UI for the Director — two-way chat (PR #3b).
 //
-// Mounts at /admin/director — list of director-enabled repos — and
-// /admin/director/:slug — the chat thread + recent decisions for one repo.
-// Two-way chat (HTMX message form, approval buttons) lands in PR #23.
+// Mounts at /admin/director (list) and /admin/director/:slug (per-repo
+// timeline + interactions). HTMX-driven; no JS framework.
+//
+// Interaction surface:
+//   POST /admin/director/:slug/messages
+//        body: type=directive|answer|veto, body=<text>
+//        → appends a user-role message; tick consumes it next cycle.
+//   POST /admin/director/:slug/decisions/:id/approve
+//        → re-runs authority gate, executes the side-effect, flips
+//          outcome to executed (or failed/skipped). Posts a report.
+//   POST /admin/director/:slug/decisions/:id/reject
+//        body: reason=<optional text>
+//        → flips outcome to rejected, records reason as veto message.
+//
+// Each POST returns an HTMX-swapped fragment of the chat thread so the
+// page updates in place without a full reload.
 
 import { Hono } from "hono";
 import type { Db } from "../storage/db.js";
 import type { RuntimeConfig } from "../config/schema.js";
-import { repoKey } from "../config/schema.js";
-import { html, isHtmx, page, t as time, type TrustedHtml } from "./layout.js";
+import { repoKey, type RepoConfig } from "../config/schema.js";
+import { html, isHtmx, page, raw, t as time, type TrustedHtml } from "./layout.js";
 import { card } from "./components/card.js";
 import { badge, type BadgeTone } from "./components/badge.js";
-import { recentMessages } from "../director/chat.js";
+import { appendMessage, recentMessages } from "../director/chat.js";
 import { recentDecisions } from "../director/decisions.js";
 import { ensureBudgetState, checkBudgetGate } from "../director/budget.js";
 import { latestCharterVersion } from "../director/charter.js";
+import { approveDecision, rejectDecision } from "../director/executor.js";
+import { GithubVcsProvider } from "../providers/github.js";
+import type { VcsProvider } from "../providers/vcs.js";
 import type { DirectorMessage, MessageType } from "../director/types.js";
 
 interface Args {
@@ -28,7 +44,6 @@ type RepoEntry = {
   owner: string;
   name: string;
   mode: string;
-  enabled: boolean;
   hasCharter: boolean;
 };
 
@@ -51,7 +66,6 @@ function listEntries(db: Db, getConfig: () => RuntimeConfig): RepoEntry[] {
       owner: repo.owner,
       name: repo.name,
       mode: d.mode,
-      enabled: d.enabled,
       hasCharter: !!d.charter,
     });
   }
@@ -84,12 +98,25 @@ function messageTypeBadgeTone(type: MessageType): BadgeTone {
       return "danger";
     case "report":
       return "success";
+    case "question":
+      return "info";
     default:
       return "neutral";
   }
 }
 
-function renderMessage(m: DirectorMessage): TrustedHtml {
+// Did this proposal-type message represent a still-pending decision? If
+// the underlying decision has been executed/rejected/etc, we hide the
+// approve/reject buttons.
+function decisionStillPending(db: Db, decisionId: number | null): boolean {
+  if (decisionId == null) return false;
+  const row = db
+    .prepare(`SELECT outcome FROM director_decisions WHERE id = ?`)
+    .get(decisionId) as { outcome: string } | undefined;
+  return row?.outcome === "pending";
+}
+
+function renderMessage(db: Db, slug: string, m: DirectorMessage): TrustedHtml {
   const isDirector = m.role === "director";
   const isUser = m.role === "user";
   const align = isUser ? "ml-auto" : "";
@@ -99,6 +126,10 @@ function renderMessage(m: DirectorMessage): TrustedHtml {
       ? "bg-[var(--accent-soft)]"
       : "bg-[var(--surface-3)]";
   const speaker = isDirector ? "👔 director" : isUser ? "👤 you" : "⚙️ system";
+
+  const isLiveProposal =
+    m.type === "proposal" && decisionStillPending(db, m.decisionId);
+
   return html`
     <div class="flex flex-col gap-1 max-w-[80ch] ${align}">
       <div class="flex items-center gap-2 text-xs text-[var(--text-2)]">
@@ -111,8 +142,103 @@ function renderMessage(m: DirectorMessage): TrustedHtml {
       >
         ${m.body}
       </div>
+      ${isLiveProposal && m.decisionId
+        ? renderProposalActions(slug, m.decisionId)
+        : ""}
     </div>
   `;
+}
+
+function renderProposalActions(slug: string, decisionId: number): TrustedHtml {
+  return html`
+    <div class="flex items-center gap-2 mt-1">
+      <button
+        class="btn btn-success btn-sm"
+        hx-post="/admin/director/${slug}/decisions/${decisionId}/approve"
+        hx-target="#chat-thread"
+        hx-swap="outerHTML"
+        hx-confirm="Approve and execute decision #${decisionId}?"
+      >
+        ✓ Approve
+      </button>
+      <button
+        class="btn btn-danger btn-sm"
+        hx-post="/admin/director/${slug}/decisions/${decisionId}/reject"
+        hx-target="#chat-thread"
+        hx-swap="outerHTML"
+        hx-include="closest div[data-decision-form]"
+      >
+        ✗ Reject
+      </button>
+      <input
+        type="text"
+        name="reason"
+        form="reject-form-${decisionId}"
+        placeholder="reject reason (optional)"
+        class="form-input form-input-sm flex-1 text-xs"
+        data-decision-form
+      />
+    </div>
+  `;
+}
+
+function renderUserMessageForm(slug: string): TrustedHtml {
+  return html`
+    <form
+      class="flex flex-col gap-2 p-3 border border-[var(--border)] rounded-md bg-[var(--surface-2)]"
+      hx-post="/admin/director/${slug}/messages"
+      hx-target="#chat-thread"
+      hx-swap="outerHTML"
+      hx-on::after-request="if(event.detail.successful) this.reset()"
+    >
+      <div class="flex items-center gap-2 text-xs">
+        <label class="text-[var(--text-2)]">Type:</label>
+        <select name="type" class="form-select form-select-sm">
+          <option value="directive">directive</option>
+          <option value="answer">answer</option>
+          <option value="veto">veto</option>
+        </select>
+      </div>
+      <textarea
+        name="body"
+        rows="2"
+        required
+        placeholder="Write a directive (e.g. 'focus on tests this week') or answer the director's last question."
+        class="form-textarea text-sm"
+      ></textarea>
+      <div>
+        <button type="submit" class="btn btn-primary btn-sm">Send</button>
+      </div>
+    </form>
+  `;
+}
+
+function renderChatThread(
+  db: Db,
+  slug: string,
+  messages: DirectorMessage[],
+): TrustedHtml {
+  return html`
+    <div id="chat-thread" class="flex flex-col gap-3">
+      ${renderUserMessageForm(slug)}
+      ${messages.length === 0
+        ? html`<p class="text-sm text-[var(--text-2)]">
+            Empty thread. The director will start posting here once it ticks.
+          </p>`
+        : html`<div class="flex flex-col gap-3">
+            ${messages.map((m) => renderMessage(db, slug, m))}
+          </div>`}
+    </div>
+  `;
+}
+
+function defaultVcsFactory(repo: RepoConfig): VcsProvider {
+  switch (repo.provider) {
+    case "github":
+      return new GithubVcsProvider();
+    default:
+      throw new Error(`director admin: VcsProvider for ${repo.provider} not wired`);
+  }
 }
 
 export function directorAdminRoute({ db, getConfig }: Args): Hono {
@@ -284,12 +410,7 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
 
     const chatCard = card({
       title: `Chat — ${messages.length} message(s)`,
-      body:
-        messages.length === 0
-          ? html`<p class="text-sm text-[var(--text-2)]">
-              Empty thread. The director will start posting here once it ticks.
-            </p>`
-          : html` <div class="flex flex-col gap-2">${messages.map(renderMessage)}</div> `,
+      body: renderChatThread(db, slug, messages),
     });
 
     const decisionsCard = card({
@@ -322,7 +443,9 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
                                 ? "success"
                                 : d.outcome === "failed"
                                   ? "danger"
-                                  : "neutral",
+                                  : d.outcome === "rejected"
+                                    ? "warning"
+                                    : "neutral",
                           })}
                         </td>
                         <td>${d.charterVersion ? `v${d.charterVersion}` : "—"}</td>
@@ -353,6 +476,85 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
         ],
       }),
     );
+  });
+
+  // ── POST /:slug/messages — user posts a directive/answer/veto ─────────
+  app.post("/:slug/messages", async (c) => {
+    const slug = c.req.param("slug");
+    const entries = listEntries(db, getConfig);
+    const entry = entries.find((e) => e.slug === slug);
+    if (!entry) return c.notFound();
+
+    const form = await c.req.parseBody();
+    const type = String(form.type ?? "directive");
+    const body = String(form.body ?? "").trim();
+    if (!body) return c.html(raw("body required"), 400);
+    if (!["directive", "answer", "veto"].includes(type)) {
+      return c.html(raw("invalid type"), 400);
+    }
+
+    appendMessage(db, {
+      repoId: entry.repoId,
+      role: "user",
+      type: type as "directive" | "answer" | "veto",
+      body,
+      metadata: { repo: slug, actor: "admin" },
+    });
+
+    const messages = recentMessages(db, entry.repoId, 100);
+    return c.html(renderChatThread(db, slug, messages));
+  });
+
+  // ── POST /:slug/decisions/:id/approve — execute a pending decision ────
+  app.post("/:slug/decisions/:id/approve", async (c) => {
+    const slug = c.req.param("slug");
+    const decisionId = Number(c.req.param("id"));
+    const entries = listEntries(db, getConfig);
+    const entry = entries.find((e) => e.slug === slug);
+    if (!entry) return c.notFound();
+
+    const config = getConfig();
+    const repo = config.repos.find((r) => repoKey(r) === slug);
+    if (!repo || !repo.director) return c.notFound();
+
+    await approveDecision({
+      db,
+      decisionId,
+      repo,
+      director: repo.director,
+      actor: "admin",
+      getVcs: () => defaultVcsFactory(repo),
+    });
+
+    const messages = recentMessages(db, entry.repoId, 100);
+    return c.html(renderChatThread(db, slug, messages));
+  });
+
+  // ── POST /:slug/decisions/:id/reject — record reject + reason ─────────
+  app.post("/:slug/decisions/:id/reject", async (c) => {
+    const slug = c.req.param("slug");
+    const decisionId = Number(c.req.param("id"));
+    const entries = listEntries(db, getConfig);
+    const entry = entries.find((e) => e.slug === slug);
+    if (!entry) return c.notFound();
+
+    const config = getConfig();
+    const repo = config.repos.find((r) => repoKey(r) === slug);
+    if (!repo) return c.notFound();
+
+    const form = await c.req.parseBody();
+    const reason = String(form.reason ?? "").trim() || undefined;
+
+    rejectDecision({
+      db,
+      decisionId,
+      repo,
+      actor: "admin",
+      reason,
+    });
+
+    const messages = recentMessages(db, entry.repoId, 100);
+    return c.html(renderChatThread(db, slug, messages));
   });
 
   return app;

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -21,7 +21,7 @@ import { Hono } from "hono";
 import type { Db } from "../storage/db.js";
 import type { RuntimeConfig } from "../config/schema.js";
 import { repoKey, type RepoConfig } from "../config/schema.js";
-import { html, isHtmx, page, raw, t as time, type TrustedHtml } from "./layout.js";
+import { html, isHtmx, page, t as time, type TrustedHtml } from "./layout.js";
 import { card } from "./components/card.js";
 import { badge, type BadgeTone } from "./components/badge.js";
 import { appendMessage, recentMessages } from "../director/chat.js";
@@ -488,9 +488,9 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
     const form = await c.req.parseBody();
     const type = String(form.type ?? "directive");
     const body = String(form.body ?? "").trim();
-    if (!body) return c.html(raw("body required"), 400);
+    if (!body) return c.html("body required", 400);
     if (!["directive", "answer", "veto"].includes(type)) {
-      return c.html(raw("invalid type"), 400);
+      return c.html("invalid type", 400);
     }
 
     appendMessage(db, {
@@ -502,7 +502,7 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
     });
 
     const messages = recentMessages(db, entry.repoId, 100);
-    return c.html(renderChatThread(db, slug, messages));
+    return c.html(renderChatThread(db, slug, messages).value);
   });
 
   // ── POST /:slug/decisions/:id/approve — execute a pending decision ────
@@ -527,7 +527,7 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
     });
 
     const messages = recentMessages(db, entry.repoId, 100);
-    return c.html(renderChatThread(db, slug, messages));
+    return c.html(renderChatThread(db, slug, messages).value);
   });
 
   // ── POST /:slug/decisions/:id/reject — record reject + reason ─────────
@@ -554,7 +554,7 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
     });
 
     const messages = recentMessages(db, entry.repoId, 100);
-    return c.html(renderChatThread(db, slug, messages));
+    return c.html(renderChatThread(db, slug, messages).value);
   });
 
   return app;

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -110,9 +110,9 @@ function messageTypeBadgeTone(type: MessageType): BadgeTone {
 // approve/reject buttons.
 function decisionStillPending(db: Db, decisionId: number | null): boolean {
   if (decisionId == null) return false;
-  const row = db
-    .prepare(`SELECT outcome FROM director_decisions WHERE id = ?`)
-    .get(decisionId) as { outcome: string } | undefined;
+  const row = db.prepare(`SELECT outcome FROM director_decisions WHERE id = ?`).get(decisionId) as
+    | { outcome: string }
+    | undefined;
   return row?.outcome === "pending";
 }
 
@@ -127,8 +127,7 @@ function renderMessage(db: Db, slug: string, m: DirectorMessage): TrustedHtml {
       : "bg-[var(--surface-3)]";
   const speaker = isDirector ? "👔 director" : isUser ? "👤 you" : "⚙️ system";
 
-  const isLiveProposal =
-    m.type === "proposal" && decisionStillPending(db, m.decisionId);
+  const isLiveProposal = m.type === "proposal" && decisionStillPending(db, m.decisionId);
 
   return html`
     <div class="flex flex-col gap-1 max-w-[80ch] ${align}">
@@ -142,9 +141,7 @@ function renderMessage(db: Db, slug: string, m: DirectorMessage): TrustedHtml {
       >
         ${m.body}
       </div>
-      ${isLiveProposal && m.decisionId
-        ? renderProposalActions(slug, m.decisionId)
-        : ""}
+      ${isLiveProposal && m.decisionId ? renderProposalActions(slug, m.decisionId) : ""}
     </div>
   `;
 }
@@ -213,11 +210,7 @@ function renderUserMessageForm(slug: string): TrustedHtml {
   `;
 }
 
-function renderChatThread(
-  db: Db,
-  slug: string,
-  messages: DirectorMessage[],
-): TrustedHtml {
+function renderChatThread(db: Db, slug: string, messages: DirectorMessage[]): TrustedHtml {
   return html`
     <div id="chat-thread" class="flex flex-col gap-3">
       ${renderUserMessageForm(slug)}

--- a/test/director-approval.test.mjs
+++ b/test/director-approval.test.mjs
@@ -1,0 +1,328 @@
+// Tests for human approve/reject of pending director decisions.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import { runTick } from "../dist/director/tick.js";
+import { approveDecision, rejectDecision } from "../dist/director/executor.js";
+import { recentDecisions, getDecisionById } from "../dist/director/decisions.js";
+import { recentMessages } from "../dist/director/chat.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-approval-test-"));
+  const db = initDb(dir);
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+const cleanup = (dir) => rmSync(dir, { recursive: true, force: true });
+
+const charter = {
+  vision: "Test charter for approval tests.",
+  priorities: [{ id: "rel", weight: 1.0, rubric: "reliability" }],
+  out_of_bounds: [],
+  out_of_bounds_paths: [],
+  definition_of_done: [],
+};
+
+const baseBudget = {
+  initial_daily_usd: 2.0,
+  initial_weekly_usd: 10.0,
+  max_daily_usd: 10.0,
+  max_weekly_usd: 50.0,
+  think_daily_usd: 1.0,
+  pause_on_failure_streak: 3,
+  good_outcome_quarantine_days: 7,
+};
+
+const fullAuthority = {
+  can_create_issues: true,
+  can_label: true,
+  can_close_issues: true,
+  can_comment: true,
+  can_approve_pr: true,
+  can_merge: true,
+  can_modify_charter: true,
+};
+
+function director(mode, overrides = {}) {
+  return {
+    enabled: true,
+    mode,
+    cadence_hours: 6,
+    bot_prefix: "👔 director:",
+    charter,
+    budget: baseBudget,
+    authority: { ...fullAuthority, ...(overrides.authority ?? {}) },
+  };
+}
+
+const repo = (d) => ({
+  provider: "github",
+  owner: "openronin",
+  name: "openronin",
+  watched: true,
+  lanes: ["triage"],
+  director: d,
+});
+
+function mockEngine(decisions) {
+  return () => ({
+    id: "mock",
+    defaultModel: "mock",
+    async run() {
+      const json = {
+        observations: "Project state stable, nothing pressing surfaces in this snapshot.",
+        reasoning: "Routine planning per charter priority rel; one proposal worth queueing.",
+        decisions,
+      };
+      return {
+        content: JSON.stringify(json),
+        json,
+        usage: { tokensIn: 1000, tokensOut: 200, costUsd: 0.001 },
+        finishReason: "end_turn",
+        durationMs: 100,
+      };
+    },
+  });
+}
+
+function mockVcs() {
+  const calls = [];
+  return {
+    calls,
+    provider: {
+      id: "mock-vcs",
+      listOpenItems: async function* () {},
+      async getItem() {
+        throw new Error("not used");
+      },
+      async postComment(_r, n, b) {
+        calls.push({ method: "postComment", n, b });
+        return { id: "c1", url: `https://gh/c/${n}` };
+      },
+      async updateComment() {},
+      async closeItem(_r, n) {
+        calls.push({ method: "closeItem", n });
+      },
+      async listAllPrFeedback() {
+        return [];
+      },
+      verifyWebhookSignature() {
+        return true;
+      },
+      async createIssue(_r, args) {
+        calls.push({ method: "createIssue", ...args });
+        return { number: 777, url: "https://gh/issues/777" };
+      },
+      async addLabels(_r, n, l) {
+        calls.push({ method: "addLabels", n, l });
+      },
+      async removeLabels(_r, n, l) {
+        calls.push({ method: "removeLabels", n, l });
+      },
+      async approvePullRequest(_r, n, b) {
+        calls.push({ method: "approvePullRequest", n, b });
+      },
+      async mergePullRequest(_r, n, s) {
+        calls.push({ method: "mergePullRequest", n, s });
+        return { merged: true, sha: "abc" };
+      },
+    },
+  };
+}
+
+async function runProposeTick(db, repoId, dir) {
+  return runTick({
+    db,
+    repoId,
+    repo: repo(director("propose")),
+    director: director("propose"),
+    dataDir: dir,
+    engineFactory: mockEngine([
+      {
+        type: "create_issue",
+        rationale: "needed to address an observability gap noticed this tick",
+        payload: {
+          title: "Add /metrics endpoint with cost_usd_total",
+          body: "## Problem\n\nNo metric.\n\n## Acceptance\n- [ ] /metrics emits cost",
+          labels: ["openronin:do-it"],
+          priority: "normal",
+        },
+      },
+    ]),
+    vcsFactory: () => ({}),
+  });
+}
+
+test("approveDecision: pending → executed, VCS called once, report in chat", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runProposeTick(db, repoId, dir);
+    const ds = recentDecisions(db, repoId, 5);
+    const pending = ds.find((d) => d.outcome === "pending");
+    assert.ok(pending, "tick should produce one pending decision");
+
+    const result = await approveDecision({
+      db,
+      decisionId: pending.id,
+      repo: repo(director("propose")),
+      director: director("propose"),
+      actor: "test",
+      getVcs: () => vcs.provider,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.outcome, "executed");
+
+    const after = getDecisionById(db, pending.id);
+    assert.equal(after.outcome, "executed");
+    assert.match(after.outcomeDetails, /issue #777/);
+
+    assert.equal(vcs.calls.filter((c) => c.method === "createIssue").length, 1);
+
+    const msgs = recentMessages(db, repoId, 20);
+    const userAck = msgs.find((m) => m.role === "user" && m.body.includes("Approved"));
+    const report = msgs.find((m) => m.type === "report");
+    assert.ok(userAck);
+    assert.ok(report);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("rejectDecision: pending → rejected, no VCS, veto in chat", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runProposeTick(db, repoId, dir);
+    const pending = recentDecisions(db, repoId, 5).find((d) => d.outcome === "pending");
+
+    rejectDecision({
+      db,
+      decisionId: pending.id,
+      repo: repo(director("propose")),
+      actor: "test",
+      reason: "not aligned with current sprint",
+    });
+
+    const after = getDecisionById(db, pending.id);
+    assert.equal(after.outcome, "rejected");
+    assert.match(after.outcomeDetails, /not aligned/);
+    assert.equal(vcs.calls.length, 0);
+
+    const veto = recentMessages(db, repoId, 20).find((m) => m.type === "veto");
+    assert.ok(veto);
+    assert.match(veto.body, /Rejected/);
+    assert.match(veto.body, /not aligned/);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("approveDecision: re-checks authority — flipping can_create_issues=false → skipped", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runProposeTick(db, repoId, dir);
+    const pending = recentDecisions(db, repoId, 5).find((d) => d.outcome === "pending");
+
+    // Operator revoked authority between proposal and approval.
+    const downgradedDirector = director("propose", {
+      authority: { can_create_issues: false },
+    });
+
+    const result = await approveDecision({
+      db,
+      decisionId: pending.id,
+      repo: repo(downgradedDirector),
+      director: downgradedDirector,
+      actor: "test",
+      getVcs: () => vcs.provider,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.outcome, "skipped");
+
+    const after = getDecisionById(db, pending.id);
+    assert.equal(after.outcome, "skipped");
+    assert.equal(vcs.calls.length, 0, "no VCS calls when gated");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("approveDecision: rejects double-approval (already executed)", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runProposeTick(db, repoId, dir);
+    const pending = recentDecisions(db, repoId, 5).find((d) => d.outcome === "pending");
+
+    const first = await approveDecision({
+      db,
+      decisionId: pending.id,
+      repo: repo(director("propose")),
+      director: director("propose"),
+      actor: "test",
+      getVcs: () => vcs.provider,
+    });
+    assert.equal(first.outcome, "executed");
+
+    const second = await approveDecision({
+      db,
+      decisionId: pending.id,
+      repo: repo(director("propose")),
+      director: director("propose"),
+      actor: "test",
+      getVcs: () => vcs.provider,
+    });
+    assert.equal(second.ok, false);
+    assert.match(second.reason, /not pending/);
+
+    assert.equal(
+      vcs.calls.filter((c) => c.method === "createIssue").length,
+      1,
+      "VCS call must run only once",
+    );
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("rejectDecision: rejects on already-executed (not pending)", async () => {
+  const { db, dir, repoId } = freshDb();
+  const vcs = mockVcs();
+  try {
+    await runProposeTick(db, repoId, dir);
+    const pending = recentDecisions(db, repoId, 5).find((d) => d.outcome === "pending");
+
+    await approveDecision({
+      db,
+      decisionId: pending.id,
+      repo: repo(director("propose")),
+      director: director("propose"),
+      actor: "test",
+      getVcs: () => vcs.provider,
+    });
+
+    const result = rejectDecision({
+      db,
+      decisionId: pending.id,
+      repo: repo(director("propose")),
+      actor: "test",
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.reason, /not pending/);
+  } finally {
+    cleanup(dir);
+  }
+});


### PR DESCRIPTION
## Summary

Plan-PR #3b — the human-feedback half of the propose/semi_auto loop. With #3a (execution backend), pending decisions piled up in chat with a hint to approve them — but there was no way to actually approve. This PR adds three POST endpoints + HTMX UI to make it work.

## What's new

- **Three POST routes on \`/admin/director/:slug\`**:
  - \`POST /messages\` — operator posts \`directive\`/\`answer\`/\`veto\` user-role messages.
  - \`POST /decisions/:id/approve\` — re-runs authority gate, executes via \`VcsProvider\`, flips outcome \`pending → executed\`/\`failed\`/\`skipped\`.
  - \`POST /decisions/:id/reject\` — flips \`pending → rejected\` with optional reason.
- **HTMX UI**: pending proposal bubbles grow inline \`[✓ Approve]\` / \`[✗ Reject]\` buttons. A directive/answer/veto form sits at the top of the thread. All swaps are partial — no page reload.
- **\`approveDecision()\` / \`rejectDecision()\`** exported from \`src/director/executor.ts\` so the upcoming Telegram bridge (#4) reuses the same code path.
- **\`getDecisionById()\`** added to the decisions data layer.

## Tests added

5 new tests in \`test/director-approval.test.mjs\`:

- approve: pending → executed, VCS called once, report posted to chat
- reject: pending → rejected, no VCS, veto recorded
- approve re-checks authority (operator flipping \`can_*\` mid-flight → skipped)
- double-approve guard (already executed → returns ok=false, VCS called only once)
- reject after execute (already executed → returns ok=false)

Total: 85 unit tests, 0 fail, 0 lint, format clean.

## Operational

- Production currently in \`propose\` mode on openronin/openronin (decision #25 sits pending right now, will be approvable after this lands).
- After merge: deploy fires, \`openronin\` restarts, \`openronin-director\` needs separate \`systemctl restart\`.

## Test plan

- [x] \`pnpm run check\` green
- [ ] After merge: open \`/admin/director/github--openronin--openronin\`, click Approve on decision #25, observe issue created on github + outcome=executed in chat