### PR TITLE
feat(director): Telegram bridge — mirror chat + management commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,9 +86,12 @@ TELEGRAM_BOT_TOKEN=
 
 # Telegram bridge for the director's chat thread. Different bot from the
 # tracker provider's TELEGRAM_BOT_TOKEN above. Get token from @BotFather.
-# Authorized user IDs go in $OPENRONIN_DATA_DIR/config/director.yaml,
-# never in this file.
 # OPENRONIN_DIRECTOR_TELEGRAM_TOKEN=
+
+# Comma-separated list of Telegram user_ids allowed to interact with the
+# bridge. The bridge refuses to start if the token is set but this is empty —
+# it would otherwise accept commands from anyone.
+# OPENRONIN_DIRECTOR_TELEGRAM_USER_IDS=12345,67890
 
 # Engine the director uses for its planning tick. Auto-detected by default:
 # anthropic if ANTHROPIC_API_KEY is set, else mimo if XIAOMI_MIMO_API_KEY is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to **openronin** are documented here. The format follows [Ke
 
 ## [Unreleased]
 
+### Added — director: Telegram bridge
+
+The director's chat thread now mirrors to Telegram for whitelisted users, and accepts management commands back. Lets an operator approve / reject / pause / resume from a phone without opening the admin UI.
+
+- **Outbound mirror.** Each new `director_messages` row with `role='director'|'system'` is forwarded to every whitelisted Telegram chat, with a `/approve <id> · /reject <id>` reminder appended to proposals.
+- **Inbound commands** (whitelist enforced):
+  - `/repos`, `/status`, `/budget`, `/pending`, `/help`
+  - `/approve <id>`, `/reject <id> [reason]` — same code path as the admin UI buttons (reuses `approveDecision()` / `rejectDecision()`)
+  - `/pause <slug>`, `/resume <slug>`
+- **Free text** from a whitelisted user is recorded as a `directive`-typed user message. Prefix with `repo:<slug> -- ` to target a specific repo when several are director-enabled.
+- Configured via `OPENRONIN_DIRECTOR_TELEGRAM_TOKEN` (separate bot from the tracker provider's `TELEGRAM_BOT_TOKEN`) and `OPENRONIN_DIRECTOR_TELEGRAM_USER_IDS=12345,67890`. Bridge refuses to start if token is set but whitelist is empty.
+- Runs in-process inside `openronin-director.service` alongside the tick loop. Two background async tasks: long-poll for inbound updates, 5s-interval mirror of new director messages outbound.
+- 6 tests with mocked `fetch()` cover incoming directive, /approve, /reject, /pending, /pause+/resume, and unauthorized-user filter.
+
+
 ### Added — director: two-way admin chat (approve/reject + user messages)
 
 The `/admin/director/<slug>` page is no longer read-only. Three new POST endpoints make it a control surface:

--- a/src/director/index.ts
+++ b/src/director/index.ts
@@ -147,6 +147,15 @@ export async function runDirectorService(): Promise<void> {
   process.on("SIGTERM", () => onSignal("SIGTERM"));
   process.on("SIGINT", () => onSignal("SIGINT"));
 
+  // Telegram bridge — opt-in via env, no-op if not configured.
+  const { startDirectorTelegramBridgeIfConfigured } = await import("./telegram.js");
+  const tgBridge = startDirectorTelegramBridgeIfConfigured(db, () => config);
+  if (tgBridge) {
+    // Wire SIGTERM to stop the bridge so it stops polling promptly.
+    process.on("SIGTERM", () => tgBridge.stop());
+    process.on("SIGINT", () => tgBridge.stop());
+  }
+
   // eslint-disable-next-line no-console
   console.log(
     `[director] started (pid ${process.pid}); ${listDirectorEnabledRepos(db, config).length} enabled repo(s); ` +

--- a/src/director/telegram.ts
+++ b/src/director/telegram.ts
@@ -1,0 +1,563 @@
+// Director Telegram bridge.
+//
+// Mirrors the director's chat thread to Telegram for one or more whitelisted
+// users, and accepts commands back. Runs in-process inside the
+// openronin-director service alongside the tick loop.
+//
+// Outbound (director → telegram):
+//   • Every new `director_messages` row with role='director' or role='system'
+//     gets pushed to each whitelisted Telegram chat.
+//   • A pending proposal is sent with a reminder ("approve via /approve <id>").
+//
+// Inbound (telegram → director):
+//   • Plain text from a whitelisted user → recorded as a user-role
+//     `directive` message in the chat (the next tick consumes it).
+//   • Slash commands (whitelist enforced):
+//       /status                — director state + last 3 messages
+//       /budget                — budget + failure-streak per repo
+//       /pending               — list pending decisions
+//       /approve <id> [text]   — approve decision, run executor
+//       /reject  <id> [text]   — reject decision
+//       /pause   <slug>        — pause director on this repo
+//       /resume  <slug>        — clear pause flag
+//       /repos                 — list director-enabled repos
+//       /help                  — usage
+//
+// Uses its own bot token (OPENRONIN_DIRECTOR_TELEGRAM_TOKEN), distinct from
+// the tracker's TELEGRAM_BOT_TOKEN — the tracker accepts task input from a
+// chat, the director listens for management commands. Whitelist via
+// OPENRONIN_DIRECTOR_TELEGRAM_USER_IDS=12345,67890.
+
+import type { Db } from "../storage/db.js";
+import type { RuntimeConfig } from "../config/schema.js";
+import { repoKey, type RepoConfig } from "../config/schema.js";
+import { appendMessage } from "./chat.js";
+import {
+  approveDecision,
+  rejectDecision,
+} from "./executor.js";
+import { ensureBudgetState, pause as pauseRepo, unpause as unpauseRepo } from "./budget.js";
+import { pendingDecisions, getDecisionById } from "./decisions.js";
+import { GithubVcsProvider } from "../providers/github.js";
+import type { VcsProvider } from "../providers/vcs.js";
+
+const POLL_TIMEOUT_S = 30;
+const MIRROR_INTERVAL_MS = 5_000;
+
+interface TelegramMessage {
+  message_id: number;
+  from?: { id: number; username?: string; first_name?: string };
+  chat: { id: number; type: string };
+  text?: string;
+  date: number;
+}
+
+interface TelegramUpdate {
+  update_id: number;
+  message?: TelegramMessage;
+}
+
+interface TelegramApiResponse<T> {
+  ok: boolean;
+  result: T;
+  description?: string;
+}
+
+export class DirectorTelegramBridge {
+  private offset = 0;
+  private lastMirroredMessageId = 0;
+  private readonly chatIds = new Set<number>();
+  private stopping = false;
+  private readonly api: string;
+
+  constructor(
+    private readonly db: Db,
+    private readonly getConfig: () => RuntimeConfig,
+    private readonly token: string,
+    private readonly allowedUserIds: number[],
+  ) {
+    this.api = `https://api.telegram.org/bot${token}`;
+  }
+
+  async start(): Promise<void> {
+    // Bootstrap mirror cursor at the highest existing director_messages id —
+    // we don't backfill historical chat on restart; new ticks pick up from
+    // here. Trade-off: simpler than persisting state, at the cost of
+    // missing messages produced while the bridge was offline.
+    const row = this.db
+      .prepare(`SELECT COALESCE(MAX(id), 0) AS m FROM director_messages`)
+      .get() as { m: number };
+    this.lastMirroredMessageId = row.m;
+    // eslint-disable-next-line no-console
+    console.log(
+      `[director-telegram] bridge starting; mirror cursor at message_id=${this.lastMirroredMessageId}; whitelist=${JSON.stringify(this.allowedUserIds)}`,
+    );
+
+    void this.runIncomingLoop();
+    void this.runMirrorLoop();
+  }
+
+  stop(): void {
+    this.stopping = true;
+  }
+
+  // ── Outbound: poll new director_messages → push to telegram ──────────
+
+  private async runMirrorLoop(): Promise<void> {
+    while (!this.stopping) {
+      try {
+        await this.mirrorOnce();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("[director-telegram] mirror error:", err);
+      }
+      await sleep(MIRROR_INTERVAL_MS);
+    }
+  }
+
+  private async mirrorOnce(): Promise<void> {
+    if (this.chatIds.size === 0) return; // no one to send to yet
+
+    const rows = this.db
+      .prepare(
+        `SELECT m.id, m.repo_id, m.role, m.type, m.body, m.decision_id,
+                r.owner, r.name
+         FROM director_messages m
+         JOIN repos r ON r.id = m.repo_id
+         WHERE m.id > ? AND m.role IN ('director','system')
+         ORDER BY m.id ASC LIMIT 20`,
+      )
+      .all(this.lastMirroredMessageId) as {
+      id: number;
+      repo_id: number;
+      role: string;
+      type: string;
+      body: string;
+      decision_id: number | null;
+      owner: string;
+      name: string;
+    }[];
+
+    for (const r of rows) {
+      const text = formatChatMessageForTelegram(r);
+      for (const chatId of this.chatIds) {
+        try {
+          await this.sendMessage(chatId, text);
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error(`[director-telegram] sendMessage to ${chatId} failed:`, err);
+        }
+      }
+      this.lastMirroredMessageId = r.id;
+    }
+  }
+
+  // ── Inbound: long-poll telegram updates ──────────────────────────────
+
+  private async runIncomingLoop(): Promise<void> {
+    while (!this.stopping) {
+      try {
+        await this.pollOnce();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("[director-telegram] poll error:", err);
+        await sleep(5_000);
+      }
+    }
+  }
+
+  private async pollOnce(): Promise<void> {
+    const url = `${this.api}/getUpdates?offset=${this.offset}&timeout=${POLL_TIMEOUT_S}&allowed_updates=%5B%22message%22%5D`;
+    const resp = await fetch(url, {
+      signal: AbortSignal.timeout((POLL_TIMEOUT_S + 10) * 1000),
+    });
+    if (!resp.ok) {
+      throw new Error(`getUpdates ${resp.status}`);
+    }
+    const data = (await resp.json()) as TelegramApiResponse<TelegramUpdate[]>;
+    if (!data.ok) throw new Error(`telegram error: ${data.description}`);
+    for (const upd of data.result) {
+      this.offset = Math.max(this.offset, upd.update_id + 1);
+      const msg = upd.message;
+      if (!msg?.text || !msg.from) continue;
+      if (!this.allowedUserIds.includes(msg.from.id)) {
+        // Silently ignore unauthorized senders. Optional: send a reply
+        // saying "not authorized", but that leaks bot existence.
+        continue;
+      }
+      // Remember this chat for mirroring future director output.
+      this.chatIds.add(msg.chat.id);
+      try {
+        await this.handleIncoming(msg);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("[director-telegram] handler error:", err);
+        await this.sendMessage(
+          msg.chat.id,
+          `❌ Internal error: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
+  private async handleIncoming(msg: TelegramMessage): Promise<void> {
+    const text = msg.text!.trim();
+    if (text.startsWith("/")) {
+      await this.handleCommand(msg, text);
+    } else {
+      await this.handleFreeText(msg, text);
+    }
+  }
+
+  // Free-form text from the user → recorded as a `directive` message on
+  // the first director-enabled repo (or all of them if multiple). The
+  // operator can scope explicitly with `/repos` then prefix in future,
+  // but for now we keep it simple.
+  private async handleFreeText(msg: TelegramMessage, text: string): Promise<void> {
+    const repos = this.directorRepos();
+    if (repos.length === 0) {
+      await this.sendMessage(msg.chat.id, "No director-enabled repos configured.");
+      return;
+    }
+    // Default to first; support `repo:slug -- text` if they want to be explicit.
+    let target = repos[0]!;
+    let body = text;
+    const m = text.match(/^repo:([^\s]+)\s+--\s+([\s\S]+)$/);
+    if (m) {
+      const explicit = repos.find((r) => repoKey(r) === m[1]);
+      if (!explicit) {
+        await this.sendMessage(msg.chat.id, `Unknown repo: ${m[1]}`);
+        return;
+      }
+      target = explicit;
+      body = m[2]!;
+    }
+
+    const repoId = this.repoIdFor(target);
+    if (repoId == null) return;
+    appendMessage(this.db, {
+      repoId,
+      role: "user",
+      type: "directive",
+      body,
+      metadata: { actor: `telegram:${msg.from?.id}`, repo: repoKey(target) },
+    });
+    await this.sendMessage(
+      msg.chat.id,
+      `✓ directive recorded on ${repoKey(target)}. Director will pick it up on next tick.`,
+    );
+  }
+
+  // Slash commands — minimal but covers the management surface.
+  private async handleCommand(msg: TelegramMessage, text: string): Promise<void> {
+    const [raw, ...args] = text.split(/\s+/);
+    const cmd = (raw ?? "").toLowerCase().split("@")[0];
+    switch (cmd) {
+      case "/start":
+      case "/help":
+        await this.sendMessage(msg.chat.id, helpText());
+        return;
+      case "/repos":
+        await this.handleRepos(msg);
+        return;
+      case "/status":
+        await this.handleStatus(msg);
+        return;
+      case "/budget":
+        await this.handleBudget(msg);
+        return;
+      case "/pending":
+        await this.handlePending(msg);
+        return;
+      case "/approve":
+        await this.handleApprove(msg, args);
+        return;
+      case "/reject":
+        await this.handleReject(msg, args);
+        return;
+      case "/pause":
+        await this.handlePause(msg, args, true);
+        return;
+      case "/resume":
+        await this.handlePause(msg, args, false);
+        return;
+      default:
+        await this.sendMessage(msg.chat.id, `Unknown command: ${raw}\n\n${helpText()}`);
+    }
+  }
+
+  // ── Command handlers ────────────────────────────────────────────────
+
+  private async handleRepos(msg: TelegramMessage): Promise<void> {
+    const repos = this.directorRepos();
+    if (repos.length === 0) {
+      await this.sendMessage(msg.chat.id, "No director-enabled repos.");
+      return;
+    }
+    const lines = repos.map((r) => `• ${repoKey(r)} — mode=${r.director?.mode}`);
+    await this.sendMessage(msg.chat.id, lines.join("\n"));
+  }
+
+  private async handleStatus(msg: TelegramMessage): Promise<void> {
+    const repos = this.directorRepos();
+    if (repos.length === 0) {
+      await this.sendMessage(msg.chat.id, "No director-enabled repos.");
+      return;
+    }
+    const lines: string[] = [];
+    for (const r of repos) {
+      const id = this.repoIdFor(r);
+      if (id == null) continue;
+      const state = ensureBudgetState(this.db, id, r.director!.budget);
+      const pending = pendingDecisions(this.db, id);
+      lines.push(
+        `*${repoKey(r)}* — mode=${r.director!.mode}, pending=${pending.length}, ` +
+          `streak=${state.failureStreak}, paused=${state.paused}, ` +
+          `today=$${state.spentTodayThinkUsd.toFixed(4)} think + $${state.spentTodayUsd.toFixed(2)} project`,
+      );
+    }
+    await this.sendMessage(msg.chat.id, lines.join("\n"));
+  }
+
+  private async handleBudget(msg: TelegramMessage): Promise<void> {
+    await this.handleStatus(msg);
+  }
+
+  private async handlePending(msg: TelegramMessage): Promise<void> {
+    const repos = this.directorRepos();
+    if (repos.length === 0) {
+      await this.sendMessage(msg.chat.id, "No director-enabled repos.");
+      return;
+    }
+    const lines: string[] = [];
+    for (const r of repos) {
+      const id = this.repoIdFor(r);
+      if (id == null) continue;
+      const ds = pendingDecisions(this.db, id);
+      if (ds.length === 0) continue;
+      lines.push(`*${repoKey(r)}*:`);
+      for (const d of ds) {
+        lines.push(
+          `  #${d.id} ${d.decisionType} — ${truncate(d.rationale, 120)}\n  /approve ${d.id}  ·  /reject ${d.id}`,
+        );
+      }
+    }
+    await this.sendMessage(
+      msg.chat.id,
+      lines.length === 0 ? "No pending decisions." : lines.join("\n"),
+    );
+  }
+
+  private async handleApprove(msg: TelegramMessage, args: string[]): Promise<void> {
+    const id = Number(args[0]);
+    if (!Number.isFinite(id)) {
+      await this.sendMessage(msg.chat.id, "Usage: /approve <decision_id>");
+      return;
+    }
+    const decision = getDecisionById(this.db, id);
+    if (!decision) {
+      await this.sendMessage(msg.chat.id, `decision #${id} not found`);
+      return;
+    }
+    const repo = this.repoForId(decision.repoId);
+    if (!repo) {
+      await this.sendMessage(msg.chat.id, `repo for decision #${id} not director-enabled`);
+      return;
+    }
+    const result = await approveDecision({
+      db: this.db,
+      decisionId: id,
+      repo,
+      director: repo.director!,
+      actor: `telegram:${msg.from?.id}`,
+      getVcs: () => this.defaultVcs(repo),
+    });
+    if (!result.ok) {
+      await this.sendMessage(msg.chat.id, `❌ ${result.reason}`);
+      return;
+    }
+    await this.sendMessage(msg.chat.id, `✓ decision #${id} → ${result.outcome}: ${result.details}`);
+  }
+
+  private async handleReject(msg: TelegramMessage, args: string[]): Promise<void> {
+    const id = Number(args[0]);
+    if (!Number.isFinite(id)) {
+      await this.sendMessage(msg.chat.id, "Usage: /reject <decision_id> [reason]");
+      return;
+    }
+    const reason = args.slice(1).join(" ").trim() || undefined;
+    const decision = getDecisionById(this.db, id);
+    if (!decision) {
+      await this.sendMessage(msg.chat.id, `decision #${id} not found`);
+      return;
+    }
+    const repo = this.repoForId(decision.repoId);
+    if (!repo) {
+      await this.sendMessage(msg.chat.id, `repo for decision #${id} not director-enabled`);
+      return;
+    }
+    const result = rejectDecision({
+      db: this.db,
+      decisionId: id,
+      repo,
+      actor: `telegram:${msg.from?.id}`,
+      reason,
+    });
+    if (!result.ok) {
+      await this.sendMessage(msg.chat.id, `❌ ${result.reason}`);
+      return;
+    }
+    await this.sendMessage(msg.chat.id, `✗ decision #${id} → rejected`);
+  }
+
+  private async handlePause(
+    msg: TelegramMessage,
+    args: string[],
+    pauseFlag: boolean,
+  ): Promise<void> {
+    const slug = args[0];
+    if (!slug) {
+      await this.sendMessage(msg.chat.id, "Usage: /pause <slug> | /resume <slug>");
+      return;
+    }
+    const repo = this.directorRepos().find((r) => repoKey(r) === slug);
+    if (!repo) {
+      await this.sendMessage(msg.chat.id, `Unknown repo: ${slug}`);
+      return;
+    }
+    const id = this.repoIdFor(repo);
+    if (id == null) return;
+    if (pauseFlag) {
+      pauseRepo(this.db, id, `manual pause via telegram by ${msg.from?.id}`);
+      await this.sendMessage(msg.chat.id, `⏸ paused ${slug}`);
+    } else {
+      unpauseRepo(this.db, id);
+      await this.sendMessage(msg.chat.id, `▶ resumed ${slug}`);
+    }
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────
+
+  private directorRepos(): RepoConfig[] {
+    return this.getConfig().repos.filter((r) => r.director?.enabled && r.director.charter);
+  }
+
+  private repoIdFor(repo: RepoConfig): number | null {
+    const row = this.db
+      .prepare(`SELECT id FROM repos WHERE provider = ? AND owner = ? AND name = ?`)
+      .get(repo.provider, repo.owner, repo.name) as { id: number } | undefined;
+    return row?.id ?? null;
+  }
+
+  private repoForId(repoId: number): RepoConfig | null {
+    const row = this.db
+      .prepare(`SELECT provider, owner, name FROM repos WHERE id = ?`)
+      .get(repoId) as { provider: string; owner: string; name: string } | undefined;
+    if (!row) return null;
+    return (
+      this.directorRepos().find(
+        (r) => r.provider === row.provider && r.owner === row.owner && r.name === row.name,
+      ) ?? null
+    );
+  }
+
+  private defaultVcs(repo: RepoConfig): VcsProvider {
+    if (repo.provider === "github") return new GithubVcsProvider();
+    throw new Error(`Telegram bridge: VcsProvider for ${repo.provider} not wired`);
+  }
+
+  private async sendMessage(chatId: number, text: string): Promise<void> {
+    const resp = await fetch(`${this.api}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text: text.slice(0, 4000), // Telegram message limit ~4096
+        parse_mode: "Markdown",
+      }),
+    });
+    if (!resp.ok) {
+      // Markdown parse errors fall through; retry without parse_mode so
+      // the user at least sees something.
+      const fallback = await fetch(`${this.api}/sendMessage`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: chatId, text: text.slice(0, 4000) }),
+      });
+      if (!fallback.ok) {
+        throw new Error(`sendMessage ${resp.status}`);
+      }
+    }
+  }
+}
+
+// ── Module-level entry point ─────────────────────────────────────────
+
+export function startDirectorTelegramBridgeIfConfigured(
+  db: Db,
+  getConfig: () => RuntimeConfig,
+): DirectorTelegramBridge | null {
+  const token = process.env.OPENRONIN_DIRECTOR_TELEGRAM_TOKEN;
+  if (!token) return null;
+  const idsEnv = process.env.OPENRONIN_DIRECTOR_TELEGRAM_USER_IDS ?? "";
+  const allowed = idsEnv
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(Number)
+    .filter((n) => Number.isFinite(n));
+  if (allowed.length === 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[director-telegram] OPENRONIN_DIRECTOR_TELEGRAM_TOKEN is set but OPENRONIN_DIRECTOR_TELEGRAM_USER_IDS is empty — refusing to start (would accept commands from anyone)",
+    );
+    return null;
+  }
+  const bridge = new DirectorTelegramBridge(db, getConfig, token, allowed);
+  void bridge.start();
+  return bridge;
+}
+
+// ── Formatting helpers ───────────────────────────────────────────────
+
+function formatChatMessageForTelegram(m: {
+  id: number;
+  role: string;
+  type: string;
+  body: string;
+  decision_id: number | null;
+  owner: string;
+  name: string;
+}): string {
+  const head = m.role === "system" ? "⚙️" : "👔";
+  const tail =
+    m.type === "proposal" && m.decision_id != null
+      ? `\n\n_/approve ${m.decision_id} · /reject ${m.decision_id}_`
+      : "";
+  return `${head} *${m.owner}/${m.name}* — _${m.type}_\n\n${m.body}${tail}`;
+}
+
+function helpText(): string {
+  return [
+    "*Director commands:*",
+    "/repos — list director-enabled repos",
+    "/status — current state per repo",
+    "/budget — budget + streaks",
+    "/pending — pending decisions awaiting approval",
+    "/approve <id> — approve a pending decision",
+    "/reject <id> [reason] — reject a pending decision",
+    "/pause <slug> — pause director on a repo",
+    "/resume <slug> — resume",
+    "/help — this message",
+    "",
+    "_Send any plain text → recorded as a directive on the first director-enabled repo. Prefix with `repo:<slug> -- ` to target a specific one._",
+  ].join("\n");
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + "…";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/director/telegram.ts
+++ b/src/director/telegram.ts
@@ -32,10 +32,7 @@ import type { Db } from "../storage/db.js";
 import type { RuntimeConfig } from "../config/schema.js";
 import { repoKey, type RepoConfig } from "../config/schema.js";
 import { appendMessage } from "./chat.js";
-import {
-  approveDecision,
-  rejectDecision,
-} from "./executor.js";
+import { approveDecision, rejectDecision } from "./executor.js";
 import { ensureBudgetState, pause as pauseRepo, unpause as unpauseRepo } from "./budget.js";
 import { pendingDecisions, getDecisionById } from "./decisions.js";
 import { GithubVcsProvider } from "../providers/github.js";

--- a/src/director/telegram.ts
+++ b/src/director/telegram.ts
@@ -427,6 +427,8 @@ export class DirectorTelegramBridge {
     }
     const id = this.repoIdFor(repo);
     if (id == null) return;
+    // ensureBudgetState first so the UPDATE in pause/unpause has a row to hit.
+    ensureBudgetState(this.db, id, repo.director!.budget);
     if (pauseFlag) {
       pauseRepo(this.db, id, `manual pause via telegram by ${msg.from?.id}`);
       await this.sendMessage(msg.chat.id, `⏸ paused ${slug}`);

--- a/test/director-telegram.test.mjs
+++ b/test/director-telegram.test.mjs
@@ -1,0 +1,361 @@
+// Tests for the Director Telegram bridge.
+//
+// We don't poll the live Telegram API in tests — we exercise the
+// command-handling logic by feeding in synthetic update objects via the
+// public class methods. The fetch() mocking here is minimal and just
+// records outbound calls so we can assert what the bridge would have sent.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import { DirectorTelegramBridge } from "../dist/director/telegram.js";
+import { runTick } from "../dist/director/tick.js";
+import { recentMessages } from "../dist/director/chat.js";
+import { recentDecisions, getDecisionById } from "../dist/director/decisions.js";
+
+const charter = {
+  vision: "Test charter for telegram bridge tests.",
+  priorities: [{ id: "rel", weight: 1.0, rubric: "reliability" }],
+  out_of_bounds: [],
+  out_of_bounds_paths: [],
+  definition_of_done: [],
+};
+const baseBudget = {
+  initial_daily_usd: 2.0,
+  initial_weekly_usd: 10.0,
+  max_daily_usd: 10.0,
+  max_weekly_usd: 50.0,
+  think_daily_usd: 1.0,
+  pause_on_failure_streak: 3,
+  good_outcome_quarantine_days: 7,
+};
+const fullAuthority = {
+  can_create_issues: true,
+  can_label: true,
+  can_close_issues: true,
+  can_comment: true,
+  can_approve_pr: true,
+  can_merge: true,
+  can_modify_charter: true,
+};
+const directorCfg = (mode = "propose") => ({
+  enabled: true,
+  mode,
+  cadence_hours: 6,
+  bot_prefix: "👔 director:",
+  charter,
+  budget: baseBudget,
+  authority: fullAuthority,
+});
+const repoCfg = (d = directorCfg()) => ({
+  provider: "github",
+  owner: "openronin",
+  name: "openronin",
+  watched: true,
+  lanes: ["triage"],
+  director: d,
+});
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-tg-test-"));
+  const db = initDb(dir);
+  const r = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github','openronin','openronin',1,'{}') RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: r.id };
+}
+const cleanup = (dir) => rmSync(dir, { recursive: true, force: true });
+
+// Patch global.fetch to capture outbound /sendMessage calls. Returns ok=true
+// for everything; the bridge handles parse-mode fallback by retrying without
+// markdown — we accept both calls.
+function captureFetch() {
+  const sent = [];
+  const original = global.fetch;
+  global.fetch = async (url, init) => {
+    sent.push({ url: String(url), body: JSON.parse(init?.body ?? "{}") });
+    return new Response(JSON.stringify({ ok: true, result: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+  return {
+    sent,
+    restore: () => {
+      global.fetch = original;
+    },
+  };
+}
+
+function bridgeWith(db, getConfig, allowed = [42]) {
+  return new DirectorTelegramBridge(db, getConfig, "fake-token", allowed);
+}
+
+function runProposeTick(db, repoId, dir) {
+  return runTick({
+    db,
+    repoId,
+    repo: repoCfg(),
+    director: directorCfg(),
+    dataDir: dir,
+    engineFactory: () => ({
+      id: "mock",
+      defaultModel: "x",
+      async run() {
+        const json = {
+          observations: "Project state stable, nothing pressing surfaces in this snapshot.",
+          reasoning: "Routine planning per charter priority rel; one proposal worth queueing.",
+          decisions: [
+            {
+              type: "create_issue",
+              rationale: "address an observability gap noticed this tick",
+              payload: {
+                title: "Add /metrics endpoint with cost_usd_total",
+                body: "## Problem\n\nNo metric.\n\n## Acceptance\n- [ ] /metrics emits cost",
+                labels: [],
+                priority: "normal",
+              },
+            },
+          ],
+        };
+        return {
+          content: JSON.stringify(json),
+          json,
+          usage: { tokensIn: 1000, tokensOut: 200, costUsd: 0.001 },
+          finishReason: "end_turn",
+          durationMs: 100,
+        };
+      },
+    }),
+    vcsFactory: () => ({}),
+  });
+}
+
+test("bridge: free-form text from authorized user → directive recorded", async () => {
+  const { db, dir, repoId } = freshDb();
+  const fetchMock = captureFetch();
+  try {
+    const bridge = bridgeWith(db, () => ({ dataDir: dir, global: {}, repos: [repoCfg()] }));
+    // synthesise an incoming Telegram update via internal handler
+    await bridge["handleIncoming"]({
+      message_id: 1,
+      from: { id: 42, username: "test" },
+      chat: { id: 100, type: "private" },
+      text: "focus on testing this week",
+      date: 0,
+    });
+    const msgs = recentMessages(db, repoId, 5);
+    const directive = msgs.find((m) => m.type === "directive");
+    assert.ok(directive);
+    assert.match(directive.body, /focus on testing/);
+    // Acknowledgement also went out via sendMessage
+    const ack = fetchMock.sent.find((s) => s.url.includes("sendMessage"));
+    assert.ok(ack);
+    assert.match(ack.body.text, /directive recorded/);
+  } finally {
+    fetchMock.restore();
+    cleanup(dir);
+  }
+});
+
+test("bridge: /approve <id> approves and reports outcome", async () => {
+  const { db, dir, repoId } = freshDb();
+  const fetchMock = captureFetch();
+  try {
+    await runProposeTick(db, repoId, dir);
+    const pending = recentDecisions(db, repoId, 5).find((d) => d.outcome === "pending");
+    assert.ok(pending);
+
+    // Provide a mock VcsProvider via overriding defaultVcs on the bridge
+    const bridge = bridgeWith(db, () => ({ dataDir: dir, global: {}, repos: [repoCfg()] }));
+    bridge["defaultVcs"] = () => ({
+      id: "mock",
+      async createIssue() {
+        return { number: 999, url: "https://gh/i/999" };
+      },
+      // unused
+      listOpenItems: async function* () {},
+      async getItem() {
+        throw new Error("x");
+      },
+      async postComment() {
+        return { id: "c", url: "u" };
+      },
+      async updateComment() {},
+      async closeItem() {},
+      async listAllPrFeedback() {
+        return [];
+      },
+      verifyWebhookSignature() {
+        return true;
+      },
+      async addLabels() {},
+      async removeLabels() {},
+      async approvePullRequest() {},
+      async mergePullRequest() {
+        return { merged: true };
+      },
+    });
+
+    await bridge["handleIncoming"]({
+      message_id: 1,
+      from: { id: 42, username: "test" },
+      chat: { id: 100, type: "private" },
+      text: `/approve ${pending.id}`,
+      date: 0,
+    });
+
+    const after = getDecisionById(db, pending.id);
+    assert.equal(after.outcome, "executed");
+    const ack = fetchMock.sent.find(
+      (s) =>
+        s.url.includes("sendMessage") &&
+        typeof s.body.text === "string" &&
+        s.body.text.includes("→ executed"),
+    );
+    assert.ok(ack);
+  } finally {
+    fetchMock.restore();
+    cleanup(dir);
+  }
+});
+
+test("bridge: /reject <id> reason", async () => {
+  const { db, dir, repoId } = freshDb();
+  const fetchMock = captureFetch();
+  try {
+    await runProposeTick(db, repoId, dir);
+    const pending = recentDecisions(db, repoId, 5).find((d) => d.outcome === "pending");
+
+    const bridge = bridgeWith(db, () => ({ dataDir: dir, global: {}, repos: [repoCfg()] }));
+    await bridge["handleIncoming"]({
+      message_id: 2,
+      from: { id: 42 },
+      chat: { id: 100, type: "private" },
+      text: `/reject ${pending.id} not aligned with sprint`,
+      date: 0,
+    });
+
+    const after = getDecisionById(db, pending.id);
+    assert.equal(after.outcome, "rejected");
+    assert.match(after.outcomeDetails, /not aligned with sprint/);
+  } finally {
+    fetchMock.restore();
+    cleanup(dir);
+  }
+});
+
+test("bridge: /pending lists pending decisions", async () => {
+  const { db, dir, repoId } = freshDb();
+  const fetchMock = captureFetch();
+  try {
+    await runProposeTick(db, repoId, dir);
+
+    const bridge = bridgeWith(db, () => ({ dataDir: dir, global: {}, repos: [repoCfg()] }));
+    await bridge["handleIncoming"]({
+      message_id: 3,
+      from: { id: 42 },
+      chat: { id: 100, type: "private" },
+      text: "/pending",
+      date: 0,
+    });
+    const reply = fetchMock.sent.find((s) => s.url.includes("sendMessage"));
+    assert.ok(reply);
+    assert.match(reply.body.text, /create_issue/);
+  } finally {
+    fetchMock.restore();
+    cleanup(dir);
+  }
+});
+
+test("bridge: /pause and /resume toggle paused flag", async () => {
+  const { db, dir, repoId } = freshDb();
+  const fetchMock = captureFetch();
+  try {
+    const bridge = bridgeWith(db, () => ({ dataDir: dir, global: {}, repos: [repoCfg()] }));
+    await bridge["handleIncoming"]({
+      message_id: 4,
+      from: { id: 42 },
+      chat: { id: 100, type: "private" },
+      text: "/pause github--openronin--openronin",
+      date: 0,
+    });
+    const paused = db
+      .prepare(`SELECT paused FROM director_budget_state WHERE repo_id = ?`)
+      .get(repoId);
+    assert.equal(paused.paused, 1);
+
+    await bridge["handleIncoming"]({
+      message_id: 5,
+      from: { id: 42 },
+      chat: { id: 100, type: "private" },
+      text: "/resume github--openronin--openronin",
+      date: 0,
+    });
+    const resumed = db
+      .prepare(`SELECT paused FROM director_budget_state WHERE repo_id = ?`)
+      .get(repoId);
+    assert.equal(resumed.paused, 0);
+  } finally {
+    fetchMock.restore();
+    cleanup(dir);
+  }
+});
+
+test("bridge: unauthorized user is ignored (no DB write, no reply)", async () => {
+  const { db, dir, repoId } = freshDb();
+  const fetchMock = captureFetch();
+  try {
+    const bridge = bridgeWith(db, () => ({ dataDir: dir, global: {}, repos: [repoCfg()] }), [42]);
+    // pollOnce uses fetch.getUpdates; call private pollOnce isn't easy.
+    // Instead, simulate via runIncomingLoop's filter by hitting pollOnce path
+    // through synthetic update.
+    // Direct unit: call handleIncoming through pollOnce shim
+    // We can't easily exercise the whitelist filter from outside the loop;
+    // instead, verify it indirectly: handleIncoming itself trusts the
+    // caller to have filtered. So we verify the filter via a fresh fetch
+    // mock returning an update from user_id=99.
+    fetchMock.restore();
+    const sent = [];
+    global.fetch = async (url, init) => {
+      const u = String(url);
+      if (u.includes("getUpdates")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            result: [
+              {
+                update_id: 1,
+                message: {
+                  message_id: 1,
+                  from: { id: 99 }, // not in whitelist
+                  chat: { id: 100, type: "private" },
+                  text: "hello",
+                  date: 0,
+                },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      sent.push({ url: u, body: JSON.parse(init?.body ?? "{}") });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+    // Trigger one poll cycle
+    await bridge["pollOnce"]();
+    const msgs = recentMessages(db, repoId, 5);
+    assert.equal(msgs.length, 0, "unauthorized user must not produce DB writes");
+    assert.equal(sent.length, 0, "no reply sent to unauthorized user");
+  } finally {
+    cleanup(dir);
+    global.fetch = fetch; // best-effort restore
+  }
+});


### PR DESCRIPTION
## Summary

Plan-PR #4. The director's chat thread mirrors to Telegram for a whitelisted user, and accepts management commands back. So you can approve a proposal from your phone instead of opening /admin/director.

## Outbound (director → Telegram)

Every new \`director_messages\` row with role='director' or 'system' is forwarded to each whitelisted Telegram chat. Pending proposals append a hint: \`/approve <id> · /reject <id>\`.

## Inbound (Telegram → director)

Slash commands (whitelist enforced):
- \`/status\` — per-repo state
- \`/budget\` — same
- \`/pending\` — list pending decisions with their IDs
- \`/approve <id>\` — same code path as the admin UI Approve button
- \`/reject <id> [reason]\` — same as Reject
- \`/pause <slug>\` / \`/resume <slug>\`
- \`/repos\`, \`/help\`

Plain text from a whitelisted user → recorded as a \`directive\`-typed message on the first director-enabled repo (or use \`repo:<slug> -- ...\` to target a specific repo).

## Configuration

Two env vars in \`director.env\`:

\`\`\`
OPENRONIN_DIRECTOR_TELEGRAM_TOKEN=<from @BotFather>
OPENRONIN_DIRECTOR_TELEGRAM_USER_IDS=12345,67890
\`\`\`

Bridge refuses to start if the token is set but the whitelist is empty (otherwise it would accept commands from anyone).

## Implementation

- New \`src/director/telegram.ts\` (~440 lines). \`DirectorTelegramBridge\` class, started by \`startDirectorTelegramBridgeIfConfigured()\` from the director service main entry.
- Two background async tasks per bridge: long-poll \`getUpdates\` for incoming, and 5s-interval scan of \`director_messages\` for outbound mirror.
- Reuses \`approveDecision()\` / \`rejectDecision()\` from \`executor.ts\` — single execution path between admin UI and Telegram.

## Tests

6 new tests (\`test/director-telegram.test.mjs\`), mock \`fetch()\` capturing outbound calls. 91 unit tests total, 0 fail, 0 lint, format clean.

## Operational

Production already has the bot token and user_id from the night-1 setup (\`/data/dev/openronin-data/director.env\`). After this merges + director restarts, the bridge will activate automatically.

## Test plan

- [x] \`pnpm run check\` green
- [ ] After merge: deploy, restart director, send /help to @openroninBot, verify response