### PR TITLE
feat(director): adaptive budget retrospective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to **openronin** are documented here. The format follows [Ke
 
 ## [Unreleased]
 
+### Added — director: adaptive budget retrospective
+
+Daily/weekly budget caps now move with the director's track record instead of staying static at the YAML-configured initial values. Once per UTC day, on the first tick of the day, `recalibrateBudget()` looks at the last 14 days of terminal decision outcomes:
+
+- **success_rate ≥ 0.80** over a meaningful sample (≥5 decisions) → caps climb 10%, capped at `max_daily_usd` / `max_weekly_usd`
+- **success_rate ≤ 0.40** → caps shrink 20%, floored at the initial values
+- **otherwise** → hold steady (no DB write, no chat message)
+
+`success_rate = executed / (executed + failed + rejected)`. `skipped` is excluded — that's an operator policy choice, not an outcome. `dry_run` and `pending` are excluded as not-yet-outcomes.
+
+Each adjustment is logged to a new `director_budget_history` table (schema migration **v13**) and surfaced as a `tick_log` chat message so the operator can see the trajectory at a glance.
+
+Caveat: this isn't a "good outcome retrospective" in the strong sense — that would require polling the VCS for revert / CI status of merged PRs over a 7-day quarantine. Out of scope here. Code documents this honestly.
+
+7 new tests cover empty samples, success-rate computation (excluding `skipped`), climb-with-ceiling, shrink-with-floor, insufficient-sample no-op, middling-rate hold-steady, history-table writes, once-per-day gating.
+
+
 ### Added — director: Telegram bridge
 
 The director's chat thread now mirrors to Telegram for whitelisted users, and accepts management commands back. Lets an operator approve / reject / pause / resume from a phone without opening the admin UI.

--- a/src/director/retrospective.ts
+++ b/src/director/retrospective.ts
@@ -1,0 +1,172 @@
+// Adaptive-budget retrospective.
+//
+// Once per UTC day (right after the day-rollover), look at the recent track
+// record of director-emitted decisions and adjust the repo's daily/weekly
+// budget caps accordingly:
+//
+//   • success_rate ≥ 0.80 over a meaningful sample → climb 10% (cap at max)
+//   • success_rate ≤ 0.40 over a meaningful sample → shrink 20% (floor at initial)
+//   • otherwise hold steady
+//
+// Sample = decisions in the last 14 days with terminal outcomes (executed,
+// failed, rejected, skipped). dry_run / pending don't count — they aren't
+// outcomes yet.
+//
+// "Success" = `executed`. `failed` and `rejected` are negative. `skipped`
+// is neutral (it just means the operator didn't unlock that decision type).
+//
+// Trade-off: this isn't a "good outcome retrospective" in the strong sense
+// (we'd need to look at whether merged PRs stuck around for 7 days without
+// being reverted). Doing that requires polling the VCS for revert / CI
+// state per merge over a week — out of scope for this version. The current
+// model is honest about its limits and writes its reasoning to chat.
+
+import type { Db } from "../storage/db.js";
+import type { BudgetConfig } from "./types.js";
+
+const WINDOW_DAYS = 14;
+const MIN_SAMPLE_SIZE = 5;
+const CLIMB_THRESHOLD = 0.8;
+const SHRINK_THRESHOLD = 0.4;
+const CLIMB_FACTOR = 1.1;
+const SHRINK_FACTOR = 0.8;
+
+export type RetroSample = {
+  windowDays: number;
+  total: number;
+  executed: number;
+  failed: number;
+  rejected: number;
+  skipped: number;
+  // Computed: success_rate = executed / (executed + failed + rejected).
+  // skipped excluded (operator policy, not outcome).
+  successRate: number | null;
+};
+
+export type RetroResult = {
+  sample: RetroSample;
+  oldDaily: number;
+  newDaily: number;
+  oldWeekly: number;
+  newWeekly: number;
+  reason: string;
+};
+
+export function sampleRecentOutcomes(db: Db, repoId: number): RetroSample {
+  const row = db
+    .prepare(
+      `SELECT
+         SUM(CASE WHEN outcome = 'executed' THEN 1 ELSE 0 END) AS executed,
+         SUM(CASE WHEN outcome = 'failed'   THEN 1 ELSE 0 END) AS failed,
+         SUM(CASE WHEN outcome = 'rejected' THEN 1 ELSE 0 END) AS rejected,
+         SUM(CASE WHEN outcome = 'skipped'  THEN 1 ELSE 0 END) AS skipped,
+         COUNT(*) AS total
+       FROM director_decisions
+       WHERE repo_id = ?
+         AND ts > datetime('now', '-' || ? || ' days')
+         AND outcome IN ('executed','failed','rejected','skipped')`,
+    )
+    .get(repoId, WINDOW_DAYS) as
+    | {
+        executed: number | null;
+        failed: number | null;
+        rejected: number | null;
+        skipped: number | null;
+        total: number;
+      }
+    | undefined;
+  const executed = row?.executed ?? 0;
+  const failed = row?.failed ?? 0;
+  const rejected = row?.rejected ?? 0;
+  const skipped = row?.skipped ?? 0;
+  const total = row?.total ?? 0;
+  const counted = executed + failed + rejected; // skipped excluded
+  const successRate = counted > 0 ? executed / counted : null;
+  return { windowDays: WINDOW_DAYS, total, executed, failed, rejected, skipped, successRate };
+}
+
+export function recalibrateBudget(
+  db: Db,
+  repoId: number,
+  cfg: BudgetConfig,
+): RetroResult | null {
+  const sample = sampleRecentOutcomes(db, repoId);
+
+  // Read current caps.
+  const cur = db
+    .prepare(
+      `SELECT daily_cap_usd, weekly_cap_usd FROM director_budget_state WHERE repo_id = ?`,
+    )
+    .get(repoId) as { daily_cap_usd: number; weekly_cap_usd: number } | undefined;
+  if (!cur) return null;
+
+  const oldDaily = cur.daily_cap_usd;
+  const oldWeekly = cur.weekly_cap_usd;
+
+  // Don't move the caps until we have enough signal.
+  if (sample.executed + sample.failed + sample.rejected < MIN_SAMPLE_SIZE) {
+    return null;
+  }
+
+  const rate = sample.successRate ?? 0;
+  let factor = 1;
+  let reason = "no change";
+  if (rate >= CLIMB_THRESHOLD) {
+    factor = CLIMB_FACTOR;
+    reason = `climb (success_rate ${(rate * 100).toFixed(0)}% over ${sample.executed + sample.failed + sample.rejected} decisions)`;
+  } else if (rate <= SHRINK_THRESHOLD) {
+    factor = SHRINK_FACTOR;
+    reason = `shrink (success_rate ${(rate * 100).toFixed(0)}% over ${sample.executed + sample.failed + sample.rejected} decisions)`;
+  } else {
+    return null; // hold steady
+  }
+
+  const newDaily = clamp(oldDaily * factor, cfg.initial_daily_usd, cfg.max_daily_usd);
+  const newWeekly = clamp(oldWeekly * factor, cfg.initial_weekly_usd, cfg.max_weekly_usd);
+
+  // No-op if floor/ceiling kept us at the same number.
+  if (Math.abs(newDaily - oldDaily) < 0.005 && Math.abs(newWeekly - oldWeekly) < 0.005) {
+    return null;
+  }
+
+  db.prepare(
+    `UPDATE director_budget_state
+     SET daily_cap_usd = ?, weekly_cap_usd = ?, updated_at = datetime('now')
+     WHERE repo_id = ?`,
+  ).run(newDaily, newWeekly, repoId);
+
+  db.prepare(
+    `INSERT INTO director_budget_history
+       (repo_id, old_daily_cap, new_daily_cap, old_weekly_cap, new_weekly_cap,
+        success_rate, sample_size, reason)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    repoId,
+    oldDaily,
+    newDaily,
+    oldWeekly,
+    newWeekly,
+    sample.successRate,
+    sample.executed + sample.failed + sample.rejected,
+    reason,
+  );
+
+  return { sample, oldDaily, newDaily, oldWeekly, newWeekly, reason };
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+// Was the last recalibration on a different UTC day from now? If yes, we
+// should run again. We piggyback on `last_reset_day` from
+// `director_budget_state` so we don't need a separate column.
+export function shouldRecalibrateToday(db: Db, repoId: number): boolean {
+  const row = db
+    .prepare(
+      `SELECT MAX(date(ts)) AS last_day FROM director_budget_history WHERE repo_id = ?`,
+    )
+    .get(repoId) as { last_day: string | null } | undefined;
+  const today = new Date().toISOString().slice(0, 10);
+  return !row?.last_day || row.last_day < today;
+}

--- a/src/director/retrospective.ts
+++ b/src/director/retrospective.ts
@@ -85,18 +85,12 @@ export function sampleRecentOutcomes(db: Db, repoId: number): RetroSample {
   return { windowDays: WINDOW_DAYS, total, executed, failed, rejected, skipped, successRate };
 }
 
-export function recalibrateBudget(
-  db: Db,
-  repoId: number,
-  cfg: BudgetConfig,
-): RetroResult | null {
+export function recalibrateBudget(db: Db, repoId: number, cfg: BudgetConfig): RetroResult | null {
   const sample = sampleRecentOutcomes(db, repoId);
 
   // Read current caps.
   const cur = db
-    .prepare(
-      `SELECT daily_cap_usd, weekly_cap_usd FROM director_budget_state WHERE repo_id = ?`,
-    )
+    .prepare(`SELECT daily_cap_usd, weekly_cap_usd FROM director_budget_state WHERE repo_id = ?`)
     .get(repoId) as { daily_cap_usd: number; weekly_cap_usd: number } | undefined;
   if (!cur) return null;
 
@@ -163,9 +157,7 @@ function clamp(v: number, lo: number, hi: number): number {
 // `director_budget_state` so we don't need a separate column.
 export function shouldRecalibrateToday(db: Db, repoId: number): boolean {
   const row = db
-    .prepare(
-      `SELECT MAX(date(ts)) AS last_day FROM director_budget_history WHERE repo_id = ?`,
-    )
+    .prepare(`SELECT MAX(date(ts)) AS last_day FROM director_budget_history WHERE repo_id = ?`)
     .get(repoId) as { last_day: string | null } | undefined;
   const today = new Date().toISOString().slice(0, 10);
   return !row?.last_day || row.last_day < today;

--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -36,6 +36,7 @@ import {
 import { recordDecision } from "./decisions.js";
 import { captureStateSnapshot } from "./state.js";
 import { composePrompt } from "./prompt.js";
+import { recalibrateBudget, shouldRecalibrateToday } from "./retrospective.js";
 import { parseTickOutput, type ParsedDecision, type TickOutput } from "./decision-schema.js";
 import { executeDecision } from "./executor.js";
 import { GithubVcsProvider } from "../providers/github.js";
@@ -75,6 +76,34 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
   }
 
   rolloverDayIfNeeded(db, repoId);
+  ensureBudgetState(db, repoId, director.budget);
+
+  // Once per UTC day, recalibrate the budget caps based on recent outcomes.
+  // This runs BEFORE the gate check below so a freshly-shrunk cap can
+  // immediately throttle the day.
+  if (shouldRecalibrateToday(db, repoId)) {
+    const retro = recalibrateBudget(db, repoId, director.budget);
+    if (retro) {
+      appendMessage(db, {
+        repoId,
+        role: "system",
+        type: "tick_log",
+        body:
+          `budget recalibrated: daily $${retro.oldDaily.toFixed(2)} → $${retro.newDaily.toFixed(2)}, ` +
+          `weekly $${retro.oldWeekly.toFixed(2)} → $${retro.newWeekly.toFixed(2)} (${retro.reason})`,
+        metadata: {
+          repo: repoKey(repo),
+          oldDaily: retro.oldDaily,
+          newDaily: retro.newDaily,
+          oldWeekly: retro.oldWeekly,
+          newWeekly: retro.newWeekly,
+          successRate: retro.sample.successRate,
+          sampleSize: retro.sample.executed + retro.sample.failed + retro.sample.rejected,
+        },
+      });
+    }
+  }
+
   const budget = ensureBudgetState(db, repoId, director.budget);
   const gate = checkBudgetGate(budget, director.budget);
   if (!gate.ok) {

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -293,4 +293,30 @@ function applyMigrations(db: Db): void {
       "INSERT INTO schema_version (version, applied_at) VALUES (12, datetime('now'))",
     ).run();
   }
+
+  // v13 — Director adaptive-budget retrospective. Each adjustment to a
+  // repo's daily/weekly cap is logged here so the operator sees the
+  // trajectory in the admin UI and the LLM can read it back as part of
+  // state on subsequent ticks.
+  if (current < 13) {
+    db.exec(`
+      CREATE TABLE director_budget_history (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        repo_id INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+        ts TEXT NOT NULL DEFAULT (datetime('now')),
+        old_daily_cap REAL NOT NULL,
+        new_daily_cap REAL NOT NULL,
+        old_weekly_cap REAL NOT NULL,
+        new_weekly_cap REAL NOT NULL,
+        success_rate REAL,
+        sample_size INTEGER,
+        reason TEXT NOT NULL
+      );
+      CREATE INDEX idx_director_budget_history_repo_ts
+        ON director_budget_history(repo_id, ts DESC);
+    `);
+    db.prepare(
+      "INSERT INTO schema_version (version, applied_at) VALUES (13, datetime('now'))",
+    ).run();
+  }
 }

--- a/test/director-retrospective.test.mjs
+++ b/test/director-retrospective.test.mjs
@@ -180,9 +180,7 @@ test("recalibrate writes to budget history table", () => {
       "failed",
     ]);
     recalibrateBudget(db, repoId, cfg);
-    const hist = db
-      .prepare(`SELECT * FROM director_budget_history WHERE repo_id = ?`)
-      .all(repoId);
+    const hist = db.prepare(`SELECT * FROM director_budget_history WHERE repo_id = ?`).all(repoId);
     assert.equal(hist.length, 1);
     assert.match(hist[0].reason, /climb/);
   } finally {
@@ -203,11 +201,7 @@ test("shouldRecalibrateToday: true on first call, false right after", () => {
       "failed",
     ]);
     recalibrateBudget(db, repoId, cfg);
-    assert.equal(
-      shouldRecalibrateToday(db, repoId),
-      false,
-      "second call same day should not",
-    );
+    assert.equal(shouldRecalibrateToday(db, repoId), false, "second call same day should not");
   } finally {
     cleanup(dir);
   }

--- a/test/director-retrospective.test.mjs
+++ b/test/director-retrospective.test.mjs
@@ -1,0 +1,214 @@
+// Tests for the adaptive-budget retrospective.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import {
+  recalibrateBudget,
+  sampleRecentOutcomes,
+  shouldRecalibrateToday,
+} from "../dist/director/retrospective.js";
+import { ensureBudgetState } from "../dist/director/budget.js";
+import { recordDecision, setDecisionOutcome } from "../dist/director/decisions.js";
+
+const cfg = {
+  initial_daily_usd: 2.0,
+  initial_weekly_usd: 10.0,
+  max_daily_usd: 10.0,
+  max_weekly_usd: 50.0,
+  think_daily_usd: 1.0,
+  pause_on_failure_streak: 3,
+  good_outcome_quarantine_days: 7,
+};
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-retro-test-"));
+  const db = initDb(dir);
+  const r = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github','o','o',1,'{}') RETURNING id`,
+    )
+    .get();
+  ensureBudgetState(db, r.id, cfg);
+  return { db, dir, repoId: r.id };
+}
+const cleanup = (dir) => rmSync(dir, { recursive: true, force: true });
+
+function seedDecisions(db, repoId, outcomes) {
+  for (const outcome of outcomes) {
+    const d = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "seeded for retro test",
+      outcome: "pending",
+    });
+    setDecisionOutcome(db, d.id, outcome, "seeded");
+  }
+}
+
+test("sample: empty → null success rate", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const s = sampleRecentOutcomes(db, repoId);
+    assert.equal(s.total, 0);
+    assert.equal(s.successRate, null);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("sample: counts and success_rate excludes skipped", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    seedDecisions(db, repoId, [
+      "executed",
+      "executed",
+      "executed",
+      "executed",
+      "failed",
+      "rejected",
+      "skipped", // excluded
+      "skipped", // excluded
+    ]);
+    const s = sampleRecentOutcomes(db, repoId);
+    assert.equal(s.executed, 4);
+    assert.equal(s.failed, 1);
+    assert.equal(s.rejected, 1);
+    assert.equal(s.skipped, 2);
+    // 4 / (4+1+1) = 0.666...
+    assert.ok(Math.abs(s.successRate - 4 / 6) < 1e-9);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("recalibrate: high success rate → climb, capped at max", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    // 9 executed out of 10 = 90% → climb
+    seedDecisions(db, repoId, [
+      "executed",
+      "executed",
+      "executed",
+      "executed",
+      "executed",
+      "executed",
+      "executed",
+      "executed",
+      "executed",
+      "failed",
+    ]);
+    const r = recalibrateBudget(db, repoId, cfg);
+    assert.ok(r);
+    assert.equal(r.oldDaily, 2.0);
+    assert.ok(r.newDaily > r.oldDaily);
+    assert.ok(r.newDaily <= cfg.max_daily_usd);
+    assert.match(r.reason, /climb/);
+
+    // Repeat enough times — should stop climbing at max_daily_usd.
+    for (let i = 0; i < 50; i++) {
+      // Each call writes to history table, but we want to roll the day
+      // to allow it to fire — for the test, just call directly.
+      recalibrateBudget(db, repoId, cfg);
+    }
+    const final = db
+      .prepare(`SELECT daily_cap_usd FROM director_budget_state WHERE repo_id = ?`)
+      .get(repoId);
+    assert.ok(final.daily_cap_usd <= cfg.max_daily_usd);
+    // After enough climbs we should be at the ceiling (within rounding).
+    assert.ok(final.daily_cap_usd > 9.0);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("recalibrate: low success rate → shrink, floored at initial", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    // First climb a bit so we have room to shrink
+    db.prepare(
+      `UPDATE director_budget_state SET daily_cap_usd = 5.0, weekly_cap_usd = 25.0 WHERE repo_id = ?`,
+    ).run(repoId);
+    seedDecisions(db, repoId, ["executed", "failed", "failed", "failed", "rejected"]);
+    const r = recalibrateBudget(db, repoId, cfg);
+    assert.ok(r);
+    assert.ok(r.newDaily < r.oldDaily);
+    assert.match(r.reason, /shrink/);
+    assert.ok(r.newDaily >= cfg.initial_daily_usd);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("recalibrate: insufficient sample → null (no change)", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    seedDecisions(db, repoId, ["executed", "executed"]); // < MIN_SAMPLE_SIZE = 5
+    const r = recalibrateBudget(db, repoId, cfg);
+    assert.equal(r, null);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("recalibrate: middling rate → null (hold steady)", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    seedDecisions(db, repoId, ["executed", "executed", "executed", "failed", "failed", "failed"]);
+    const r = recalibrateBudget(db, repoId, cfg);
+    // 3/(3+3) = 50% → between thresholds → no change
+    assert.equal(r, null);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("recalibrate writes to budget history table", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    seedDecisions(db, repoId, [
+      "executed",
+      "executed",
+      "executed",
+      "executed",
+      "executed",
+      "failed",
+    ]);
+    recalibrateBudget(db, repoId, cfg);
+    const hist = db
+      .prepare(`SELECT * FROM director_budget_history WHERE repo_id = ?`)
+      .all(repoId);
+    assert.equal(hist.length, 1);
+    assert.match(hist[0].reason, /climb/);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("shouldRecalibrateToday: true on first call, false right after", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    assert.equal(shouldRecalibrateToday(db, repoId), true, "first call should recalibrate");
+    seedDecisions(db, repoId, [
+      "executed",
+      "executed",
+      "executed",
+      "executed",
+      "executed",
+      "failed",
+    ]);
+    recalibrateBudget(db, repoId, cfg);
+    assert.equal(
+      shouldRecalibrateToday(db, repoId),
+      false,
+      "second call same day should not",
+    );
+  } finally {
+    cleanup(dir);
+  }
+});


### PR DESCRIPTION
## Summary

Plan-PR #5, the last in the director rollout. Daily/weekly budget caps no longer sit at the YAML-configured initial values — they move with the director's recent track record.

## How it adapts

Once per UTC day, on the first tick of the day, look at the last 14 days of terminal decision outcomes:

- **success_rate ≥ 0.80** over ≥5 decisions → climb 10% (capped at \`max_daily_usd\` / \`max_weekly_usd\`)
- **success_rate ≤ 0.40** → shrink 20% (floored at initial)
- **otherwise** → hold

\`success_rate = executed / (executed + failed + rejected)\`. \`skipped\` is excluded (operator policy, not outcome). \`dry_run\` / \`pending\` excluded (not yet terminal).

## Schema migration v13

New table \`director_budget_history\` records every adjustment with the success rate, sample size, and reason. Visible to the LLM on subsequent ticks via the recent-decisions snapshot. Not yet surfaced in admin UI — could add a small chart in a follow-up but not blocking.

## Honest about its limits

This is **not** a "good outcome retrospective" in the strong sense. A real one would poll the VCS to detect reverts, CI failures, and re-opens over a 7-day quarantine after each \`executed\` merge. That requires per-merge polling state I haven't built. The current model uses immediate decision outcomes as a proxy. Code comments call this out.

## Tests

7 new (\`test/director-retrospective.test.mjs\`): empty sample, success-rate excludes skipped, climb-with-ceiling, shrink-with-floor, insufficient-sample no-op, middling-rate hold-steady, history-table writes, once-per-day gating.

## Total project state

98 unit tests, 0 fail, 0 lint, format clean.

## Test plan

- [x] \`pnpm run check\` green
- [ ] After merge: deploy fires, director restarts, on next tick recalibrate runs once. With current state (4 executed, 0 failed, 0 rejected on this repo), sample size 4 < MIN_SAMPLE_SIZE 5 → no change yet. Next decision either way will give us a 5th sample and trigger a real adjustment.