### PR TITLE
feat(director): per-repo language setting for the chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,11 @@ TELEGRAM_BOT_TOKEN=
 # it would otherwise accept commands from anyone.
 # OPENRONIN_DIRECTOR_TELEGRAM_USER_IDS=12345,67890
 
+# Note: language the director writes in (chat thread, ask_user questions,
+# proposal bodies, issue/PR comments) is per-repo, not env. Set it in the
+# per-repo YAML at $OPENRONIN_DATA_DIR/config/repos/<slug>.yaml under
+# `director.language` (default: English; set "Russian", "日本語", etc).
+
 # Engine the director uses for its planning tick. Auto-detected by default:
 # anthropic if ANTHROPIC_API_KEY is set, else mimo if XIAOMI_MIMO_API_KEY is
 # set. Set explicitly to force one or the other.

--- a/docs/DIRECTOR.md
+++ b/docs/DIRECTOR.md
@@ -71,6 +71,19 @@ director:
 
 **Without `enabled: true` and a non-empty `charter`, the Director silently skips that repo.** This is the safe default.
 
+### Language
+
+The director's chat output, `ask_user` questions, proposal bodies, and the bodies of any issue/PR comment it produces are written in `director.language` (default `English`). Free-form string fed verbatim into the prompt — `"Russian"`, `"日本語"`, `"code-mixed Russian/English (technical terms in English)"` all work.
+
+This is **independent** of the existing repo-level `language_for_communication` / `language_for_commits` / `language_for_code_identifiers` — those govern the code-writing agents. A project can communicate via the director in Russian while keeping commit messages and code identifiers in English.
+
+```yaml
+director:
+  language: "Russian"
+```
+
+JSON keys, decision-type identifiers (`create_issue`, `no_op`, …), label names, and other machine-readable tokens always stay in English regardless of this setting.
+
 ## Adaptive budget
 
 Two cost streams, capped independently:

--- a/prompts/templates/director-tick.md
+++ b/prompts/templates/director-tick.md
@@ -1,5 +1,9 @@
 You are the **Director** for the open-source project `{{owner}}/{{name}}`. Your role is product-owner / project-manager: you watch the repo, decide what should be worked on next, and emit decisions that the existing automation will carry out. You **never** edit source files directly — code mutations stay with the code-writing agent (a separate engine). You only emit decisions like "create issue", "comment on PR", "approve PR", etc.
 
+## Language
+
+**Communicate in: {{language}}.** This applies to all human-readable text you produce — `observations`, `reasoning`, `rationale` fields, the body of `ask_user` questions, the body of `create_issue` proposals, comments on issues/PRs. Decision-type identifiers (`create_issue`, `no_op`, etc.), JSON keys, label names, code identifiers, and other machine-readable tokens stay in English regardless. If you must reference a charter priority by id, keep the id as-is; the surrounding sentence is in {{language}}.
+
 ## Your charter (the constitution for this repo)
 
 This is the source of truth for what "good" looks like. Cite specific priority IDs in your reasoning.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -234,6 +234,10 @@ export const RepoConfigSchema = z.object({
       mode: DirectorModeSchema.default("dry_run"),
       cadence_hours: z.number().positive().default(6),
       bot_prefix: z.string().default("👔 director:"),
+      // Language the director speaks (chat thread, ask_user, proposal
+      // bodies, issue/PR comments it emits). Independent from the
+      // repo-level language_for_* settings — those govern code agents.
+      language: z.string().default("English"),
       charter: CharterSchema.optional(),
       budget: BudgetConfigSchema,
       authority: DirectorAuthoritySchema,

--- a/src/director/prompt.ts
+++ b/src/director/prompt.ts
@@ -22,6 +22,7 @@ export type PromptInputs = {
   repoName: string;
   charterYaml: string;
   mode: string;
+  language: string;
   state: StateSnapshot;
   dataDir: string;
   repoConfig: RepoConfig;
@@ -48,6 +49,7 @@ export function composePrompt(inputs: PromptInputs): ComposedPrompt {
     name: inputs.repoName,
     charter_yaml: inputs.charterYaml.trim(),
     mode: inputs.mode,
+    language: inputs.language,
     state_json: JSON.stringify(inputs.state, null, 2),
     chat_transcript: renderChatTranscript(inputs.state.recentChat),
   });

--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -130,6 +130,7 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
     repoName: repo.name,
     charterYaml,
     mode: director.mode,
+    language: director.language,
     state,
     dataDir,
     repoConfig: repo,

--- a/src/director/types.ts
+++ b/src/director/types.ts
@@ -103,6 +103,15 @@ export const DirectorConfigSchema = z
     mode: DirectorModeSchema.default("dry_run"),
     cadence_hours: z.number().positive().default(6),
     bot_prefix: z.string().default("👔 director:"),
+    // Language the director speaks: applies to chat-thread output
+    // (observations, reasoning, ask_user questions, proposal bodies),
+    // and to issue/PR comments it produces. Independent from the
+    // existing repo-level `language_for_*` settings — a project can be
+    // Russian-speaking with the director communicating in Russian, but
+    // commit messages still in English. Free-form string, fed verbatim
+    // into the prompt; e.g. "Russian", "English", "日本語", "code-mixed
+    // Russian/English (technical terms in English)".
+    language: z.string().default("English"),
     charter: CharterSchema.optional(),
     budget: BudgetConfigSchema,
     authority: DirectorAuthoritySchema,

--- a/test/director-approval.test.mjs
+++ b/test/director-approval.test.mjs
@@ -60,6 +60,7 @@ function director(mode, overrides = {}) {
     mode,
     cadence_hours: 6,
     bot_prefix: "👔 director:",
+    language: "English",
     charter,
     budget: baseBudget,
     authority: { ...fullAuthority, ...(overrides.authority ?? {}) },

--- a/test/director-execution.test.mjs
+++ b/test/director-execution.test.mjs
@@ -65,6 +65,7 @@ function director(mode, overrides = {}) {
     mode,
     cadence_hours: 6,
     bot_prefix: "👔 director:",
+    language: "English",
     charter,
     budget: baseBudget,
     authority: { ...fullAuthority, ...(overrides.authority ?? {}) },

--- a/test/director-tick.test.mjs
+++ b/test/director-tick.test.mjs
@@ -62,6 +62,7 @@ const sampleDirector = {
   mode: "dry_run",
   cadence_hours: 6,
   bot_prefix: "👔 director:",
+  language: "English",
   charter: sampleCharter,
   budget: sampleBudget,
   authority: {
@@ -152,6 +153,42 @@ test("decision-schema: validates create_issue payload", () => {
     ],
   });
   assert.equal(out.ok, true);
+});
+
+test("director.language: passed through to prompt template verbatim", async () => {
+  const { db, dir, repoId } = freshDb();
+  let capturedPrompt = "";
+  try {
+    const russianDirector = { ...sampleDirector, language: "Russian" };
+    await runTick({
+      db,
+      repoId,
+      repo: { ...sampleRepo, director: russianDirector },
+      director: russianDirector,
+      dataDir: dir,
+      engineFactory: () => ({
+        id: "mock",
+        defaultModel: "mock",
+        async run(opts) {
+          capturedPrompt = opts.userPrompt;
+          return {
+            content: "{}",
+            json: {
+              observations: "Steady state, ничего срочного — мониторим charter priorities.",
+              reasoning: "Routine planning per charter; nothing pressing this tick.",
+              decisions: [{ type: "no_op", rationale: "Nothing actionable this tick." }],
+            },
+            usage: { tokensIn: 1000, tokensOut: 200, costUsd: 0.001 },
+            finishReason: "end_turn",
+            durationMs: 100,
+          };
+        },
+      }),
+    });
+    assert.match(capturedPrompt, /Communicate in: Russian/);
+  } finally {
+    cleanup(dir);
+  }
 });
 
 test("runTick: dry_run records decisions with outcome=dry_run, posts status to chat", async () => {


### PR DESCRIPTION
Adds `director.language` to per-repo YAML — controls what language the director writes in (chat, ask_user, proposal bodies, issue/PR comments). Default `English`. Free-form string fed verbatim into the prompt — `Russian`, `日本語`, `code-mixed Russian/English (technical terms in English)`, etc.

Independent from the existing `language_for_communication` / `language_for_commits` / `language_for_code_identifiers` — those govern the code-writing agents. A project can chat via the director in Russian while keeping commits and code in English.

Decision-type identifiers, JSON keys, label names stay in English regardless (prompt instructs this explicitly).

Touch points: types.ts, config/schema.ts, prompts/templates/director-tick.md, prompt.ts, tick.ts, docs/DIRECTOR.md, .env.example, all four director-* test files. 1 new test asserts the language string lands in the composed prompt verbatim.