### PR TITLE
feat(director): persona/voice layer

### DIFF
--- a/prompts/templates/director-tick.md
+++ b/prompts/templates/director-tick.md
@@ -1,4 +1,8 @@
-You are the **Director** for the open-source project `{{owner}}/{{name}}`. Your role is product-owner / project-manager: you watch the repo, decide what should be worked on next, and emit decisions that the existing automation will carry out. You **never** edit source files directly — code mutations stay with the code-writing agent (a separate engine). You only emit decisions like "create issue", "comment on PR", "approve PR", etc.
+You are the **product owner / PM** for the open-source project `{{owner}}/{{name}}`. You watch the repo, decide what should be worked on next, and emit decisions that the existing automation will carry out. You **never** edit source files directly — code mutations stay with the code-writing agent (a separate engine). You only emit decisions like "create issue", "comment on PR", "approve PR", etc.
+
+## Who you are
+
+{{persona_block}}
 
 ## Language
 

--- a/src/director/prompt.ts
+++ b/src/director/prompt.ts
@@ -16,6 +16,7 @@
 import { loadTemplate, renderTemplate } from "../prompts/registry.js";
 import type { RepoConfig } from "../config/schema.js";
 import type { StateSnapshot } from "./state.js";
+import type { Persona } from "./types.js";
 
 export type PromptInputs = {
   ownerName: string;
@@ -23,6 +24,7 @@ export type PromptInputs = {
   charterYaml: string;
   mode: string;
   language: string;
+  persona: Persona;
   state: StateSnapshot;
   dataDir: string;
   repoConfig: RepoConfig;
@@ -34,13 +36,39 @@ export type ComposedPrompt = {
   approxTokensIn: number; // rough — for budget pre-check
 };
 
-const DIRECTOR_SYSTEM = [
-  "You are the Director for an open-source project — a product-owner / project-manager",
-  "running on a 6-hour cadence. You emit machine-readable decisions in strict JSON.",
-  "You never edit source files; the code-writing agent does that. You decide what should",
-  "be worked on, comment on PRs, approve when ready. Stay strictly within the charter.",
-  "When in doubt, ask the user instead of guessing.",
-].join(" ");
+// The system prompt is built dynamically from the persona so the LLM
+// inhabits a real voice rather than the generic "Director" robot. The
+// boilerplate (engine boundary, JSON contract, charter discipline) is
+// invariant; only the voice/role/style is parameterised.
+export function buildSystemPrompt(persona: Persona): string {
+  return [
+    `You are ${persona.name}, the ${persona.role} for an open-source project.`,
+    "Speak in first person. You watch the project, decide what's worth working on next,",
+    "and emit machine-readable decisions in strict JSON.",
+    "",
+    `Voice: ${persona.voice}`,
+    `Style: ${persona.style}`,
+    "",
+    "You never edit source files — a separate code-writing agent does that. You create",
+    "issues, comment on PRs, approve when ready, ask the human when uncertain. Stay",
+    "strictly within the charter. Take ownership: surface stuck PRs, drifting priorities,",
+    "and budget anomalies before the human has to ask.",
+    "When in doubt, ask the user instead of guessing.",
+  ].join(" ");
+}
+
+export function renderPersonaBlock(persona: Persona): string {
+  return [
+    `**Your name:** ${persona.name}`,
+    `**Your role:** ${persona.role}`,
+    `**Your voice:** ${persona.voice}`,
+    `**Your style:** ${persona.style}`,
+    "",
+    "Sign your chat output as yourself — the chat surface labels each bubble with your",
+    "name, so don't repeat your own name inside the body. Speak like a human PM, not a",
+    "templated robot. Acknowledge user messages directly when responding to them.",
+  ].join("\n");
+}
 
 export function composePrompt(inputs: PromptInputs): ComposedPrompt {
   const template = loadTemplate("director-tick", inputs.repoConfig, inputs.dataDir);
@@ -50,14 +78,16 @@ export function composePrompt(inputs: PromptInputs): ComposedPrompt {
     charter_yaml: inputs.charterYaml.trim(),
     mode: inputs.mode,
     language: inputs.language,
+    persona_block: renderPersonaBlock(inputs.persona),
     state_json: JSON.stringify(inputs.state, null, 2),
     chat_transcript: renderChatTranscript(inputs.state.recentChat),
   });
+  const systemPrompt = buildSystemPrompt(inputs.persona);
 
   return {
-    systemPrompt: DIRECTOR_SYSTEM,
+    systemPrompt,
     userPrompt,
-    approxTokensIn: Math.ceil((DIRECTOR_SYSTEM.length + userPrompt.length) / 4),
+    approxTokensIn: Math.ceil((systemPrompt.length + userPrompt.length) / 4),
   };
 }
 

--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -41,7 +41,7 @@ import { parseTickOutput, type ParsedDecision, type TickOutput } from "./decisio
 import { executeDecision } from "./executor.js";
 import { GithubVcsProvider } from "../providers/github.js";
 import type { VcsProvider } from "../providers/vcs.js";
-import type { DecisionType, DirectorConfig } from "./types.js";
+import { PersonaSchema, type DecisionType, type DirectorConfig } from "./types.js";
 import YAML from "yaml";
 
 const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
@@ -131,6 +131,9 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
     charterYaml,
     mode: director.mode,
     language: director.language,
+    // charter loaded via Zod always has persona (PersonaSchema.default({})),
+    // but tests pass plain object literals — fall back to schema defaults.
+    persona: director.charter.persona ?? PersonaSchema.parse({}),
     state,
     dataDir,
     repoConfig: repo,

--- a/src/director/types.ts
+++ b/src/director/types.ts
@@ -53,6 +53,33 @@ export const CharterPrioritySchema = z.object({
 });
 export type CharterPriority = z.infer<typeof CharterPrioritySchema>;
 
+// ── Persona ─────────────────────────────────────────────────────────────
+// Optional voice/personality layer on top of the charter. The default is a
+// neutral "Director" — but a project can declare a named PM with a specific
+// voice ("дружелюбный, без формализмов, признаёт неопределённость") and
+// that voice is woven into the system-prompt and the chat-bubble label.
+//
+// Why on the charter and not on DirectorConfig? Because persona is part of
+// what "good communication on this project" looks like — it's tied to the
+// repo's culture, same as priorities. DirectorConfig stays operational
+// (cadence, mode, budget).
+export const PersonaSchema = z
+  .object({
+    name: z.string().min(1).default("Director"),
+    role: z.string().default("product owner / project manager"),
+    voice: z
+      .string()
+      .default("concise, direct, friendly but professional; admits uncertainty"),
+    style: z
+      .string()
+      .default(
+        "short messages by default; asks rather than guesses; takes ownership; surfaces issues proactively",
+      ),
+    avatar: z.string().optional(),
+  })
+  .default({});
+export type Persona = z.infer<typeof PersonaSchema>;
+
 export const CharterSchema = z.object({
   vision: z.string().min(1),
   priorities: z.array(CharterPrioritySchema).min(1),
@@ -60,6 +87,7 @@ export const CharterSchema = z.object({
   out_of_bounds_paths: z.array(z.string()).default([]),
   definition_of_done: z.array(z.string()).default([]),
   notes: z.string().optional(),
+  persona: PersonaSchema,
 });
 export type Charter = z.infer<typeof CharterSchema>;
 

--- a/src/director/types.ts
+++ b/src/director/types.ts
@@ -67,9 +67,7 @@ export const PersonaSchema = z
   .object({
     name: z.string().min(1).default("Director"),
     role: z.string().default("product owner / project manager"),
-    voice: z
-      .string()
-      .default("concise, direct, friendly but professional; admits uncertainty"),
+    voice: z.string().default("concise, direct, friendly but professional; admits uncertainty"),
     style: z
       .string()
       .default(

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -189,11 +189,7 @@ function renderMessage(
     : isDirector
       ? "bg-[var(--surface-elevated)] border-[var(--border)]"
       : "bg-[var(--surface-sunken)] border-[var(--border)]";
-  const speaker = isUser
-    ? "👤 you"
-    : isDirector
-      ? `${personaAvatar} ${personaName}`
-      : "⚙️ system";
+  const speaker = isUser ? "👤 you" : isDirector ? `${personaAvatar} ${personaName}` : "⚙️ system";
 
   // For proposals, the underlying decision's outcome is part of the bubble
   // — buttons when pending, a closed-out badge when resolved. Keeps the

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -52,6 +52,19 @@ type RepoEntry = {
   hasCharter: boolean;
 };
 
+// Resolve the persona display name for a repo. Charter is optional and
+// the persona block within it is also optional; fall back to a neutral
+// "Director" / 🥷 pair when nothing is configured. Used for both the
+// chat-bubble label and the empty-state copy.
+function resolvePersonaName(repo: RepoConfig | undefined): string {
+  const name = repo?.director?.charter?.persona?.name;
+  return name && name.trim().length > 0 ? name : "Director";
+}
+
+function resolvePersonaAvatar(repo: RepoConfig | undefined): string {
+  return repo?.director?.charter?.persona?.avatar ?? "🥷";
+}
+
 function listEntries(db: Db, getConfig: () => RuntimeConfig): RepoEntry[] {
   const config = getConfig();
   const idByKey = new Map<string, number>();
@@ -160,7 +173,13 @@ function decisionOutcomeView(db: Db, decisionId: number | null): DecisionOutcome
   return { outcome: row.outcome, outcomeDetails: row.outcome_details };
 }
 
-function renderMessage(db: Db, slug: string, m: DirectorMessage): TrustedHtml {
+function renderMessage(
+  db: Db,
+  slug: string,
+  m: DirectorMessage,
+  personaName: string,
+  personaAvatar: string,
+): TrustedHtml {
   const isUser = m.role === "user";
   const isDirector = m.role === "director";
   // Visual slots: director on the left, user on the right, system small.
@@ -170,7 +189,11 @@ function renderMessage(db: Db, slug: string, m: DirectorMessage): TrustedHtml {
     : isDirector
       ? "bg-[var(--surface-elevated)] border-[var(--border)]"
       : "bg-[var(--surface-sunken)] border-[var(--border)]";
-  const speaker = isUser ? "👤 you" : isDirector ? "👔 director" : "⚙️ system";
+  const speaker = isUser
+    ? "👤 you"
+    : isDirector
+      ? `${personaAvatar} ${personaName}`
+      : "⚙️ system";
 
   // For proposals, the underlying decision's outcome is part of the bubble
   // — buttons when pending, a closed-out badge when resolved. Keeps the
@@ -430,7 +453,13 @@ function renderComposer(slug: string): TrustedHtml {
   `;
 }
 
-function renderChatThread(db: Db, slug: string, messages: DirectorMessage[]): TrustedHtml {
+function renderChatThread(
+  db: Db,
+  slug: string,
+  messages: DirectorMessage[],
+  personaName: string,
+  personaAvatar: string,
+): TrustedHtml {
   // messages comes ordered ascending by id (oldest first) — render top→bottom.
   const items = groupNoise(messages);
   return html`
@@ -441,10 +470,12 @@ function renderChatThread(db: Db, slug: string, messages: DirectorMessage[]): Tr
       >
         ${messages.length === 0
           ? html`<p class="text-sm text-[var(--fg-muted)] text-center py-8">
-              Empty thread. The director will start posting here on its next tick.
+              Empty thread. ${personaName} will start posting here on its next tick.
             </p>`
           : items.map((it) =>
-              it.kind === "msg" ? renderMessage(db, slug, it.m) : renderNoiseGroup(it.msgs),
+              it.kind === "msg"
+                ? renderMessage(db, slug, it.m, personaName, personaAvatar)
+                : renderNoiseGroup(it.msgs),
             )}
       </div>
       ${renderComposer(slug)}
@@ -607,6 +638,8 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
     const charter = latestCharterVersion(db, entry.repoId);
     const budgetState = ensureBudgetState(db, entry.repoId, repo.director.budget);
     const gate = checkBudgetGate(budgetState, repo.director.budget);
+    const personaName = resolvePersonaName(repo);
+    const personaAvatar = resolvePersonaAvatar(repo);
 
     const charterCard = card({
       title: `Charter${charter ? ` (v${charter.version})` : ""}`,
@@ -706,7 +739,7 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
     const chatCard = card({
       title: `Chat — ${messages.length} message(s)`,
       body: html`<div class="flex flex-col gap-3">
-        ${statusPanel} ${renderChatThread(db, slug, messages)}
+        ${statusPanel} ${renderChatThread(db, slug, messages, personaName, personaAvatar)}
       </div>`,
     });
 
@@ -783,6 +816,9 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
     const entry = entries.find((e) => e.slug === slug);
     if (!entry) return c.notFound();
 
+    const config = getConfig();
+    const repo = config.repos.find((r) => repoKey(r) === slug);
+
     const form = await c.req.parseBody();
     const type = String(form.type ?? "directive");
     const body = String(form.body ?? "").trim();
@@ -800,7 +836,10 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
     });
 
     const messages = recentMessages(db, entry.repoId, 200);
-    return c.html(renderChatThread(db, slug, messages).value);
+    return c.html(
+      renderChatThread(db, slug, messages, resolvePersonaName(repo), resolvePersonaAvatar(repo))
+        .value,
+    );
   });
 
   // ── POST /:slug/decisions/:id/approve ────────────────────────────────
@@ -825,7 +864,10 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
     });
 
     const messages = recentMessages(db, entry.repoId, 200);
-    return c.html(renderChatThread(db, slug, messages).value);
+    return c.html(
+      renderChatThread(db, slug, messages, resolvePersonaName(repo), resolvePersonaAvatar(repo))
+        .value,
+    );
   });
 
   // ── POST /:slug/decisions/:id/reject ─────────────────────────────────
@@ -852,7 +894,10 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
     });
 
     const messages = recentMessages(db, entry.repoId, 200);
-    return c.html(renderChatThread(db, slug, messages).value);
+    return c.html(
+      renderChatThread(db, slug, messages, resolvePersonaName(repo), resolvePersonaAvatar(repo))
+        .value,
+    );
   });
 
   // ── GET /:slug/status — render just the status panel ──────────────

--- a/test/director-persona.test.mjs
+++ b/test/director-persona.test.mjs
@@ -1,0 +1,221 @@
+// Persona/voice layer for the Director.
+//
+// Verifies:
+//   • PersonaSchema fills in sane defaults so old charters keep working
+//   • CharterSchema accepts an explicit persona override
+//   • The composed prompt embeds the persona block + voice/style verbatim
+//     so the LLM actually inhabits the configured voice
+//   • runTick falls back to the default persona when the input charter is a
+//     bare object literal (tests bypass Zod, prod doesn't — but we don't
+//     want a crash in either case)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { CharterSchema, PersonaSchema } from "../dist/director/types.js";
+import { buildSystemPrompt, renderPersonaBlock } from "../dist/director/prompt.js";
+import { initDb } from "../dist/storage/db.js";
+import { runTick } from "../dist/director/tick.js";
+
+test("PersonaSchema fills defaults when given empty input", () => {
+  const persona = PersonaSchema.parse({});
+  assert.equal(persona.name, "Director");
+  assert.match(persona.role, /product owner|project manager/i);
+  assert.ok(persona.voice.length > 0);
+  assert.ok(persona.style.length > 0);
+});
+
+test("PersonaSchema accepts explicit override", () => {
+  const persona = PersonaSchema.parse({
+    name: "Лёша",
+    role: "PM",
+    voice: "дружелюбный, без формализмов",
+    style: "короткие сообщения, признаёт неопределённость",
+  });
+  assert.equal(persona.name, "Лёша");
+  assert.match(persona.voice, /дружелюбный/);
+});
+
+test("CharterSchema embeds persona with defaults", () => {
+  const charter = CharterSchema.parse({
+    vision: "Reliable, observable AI dev agent.",
+    priorities: [{ id: "x", weight: 0.5, rubric: "y" }],
+  });
+  assert.ok(charter.persona);
+  assert.equal(charter.persona.name, "Director");
+});
+
+test("buildSystemPrompt weaves persona name + voice into system text", () => {
+  const persona = PersonaSchema.parse({
+    name: "Лёша",
+    voice: "конкретный, без воды",
+  });
+  const sys = buildSystemPrompt(persona);
+  assert.match(sys, /You are Лёша/);
+  assert.match(sys, /конкретный, без воды/);
+});
+
+test("renderPersonaBlock includes name, role, voice, style", () => {
+  const persona = PersonaSchema.parse({
+    name: "Anna",
+    role: "PM",
+    voice: "warm",
+    style: "asks not guesses",
+  });
+  const block = renderPersonaBlock(persona);
+  assert.match(block, /Anna/);
+  assert.match(block, /PM/);
+  assert.match(block, /warm/);
+  assert.match(block, /asks not guesses/);
+});
+
+const sampleCharter = {
+  vision: "Reliable, observable AI dev agent.",
+  priorities: [{ id: "reliability", weight: 1.0, rubric: "graceful failure" }],
+  out_of_bounds: [],
+  out_of_bounds_paths: [],
+  definition_of_done: [],
+};
+
+const sampleBudget = {
+  initial_daily_usd: 2.0,
+  initial_weekly_usd: 10.0,
+  max_daily_usd: 10.0,
+  max_weekly_usd: 50.0,
+  think_daily_usd: 1.0,
+  pause_on_failure_streak: 3,
+  good_outcome_quarantine_days: 7,
+};
+
+const sampleDirector = {
+  enabled: true,
+  mode: "dry_run",
+  cadence_hours: 6,
+  bot_prefix: "👔 director:",
+  language: "English",
+  charter: sampleCharter,
+  budget: sampleBudget,
+  authority: {
+    can_create_issues: true,
+    can_label: true,
+    can_close_issues: false,
+    can_comment: true,
+    can_approve_pr: true,
+    can_merge: false,
+    can_modify_charter: false,
+  },
+};
+
+const sampleRepo = {
+  provider: "github",
+  owner: "openronin",
+  name: "openronin",
+  watched: true,
+  lanes: ["triage"],
+  director: sampleDirector,
+};
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-persona-test-"));
+  const db = initDb(dir);
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+
+test("runTick: persona absent on charter falls back to defaults; system prompt names 'Director'", async () => {
+  const { db, dir, repoId } = freshDb();
+  let capturedSystem = "";
+  let capturedUser = "";
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: sampleRepo,
+      director: sampleDirector,
+      dataDir: dir,
+      engineFactory: () => ({
+        id: "mock",
+        defaultModel: "mock",
+        async run(opts) {
+          capturedSystem = opts.systemPrompt;
+          capturedUser = opts.userPrompt;
+          return {
+            content: "{}",
+            json: {
+              observations: "Steady state, nothing pressing this tick.",
+              reasoning: "Routine planning per charter; nothing actionable.",
+              decisions: [{ type: "no_op", rationale: "Nothing actionable this tick." }],
+            },
+            usage: { tokensIn: 1000, tokensOut: 200, costUsd: 0.001 },
+            finishReason: "end_turn",
+            durationMs: 100,
+          };
+        },
+      }),
+    });
+    assert.match(capturedSystem, /You are Director/);
+    assert.match(capturedUser, /Your name:.*Director/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("runTick: explicit persona on charter is propagated into system + user prompt", async () => {
+  const { db, dir, repoId } = freshDb();
+  let capturedSystem = "";
+  let capturedUser = "";
+  const personaCharter = {
+    ...sampleCharter,
+    persona: {
+      name: "Лёша",
+      role: "PM",
+      voice: "конкретный, без воды",
+      style: "короткие сообщения, признаёт неопределённость",
+    },
+  };
+  const personaDirector = { ...sampleDirector, charter: personaCharter };
+  const personaRepo = { ...sampleRepo, director: personaDirector };
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: personaRepo,
+      director: personaDirector,
+      dataDir: dir,
+      engineFactory: () => ({
+        id: "mock",
+        defaultModel: "mock",
+        async run(opts) {
+          capturedSystem = opts.systemPrompt;
+          capturedUser = opts.userPrompt;
+          return {
+            content: "{}",
+            json: {
+              observations: "Steady state, ничего срочного — мониторим charter priorities.",
+              reasoning: "Routine planning per charter; nothing pressing this tick.",
+              decisions: [{ type: "no_op", rationale: "Nothing actionable this tick." }],
+            },
+            usage: { tokensIn: 1000, tokensOut: 200, costUsd: 0.001 },
+            finishReason: "end_turn",
+            durationMs: 100,
+          };
+        },
+      }),
+    });
+    assert.match(capturedSystem, /You are Лёша/);
+    assert.match(capturedSystem, /конкретный, без воды/);
+    assert.match(capturedUser, /Your name:.*Лёша/);
+    assert.match(capturedUser, /короткие сообщения/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #45. Part of #44.

The Director introduced itself as \"the Director\" and spoke in robot
boilerplate. This PR adds an optional \`charter.persona\` block (name /
role / voice / style / avatar) that:

- gets woven into the system prompt so the LLM inhabits a real voice
  instead of the generic JSON-contract template
- becomes the chat-bubble label in the admin UI (replacing the hardcoded
  \"👔 director\")
- is captured per charter version so the voice can evolve without losing
  audit trail

Defaults preserve current behaviour — old charters resolve to a neutral
\"Director\".

## Example charter snippet

\`\`\`yaml
director:
  charter:
    persona:
      name: \"Лёша\"
      role: \"PM / product owner\"
      voice: \"конкретный, без воды; признаёт неопределённость\"
      style: \"короткие сообщения, asks rather than guesses\"
      avatar: \"🧑‍💼\"
\`\`\`

## Test plan
- [x] \`pnpm run check\` green (107 tests, lint, format)
- [x] PersonaSchema fills defaults for empty input
- [x] Custom persona name/voice appears in system+user prompt
- [x] runTick falls back to default when charter has no persona