### PR TITLE
feat(director): reactive tick + typing indicator + per-repo lock

### DIFF
--- a/prompts/templates/director-tick.md
+++ b/prompts/templates/director-tick.md
@@ -16,6 +16,15 @@ This is the source of truth for what "good" looks like. Cite specific priority I
 {{charter_yaml}}
 ```
 
+## Why you're awake
+
+This tick was triggered by: **{{tick_reason}}**
+
+- `scheduled` — your regular cadence woke you up; do routine planning.
+- `user_message` — the human just wrote in the chat. **Read the latest chat messages first and respond directly** before doing anything else. A reactive tick that ignores the user is a bad tick.
+- `pr_event` / `deploy_failed` — something on the repo changed that needs a PM eye. Look at the relevant state section first.
+- `manual` — a human kicked you over from the admin UI; expect them to be watching.
+
 ## Operating mode
 
 You are running in mode `{{mode}}`. The mode controls whether your decisions actually execute:

--- a/src/director/active-tick.ts
+++ b/src/director/active-tick.ts
@@ -1,0 +1,114 @@
+// Per-repo tick lock + chat "typing…" indicator.
+//
+// Two responsibilities, one row:
+//   1. Concurrency guard — only one tick at a time per repo. tryAcquire()
+//      returns false if a fresh entry exists (lock held); release() drops
+//      the row when the tick is done. Stale-but-not-expired locks are
+//      respected; expired ones are reclaimed.
+//   2. Surfacing — the admin chat polls `getActiveTick()` to decide
+//      whether to render the persona's "thinking" bubble.
+//
+// PRIMARY KEY on repo_id makes "one row at most" structurally true. We
+// handle SQLite's ON CONFLICT in the acquire path so two callers racing
+// to start a tick get clean true/false answers, no exception throws.
+
+import type { Db } from "../storage/db.js";
+
+export type ActiveTick = {
+  repoId: number;
+  startedAt: string;
+  holderPid: number;
+  reason: string;
+  ttlS: number;
+};
+
+const DEFAULT_TTL_S = 300;
+
+type Row = {
+  repo_id: number;
+  started_at: string;
+  holder_pid: number;
+  reason: string;
+  ttl_s: number;
+};
+
+function rowToActive(row: Row): ActiveTick {
+  return {
+    repoId: row.repo_id,
+    startedAt: row.started_at,
+    holderPid: row.holder_pid,
+    reason: row.reason,
+    ttlS: row.ttl_s,
+  };
+}
+
+// Returns the active row only if it's still within ttl. Anything older
+// is treated as a crashed tick — neither shown to the user nor honoured
+// as a lock.
+export function getActiveTick(db: Db, repoId: number): ActiveTick | null {
+  const row = db
+    .prepare(
+      `SELECT repo_id, started_at, holder_pid, reason, ttl_s
+       FROM director_active_ticks
+       WHERE repo_id = ?
+         AND datetime(started_at, '+' || ttl_s || ' seconds') > datetime('now')`,
+    )
+    .get(repoId) as Row | undefined;
+  return row ? rowToActive(row) : null;
+}
+
+// Try to acquire the lock. Returns true if we now hold it, false if
+// someone else does (and their lock is still fresh).
+//
+// Implementation: INSERT OR IGNORE first; if it didn't insert, check
+// freshness and either reclaim a stale slot or bail out.
+export function tryAcquireTick(
+  db: Db,
+  repoId: number,
+  reason: string,
+  ttlS: number = DEFAULT_TTL_S,
+): boolean {
+  const inserted = db
+    .prepare(
+      `INSERT OR IGNORE INTO director_active_ticks (repo_id, holder_pid, reason, ttl_s)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .run(repoId, process.pid, reason, ttlS);
+  if (inserted.changes > 0) return true;
+
+  // A row is already there. Reclaim if it's expired.
+  const result = db
+    .prepare(
+      `UPDATE director_active_ticks
+       SET started_at = datetime('now'),
+           holder_pid = ?,
+           reason = ?,
+           ttl_s = ?
+       WHERE repo_id = ?
+         AND datetime(started_at, '+' || ttl_s || ' seconds') <= datetime('now')`,
+    )
+    .run(process.pid, reason, ttlS, repoId);
+  return result.changes > 0;
+}
+
+export function releaseTick(db: Db, repoId: number): void {
+  db.prepare(`DELETE FROM director_active_ticks WHERE repo_id = ?`).run(repoId);
+}
+
+// Convenience: run the body inside the lock. Auto-release on success or
+// throw. If the lock can't be acquired, returns null without invoking
+// the body — caller decides whether that's "skip" or "retry".
+export async function withActiveTick<T>(
+  db: Db,
+  repoId: number,
+  reason: string,
+  body: () => Promise<T>,
+  ttlS: number = DEFAULT_TTL_S,
+): Promise<T | null> {
+  if (!tryAcquireTick(db, repoId, reason, ttlS)) return null;
+  try {
+    return await body();
+  } finally {
+    releaseTick(db, repoId);
+  }
+}

--- a/src/director/index.ts
+++ b/src/director/index.ts
@@ -16,11 +16,15 @@ import { repoKey } from "../config/schema.js";
 import { initDb, type Db } from "../storage/db.js";
 import { syncReposFromConfig } from "../storage/repos.js";
 import { ensureBudgetState, rolloverDayIfNeeded } from "./budget.js";
-import { appendMessage } from "./chat.js";
-import { runTick } from "./tick.js";
+import { appendMessage, unansweredUserDirectives } from "./chat.js";
+import { runTick, type TickReason } from "./tick.js";
+import { releaseTick, tryAcquireTick } from "./active-tick.js";
 import type { DirectorConfig } from "./types.js";
 
-const SERVICE_LOOP_INTERVAL_MS = 60_000; // wake up every minute
+// Wake up every 10s — tight enough that a user chat message is reacted to
+// in <30s in the typical case, loose enough that an idle director burns
+// almost no CPU. Cadence-based scheduled ticks (6h+) are cheap to check.
+const SERVICE_LOOP_INTERVAL_MS = 10_000;
 const KILL_SWITCH_ENV = "OPENRONIN_DIRECTOR_DISABLED";
 
 type RepoLookup = {
@@ -54,7 +58,7 @@ function listDirectorEnabledRepos(db: Db, config: RuntimeConfig): RepoLookup[] {
   return out;
 }
 
-function shouldTickNow(state: { lastTickAt: string | null }, cadenceHours: number): boolean {
+function isPastCadence(state: { lastTickAt: string | null }, cadenceHours: number): boolean {
   if (!state.lastTickAt) return true;
   const last = Date.parse(state.lastTickAt + "Z"); // sqlite text is UTC
   if (Number.isNaN(last)) return true;
@@ -62,19 +66,56 @@ function shouldTickNow(state: { lastTickAt: string | null }, cadenceHours: numbe
   return elapsedMs >= cadenceHours * 3600_000;
 }
 
-async function executeTick(db: Db, target: RepoLookup, dataDir: string): Promise<void> {
-  const result = await runTick({
-    db,
-    repoId: target.repoId,
-    repo: target.repo,
-    director: target.director,
-    dataDir,
-  });
-  // eslint-disable-next-line no-console
-  console.log(
-    `[director] tick on ${repoKey(target.repo)}: ${result.status} — ${result.detail} ` +
-      `(${result.decisionsLogged} decisions, $${result.costUsd.toFixed(4)})`,
-  );
+// Why fire a tick right now? Reactive (user wrote in chat) wins over
+// scheduled (cadence elapsed). Returns null if we should stay idle.
+//
+// "Reactive" means: at least one user message exists that the director
+// hasn't responded to yet. The DB helper does the right thing — it only
+// returns user messages with no later director-role message, so once a
+// tick produces a status reply, the queue empties for that user.
+function pickTickReason(
+  db: Db,
+  repoId: number,
+  state: { lastTickAt: string | null },
+  cadenceHours: number,
+): TickReason | null {
+  if (unansweredUserDirectives(db, repoId).length > 0) return "user_message";
+  if (isPastCadence(state, cadenceHours)) return "scheduled";
+  return null;
+}
+
+async function executeTick(
+  db: Db,
+  target: RepoLookup,
+  dataDir: string,
+  reason: TickReason,
+): Promise<void> {
+  // Acquire the per-repo lock. This makes parallel ticks structurally
+  // impossible (a webhook-driven trigger landing during a scheduled tick
+  // would otherwise produce duplicate decisions) and doubles as the
+  // "thinking…" indicator the admin chat polls for.
+  if (!tryAcquireTick(db, target.repoId, reason)) {
+    // Another worker is already ticking this repo. Skip silently — the
+    // running tick will pick up any new chat messages on its next pass.
+    return;
+  }
+  try {
+    const result = await runTick({
+      db,
+      repoId: target.repoId,
+      repo: target.repo,
+      director: target.director,
+      dataDir,
+      reason,
+    });
+    // eslint-disable-next-line no-console
+    console.log(
+      `[director] tick on ${repoKey(target.repo)} (${reason}): ${result.status} — ${result.detail} ` +
+        `(${result.decisionsLogged} decisions, $${result.costUsd.toFixed(4)})`,
+    );
+  } finally {
+    releaseTick(db, target.repoId);
+  }
 }
 
 let stopping = false;
@@ -89,9 +130,10 @@ async function loopOnce(db: Db, config: RuntimeConfig): Promise<void> {
     if (stopping) return;
     rolloverDayIfNeeded(db, t.repoId);
     const state = ensureBudgetState(db, t.repoId, t.director.budget);
-    if (!shouldTickNow(state, t.director.cadence_hours)) continue;
+    const reason = pickTickReason(db, t.repoId, state, t.director.cadence_hours);
+    if (!reason) continue;
     try {
-      await executeTick(db, t, config.dataDir);
+      await executeTick(db, t, config.dataDir, reason);
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       try {

--- a/src/director/prompt.ts
+++ b/src/director/prompt.ts
@@ -25,6 +25,10 @@ export type PromptInputs = {
   mode: string;
   language: string;
   persona: Persona;
+  // Why this tick is firing — surfaced into the prompt so the LLM can
+  // prioritise (e.g. "user_message" → address the chat first; "scheduled"
+  // → routine planning). Defaults to "scheduled" for legacy callers.
+  reason?: string;
   state: StateSnapshot;
   dataDir: string;
   repoConfig: RepoConfig;
@@ -79,6 +83,7 @@ export function composePrompt(inputs: PromptInputs): ComposedPrompt {
     mode: inputs.mode,
     language: inputs.language,
     persona_block: renderPersonaBlock(inputs.persona),
+    tick_reason: inputs.reason ?? "scheduled",
     state_json: JSON.stringify(inputs.state, null, 2),
     chat_transcript: renderChatTranscript(inputs.state.recentChat),
   });

--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -48,12 +48,21 @@ const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
 const DEFAULT_MIMO_MODEL = "mimo-v2.5-pro";
 const TICK_TIMEOUT_MS = 120_000; // 2 min — generous for a 30k-token thinking call
 
+// Why the tick is firing right now. The Director used to wake up only on
+// a 6-hour timer; reactivity (responding to user chat messages, deploys,
+// etc.) introduces other reasons. The reason is surfaced in the tick_log
+// chat message and in the prompt so the LLM can prioritise accordingly.
+export type TickReason = "scheduled" | "manual" | "user_message" | "pr_event" | "deploy_failed";
+
 export type TickRunOptions = {
   db: Db;
   repoId: number;
   repo: RepoConfig;
   director: DirectorConfig;
   dataDir: string;
+  // Why this tick is firing — informs the prompt and the chat message.
+  // Defaults to "scheduled" for backwards compatibility with tests.
+  reason?: TickReason;
   // Engine factory (overridable for tests).
   engineFactory?: () => Engine;
   // VcsProvider factory (overridable for tests). Defaults to GithubVcsProvider
@@ -67,12 +76,14 @@ export type TickRunResult = {
   detail: string;
   decisionsLogged: number;
   costUsd: number;
+  reason: TickReason;
 };
 
 export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
   const { db, repoId, repo, director, dataDir } = opts;
+  const reason: TickReason = opts.reason ?? "scheduled";
   if (!director.charter) {
-    return { status: "skipped", detail: "no charter", decisionsLogged: 0, costUsd: 0 };
+    return { status: "skipped", detail: "no charter", decisionsLogged: 0, costUsd: 0, reason };
   }
 
   rolloverDayIfNeeded(db, repoId);
@@ -119,6 +130,7 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
       detail: gate.reason,
       decisionsLogged: 0,
       costUsd: 0,
+      reason,
     };
   }
 
@@ -134,6 +146,7 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
     // charter loaded via Zod always has persona (PersonaSchema.default({})),
     // but tests pass plain object literals — fall back to schema defaults.
     persona: director.charter.persona ?? PersonaSchema.parse({}),
+    reason,
     state,
     dataDir,
     repoConfig: repo,
@@ -158,7 +171,7 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
     // mark the tick + bump the streak. The streak gate will pause us after N.
     markTick(db, repoId);
     bumpFailureStreak(db, repoId);
-    return { status: "error", detail, decisionsLogged: 0, costUsd: 0 };
+    return { status: "error", detail, decisionsLogged: 0, costUsd: 0, reason };
   }
 
   let llmResult;
@@ -181,7 +194,7 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
     });
     markTick(db, repoId);
     bumpFailureStreak(db, repoId);
-    return { status: "error", detail, decisionsLogged: 0, costUsd: 0 };
+    return { status: "error", detail, decisionsLogged: 0, costUsd: 0, reason };
   }
 
   const cost = llmResult.usage.costUsd ?? 0;
@@ -205,7 +218,13 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
     });
     markTick(db, repoId);
     bumpFailureStreak(db, repoId);
-    return { status: "error", detail: "schema-invalid", decisionsLogged: 0, costUsd: cost };
+    return {
+      status: "error",
+      detail: "schema-invalid",
+      decisionsLogged: 0,
+      costUsd: cost,
+      reason,
+    };
   }
 
   const tick = parsed.value;
@@ -295,6 +314,7 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
     detail: summary,
     decisionsLogged: recorded.length,
     costUsd: cost,
+    reason,
   };
 }
 

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -34,6 +34,7 @@ import { ensureBudgetState, checkBudgetGate } from "../director/budget.js";
 import type { BudgetState } from "../director/types.js";
 import { latestCharterVersion } from "../director/charter.js";
 import { approveDecision, rejectDecision } from "../director/executor.js";
+import { getActiveTick } from "../director/active-tick.js";
 import { GithubVcsProvider } from "../providers/github.js";
 import type { VcsProvider } from "../providers/vcs.js";
 import type { DirectorMessage, MessageType } from "../director/types.js";
@@ -365,13 +366,21 @@ function renderStatusPanel(
   repoId: number,
   budget: BudgetState,
   cadenceHours: number,
+  personaName: string,
+  personaAvatar: string,
 ): TrustedHtml {
   const unanswered = unansweredUserDirectives(db, repoId);
-  const isProcessing = budget.lastTickAt === null;
+  // Truth source for "is the director thinking right now": a fresh row in
+  // director_active_ticks. Stale rows (process crashed mid-tick) are
+  // filtered out by getActiveTick's TTL guard. The previous heuristic
+  // (`budget.lastTickAt === null`) only fired on the very first tick of
+  // a brand-new repo and was effectively dead code.
+  const active = getActiveTick(db, repoId);
+  const isProcessing = active !== null;
 
   // Visual state.
   const stateLabel = isProcessing
-    ? "🟡 Director is processing…"
+    ? `🟡 ${personaAvatar} ${personaName} is thinking… (${active.reason})`
     : budget.paused
       ? "⏸ Paused"
       : "🟢 Idle";
@@ -381,11 +390,15 @@ function renderStatusPanel(
       ? "border-[var(--border)] bg-[var(--surface-sunken)]"
       : "border-[var(--success)] bg-[var(--success-soft)]";
 
+  // While the director is mid-tick, poll faster so the chat refreshes its
+  // result the moment the tick finishes. Idle: 10s is plenty.
+  const pollInterval = isProcessing ? "2s" : "10s";
+
   return html`
     <div
       id="director-status"
       hx-get="/admin/director/${slug}/status"
-      hx-trigger="every 10s"
+      hx-trigger="every ${pollInterval}"
       hx-swap="outerHTML"
       class="rounded-lg border ${stateColor} p-3 text-sm flex flex-wrap items-center gap-x-4 gap-y-2"
     >
@@ -730,6 +743,8 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
       entry.repoId,
       budgetState,
       repo.director.cadence_hours,
+      personaName,
+      personaAvatar,
     );
 
     const chatCard = card({
@@ -916,14 +931,16 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
       entry.repoId,
       budgetState,
       repo.director.cadence_hours,
+      resolvePersonaName(repo),
+      resolvePersonaAvatar(repo),
     );
     return c.html(panel.value);
   });
 
-  // ── POST /:slug/tick-now — force the director to tick within ~60s ──
-  // Clears last_tick_at; the director loop polls every 60s and treats
+  // ── POST /:slug/tick-now — force the director to tick within ~10s ──
+  // Clears last_tick_at; the director loop wakes every 10s and treats
   // null as "should tick". The user sees the status panel flip to
-  // "processing" immediately and the result appears in chat once the
+  // "thinking" immediately and the result appears in chat once the
   // tick completes (typically 10–60s).
   app.post("/:slug/tick-now", (c) => {
     const slug = c.req.param("slug");
@@ -943,7 +960,7 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
       repoId: entry.repoId,
       role: "system",
       type: "tick_log",
-      body: "Tick requested manually via /admin (forces tick on next loop iteration, ≤60s)",
+      body: "Tick requested manually via /admin (forces tick on next loop iteration, ≤10s)",
       metadata: { repo: slug, actor: "admin", action: "tick_now" },
     });
 
@@ -954,6 +971,8 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
       entry.repoId,
       budgetState,
       repo.director.cadence_hours,
+      resolvePersonaName(repo),
+      resolvePersonaAvatar(repo),
     );
     return c.html(panel.value);
   });

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -319,4 +319,24 @@ function applyMigrations(db: Db): void {
       "INSERT INTO schema_version (version, applied_at) VALUES (13, datetime('now'))",
     ).run();
   }
+
+  // v14 — Director per-repo lock + in-flight indicator. Doubles as the
+  // backing store for the chat "typing…" indicator: while a row exists for
+  // a repo, the admin UI shows the persona is thinking. Auto-stale via
+  // ttl_s so a crashed tick doesn't wedge the lock forever. PRIMARY KEY
+  // on repo_id ⇒ a single active tick per repo is structurally enforced.
+  if (current < 14) {
+    db.exec(`
+      CREATE TABLE director_active_ticks (
+        repo_id INTEGER PRIMARY KEY REFERENCES repos(id) ON DELETE CASCADE,
+        started_at TEXT NOT NULL DEFAULT (datetime('now')),
+        holder_pid INTEGER NOT NULL,
+        reason TEXT NOT NULL,
+        ttl_s INTEGER NOT NULL DEFAULT 300
+      );
+    `);
+    db.prepare(
+      "INSERT INTO schema_version (version, applied_at) VALUES (14, datetime('now'))",
+    ).run();
+  }
 }

--- a/test/director-active-tick.test.mjs
+++ b/test/director-active-tick.test.mjs
@@ -1,0 +1,128 @@
+// Per-repo active-tick lock + thinking indicator.
+//
+// Verifies:
+//   • tryAcquire returns true once, false on a second concurrent attempt
+//   • a stale (TTL-expired) lock can be reclaimed
+//   • getActiveTick filters out stale rows
+//   • release drops the lock immediately
+//   • withActiveTick wraps a body with auto-release
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import {
+  getActiveTick,
+  releaseTick,
+  tryAcquireTick,
+  withActiveTick,
+} from "../dist/director/active-tick.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-active-tick-test-"));
+  const db = initDb(dir);
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+test("tryAcquireTick: first caller wins, second is rejected", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    assert.equal(tryAcquireTick(db, repoId, "scheduled"), true);
+    assert.equal(tryAcquireTick(db, repoId, "user_message"), false);
+    const active = getActiveTick(db, repoId);
+    assert.ok(active);
+    assert.equal(active.reason, "scheduled");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("releaseTick: drops the lock immediately", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    tryAcquireTick(db, repoId, "scheduled");
+    releaseTick(db, repoId);
+    assert.equal(getActiveTick(db, repoId), null);
+    assert.equal(tryAcquireTick(db, repoId, "user_message"), true);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("getActiveTick: stale rows are filtered out", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    // Insert a row that's already past its TTL by backdating started_at.
+    db.prepare(
+      `INSERT INTO director_active_ticks (repo_id, started_at, holder_pid, reason, ttl_s)
+       VALUES (?, datetime('now', '-10 minutes'), ?, 'stale', 60)`,
+    ).run(repoId, process.pid);
+    assert.equal(getActiveTick(db, repoId), null);
+    // ...and a fresh acquire reclaims the slot.
+    assert.equal(tryAcquireTick(db, repoId, "scheduled"), true);
+    const active = getActiveTick(db, repoId);
+    assert.ok(active);
+    assert.equal(active.reason, "scheduled");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("withActiveTick: runs body, releases on success", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const result = await withActiveTick(db, repoId, "scheduled", async () => {
+      assert.ok(getActiveTick(db, repoId)); // held during body
+      return 42;
+    });
+    assert.equal(result, 42);
+    assert.equal(getActiveTick(db, repoId), null); // released after
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("withActiveTick: releases on throw", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    await assert.rejects(
+      withActiveTick(db, repoId, "scheduled", async () => {
+        throw new Error("boom");
+      }),
+      /boom/,
+    );
+    assert.equal(getActiveTick(db, repoId), null);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("withActiveTick: returns null when lock is held, body not invoked", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    tryAcquireTick(db, repoId, "scheduled");
+    let invoked = false;
+    const result = await withActiveTick(db, repoId, "user_message", async () => {
+      invoked = true;
+      return 1;
+    });
+    assert.equal(result, null);
+    assert.equal(invoked, false);
+  } finally {
+    cleanup(dir);
+  }
+});


### PR DESCRIPTION
Closes #46. Refs #44, #48 (lock primitive shared with the dedup work).

The Director was robotic in two ways:
1. It ticked only on a 6-hour cadence — a user chat message could sit unanswered for hours.
2. The admin chat had no \"is it working right now\" indicator beyond a stale heuristic that practically never fired.

This PR fixes both.

## What's new

- **Schema v14** adds \`director_active_ticks\` — single row per repo, PRIMARY KEY enforces \"one tick at a time\". The same row doubles as a TTL-guarded advisory lock (so the next dedup PR builds on it for free) and as the truth source for the chat \"thinking…\" indicator.
- **Service loop wakes every 10s** (was 60s) and fires a tick when *either*:
  - the cadence has elapsed (existing behaviour), or
  - there are unanswered user messages (new — reactive trigger, <30s typical latency).
- **TickReason** (\`scheduled\` | \`user_message\` | \`pr_event\` | \`deploy_failed\` | \`manual\`) is plumbed through \`runTick\` and surfaced in the director-tick prompt under a new \"Why you're awake\" section so the LLM addresses chat first when reason=user_message.
- **Status panel** reads \`director_active_ticks\` to show \"🟡 \<persona\> is thinking… (\<reason\>)\" with the persona name + avatar, and polls 2s while busy / 10s while idle.

## Test plan
- [x] \`pnpm run check\` green (113 unit tests; +6 active-tick tests)
- [x] tryAcquire is idempotent / lock-respecting / TTL-reclaiming
- [x] withActiveTick releases on success and on throw
- [x] Existing tests unchanged (TickReason defaults to \"scheduled\")