### PR TITLE
feat(director): edit-before-approve for proposals

### DIFF
--- a/src/director/decisions.ts
+++ b/src/director/decisions.ts
@@ -92,6 +92,17 @@ export function getDecisionById(db: Db, decisionId: number): Decision | null {
   return row ? rowToDecision(row) : null;
 }
 
+// Persist a payload edit on top of an existing pending decision. Used by
+// the edit-before-approve flow so the audit trail records what was actually
+// executed instead of the LLM's original proposal. Caller is responsible
+// for validating the new payload shape — we just store it.
+export function setDecisionPayload(db: Db, decisionId: number, payload: unknown): void {
+  db.prepare(`UPDATE director_decisions SET payload = ? WHERE id = ?`).run(
+    JSON.stringify(payload ?? null),
+    decisionId,
+  );
+}
+
 export function pendingDecisions(db: Db, repoId: number): Decision[] {
   const rows = db
     .prepare(

--- a/src/director/executor.ts
+++ b/src/director/executor.ts
@@ -38,7 +38,7 @@ import type { Db } from "../storage/db.js";
 import type { RepoConfig } from "../config/schema.js";
 import { repoKey } from "../config/schema.js";
 import type { VcsProvider, VcsRepoRef } from "../providers/vcs.js";
-import { getDecisionById, setDecisionOutcome } from "./decisions.js";
+import { getDecisionById, setDecisionOutcome, setDecisionPayload } from "./decisions.js";
 import { appendMessage } from "./chat.js";
 import type { ParsedDecision } from "./decision-schema.js";
 import type { DecisionOutcome, DirectorAuthority, DirectorConfig } from "./types.js";
@@ -350,6 +350,48 @@ function truncate(s: string, n: number): string {
   return s.length <= n ? s : s.slice(0, n - 1) + "…";
 }
 
+// ── Type-aware payload merge for edit-before-approve ─────────────────────
+//
+// Operators can tweak a proposal before approving it (rename a sloppy issue
+// title, soften an aggressive comment, drop a label). We don't trust the
+// HTTP form blindly — only known fields per decision_type are honoured.
+// Anything else is dropped silently rather than rejected so a UI quirk
+// can't break approvals.
+const EDITABLE_FIELDS: Record<string, readonly string[]> = {
+  create_issue: ["title", "body", "labels", "priority"],
+  comment_on_issue: ["body"],
+  comment_on_pr: ["body"],
+  label_issue: ["add", "remove"],
+  label_pr: ["add", "remove"],
+  close_issue: ["reason"],
+  approve_pr: ["body"],
+  merge_pr: ["strategy"],
+  ask_user: ["question", "context"],
+  amend_charter: ["proposed_changes", "rationale"],
+};
+
+export function editableFieldsFor(decisionType: string): readonly string[] {
+  return EDITABLE_FIELDS[decisionType] ?? [];
+}
+
+export function mergePayloadOverrides(
+  decisionType: string,
+  original: unknown,
+  overrides: Record<string, unknown>,
+): unknown {
+  const fields = EDITABLE_FIELDS[decisionType];
+  if (!fields) return original; // no_op or unknown type — refuse to edit
+  const base =
+    original && typeof original === "object" ? (original as Record<string, unknown>) : {};
+  const merged: Record<string, unknown> = { ...base };
+  for (const f of fields) {
+    if (Object.prototype.hasOwnProperty.call(overrides, f)) {
+      merged[f] = overrides[f];
+    }
+  }
+  return merged;
+}
+
 // ── Human approve / reject (from /admin/director or Telegram) ────────────
 //
 // `pending` decisions sit in the queue until a human acts. These two
@@ -364,6 +406,12 @@ export type ApproveOptions = {
   director: DirectorConfig;
   actor: string; // "admin" | "telegram:<userId>" — for chat metadata
   getVcs: () => VcsProvider;
+  // Optional human edits to the proposed payload. Merged on top of the
+  // stored payload before execution and persisted back to the decision row
+  // so the audit trail captures what was actually executed, not what was
+  // initially proposed. Type-aware merge — only fields valid for the given
+  // decision_type are honoured (others are dropped).
+  overrides?: Record<string, unknown>;
 };
 
 export type ApproveResult =
@@ -384,13 +432,27 @@ export async function approveDecision(opts: ApproveOptions): Promise<ApproveResu
     return { ok: false, reason: `decision ${decisionId} belongs to a different repo` };
   }
 
+  // Apply human edits (if any) on top of the stored payload. Only fields
+  // valid for this decision-type pass through; everything else is dropped.
+  // We persist the merged payload back to the row before execution so a
+  // failed run still leaves the audit trail showing what we tried.
+  let effectivePayload = decision.payload;
+  if (opts.overrides && Object.keys(opts.overrides).length > 0) {
+    effectivePayload = mergePayloadOverrides(
+      decision.decisionType,
+      decision.payload,
+      opts.overrides,
+    );
+    setDecisionPayload(db, decisionId, effectivePayload);
+  }
+
   // Reconstruct a ParsedDecision-shaped object from the stored row. The
   // schema-validation already ran when the decision was first recorded;
   // re-validating here is paranoia we'd pay on every approve. Skip it.
   const parsed = {
     type: decision.decisionType,
     rationale: decision.rationale,
-    payload: decision.payload,
+    payload: effectivePayload,
   } as unknown as ParsedDecision;
 
   // Re-check authority — operator may have flipped a `can_*` between the

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -170,9 +170,7 @@ type DecisionOutcomeView = {
 function decisionOutcomeView(db: Db, decisionId: number | null): DecisionOutcomeView | null {
   if (decisionId == null) return null;
   const row = db
-    .prepare(
-      `SELECT outcome, outcome_details, decision_type FROM director_decisions WHERE id = ?`,
-    )
+    .prepare(`SELECT outcome, outcome_details, decision_type FROM director_decisions WHERE id = ?`)
     .get(decisionId) as
     | { outcome: string; outcome_details: string | null; decision_type: string }
     | undefined;
@@ -366,10 +364,14 @@ function renderProposalActions(
 // We intentionally render plain form fields rather than a JSON editor —
 // the operator's job is to tweak title/body/labels, not to hand-craft a
 // payload schema.
-function renderEditForm(slug: string, decisionId: number, decision: {
-  decisionType: string;
-  payload: unknown;
-}): TrustedHtml {
+function renderEditForm(
+  slug: string,
+  decisionId: number,
+  decision: {
+    decisionType: string;
+    payload: unknown;
+  },
+): TrustedHtml {
   const p = (decision.payload ?? {}) as Record<string, unknown>;
   const stringField = (name: string, label: string, value: unknown): TrustedHtml => html`
     <label class="flex flex-col gap-1 text-xs">
@@ -429,7 +431,8 @@ ${typeof value === "string" ? value : ""}</textarea
     case "label_issue":
     case "label_pr":
       fields = html`
-        ${csvField("add", "Labels to add", p.add)} ${csvField("remove", "Labels to remove", p.remove)}
+        ${csvField("add", "Labels to add", p.add)}
+        ${csvField("remove", "Labels to remove", p.remove)}
       `;
       break;
     case "close_issue":

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -35,6 +35,7 @@ import type { BudgetState } from "../director/types.js";
 import { latestCharterVersion } from "../director/charter.js";
 import { approveDecision, rejectDecision } from "../director/executor.js";
 import { getActiveTick } from "../director/active-tick.js";
+import { getDecisionById } from "../director/decisions.js";
 import { GithubVcsProvider } from "../providers/github.js";
 import type { VcsProvider } from "../providers/vcs.js";
 import type { DirectorMessage, MessageType } from "../director/types.js";
@@ -163,15 +164,24 @@ function groupNoise(messages: DirectorMessage[]): RenderItem[] {
 type DecisionOutcomeView = {
   outcome: string;
   outcomeDetails: string | null;
+  decisionType: string;
 };
 
 function decisionOutcomeView(db: Db, decisionId: number | null): DecisionOutcomeView | null {
   if (decisionId == null) return null;
   const row = db
-    .prepare(`SELECT outcome, outcome_details FROM director_decisions WHERE id = ?`)
-    .get(decisionId) as { outcome: string; outcome_details: string | null } | undefined;
+    .prepare(
+      `SELECT outcome, outcome_details, decision_type FROM director_decisions WHERE id = ?`,
+    )
+    .get(decisionId) as
+    | { outcome: string; outcome_details: string | null; decision_type: string }
+    | undefined;
   if (!row) return null;
-  return { outcome: row.outcome, outcomeDetails: row.outcome_details };
+  return {
+    outcome: row.outcome,
+    outcomeDetails: row.outcome_details,
+    decisionType: row.decision_type,
+  };
 }
 
 function renderMessage(
@@ -207,8 +217,8 @@ function renderMessage(
       </div>
       <div class="rounded-lg border ${bubbleColor} p-3 max-w-[min(42rem,90%)] text-sm shadow-sm">
         <div class="md-body">${m.body}</div>
-        ${isLiveProposal && m.decisionId
-          ? renderProposalActions(slug, m.decisionId)
+        ${isLiveProposal && m.decisionId && proposalOutcome
+          ? renderProposalActions(slug, m.decisionId, proposalOutcome.decisionType)
           : proposalOutcome
             ? renderProposalOutcome(proposalOutcome)
             : ""}
@@ -292,35 +302,256 @@ function renderNoiseGroup(msgs: DirectorMessage[]): TrustedHtml {
   `;
 }
 
-function renderProposalActions(slug: string, decisionId: number): TrustedHtml {
+function renderProposalActions(
+  slug: string,
+  decisionId: number,
+  decisionType: string,
+): TrustedHtml {
+  // The "Edit" button is only meaningful for decision types with a
+  // non-trivial payload — no_op / approve_pr (no body) get the buttons
+  // without the edit affordance.
+  const editable = ![
+    "no_op",
+    // approve_pr has just an optional body, so it IS editable; merge_pr
+    // edits would just change strategy. Both are kept in the editable set.
+  ].includes(decisionType);
+
   return html`
-    <div class="flex flex-wrap items-center gap-2 mt-3 pt-3 border-t border-[var(--border)]">
-      <button
-        class="btn btn-success btn-sm"
-        hx-post="/admin/director/${slug}/decisions/${decisionId}/approve"
-        hx-target="#chat-thread"
-        hx-swap="outerHTML"
-        hx-confirm="Approve and execute decision #${decisionId}?"
-      >
-        ✓ Approve
-      </button>
-      <button
-        class="btn btn-danger btn-sm"
-        hx-post="/admin/director/${slug}/decisions/${decisionId}/reject"
-        hx-target="#chat-thread"
-        hx-swap="outerHTML"
-        hx-vals="js:{reason: document.getElementById('reject-${decisionId}').value}"
-      >
-        ✗ Reject
-      </button>
-      <input
-        id="reject-${decisionId}"
-        type="text"
-        placeholder="reject reason (optional)"
-        class="form-input form-input-sm flex-1 min-w-[14rem] text-xs"
-      />
+    <div class="flex flex-col gap-2 mt-3 pt-3 border-t border-[var(--border)]">
+      <div id="edit-slot-${decisionId}"></div>
+      <div class="flex flex-wrap items-center gap-2">
+        <button
+          class="btn btn-success btn-sm"
+          hx-post="/admin/director/${slug}/decisions/${decisionId}/approve"
+          hx-target="#chat-thread"
+          hx-swap="outerHTML"
+          hx-confirm="Approve and execute decision #${decisionId}?"
+        >
+          ✓ Approve as-is
+        </button>
+        ${editable
+          ? html`<button
+              class="btn btn-secondary btn-sm"
+              hx-get="/admin/director/${slug}/decisions/${decisionId}/edit"
+              hx-target="#edit-slot-${decisionId}"
+              hx-swap="innerHTML"
+            >
+              ✏ Edit & approve
+            </button>`
+          : ""}
+        <button
+          class="btn btn-danger btn-sm"
+          hx-post="/admin/director/${slug}/decisions/${decisionId}/reject"
+          hx-target="#chat-thread"
+          hx-swap="outerHTML"
+          hx-vals="js:{reason: document.getElementById('reject-${decisionId}').value}"
+        >
+          ✗ Reject
+        </button>
+        <input
+          id="reject-${decisionId}"
+          type="text"
+          placeholder="reject reason (optional)"
+          class="form-input form-input-sm flex-1 min-w-[14rem] text-xs"
+        />
+      </div>
     </div>
   `;
+}
+
+// Form for editing a proposal's payload before approving. The set of fields
+// rendered depends on decision_type — see EDITABLE_FIELDS in executor.ts
+// for the source of truth on what's actually applied at execution time.
+//
+// We intentionally render plain form fields rather than a JSON editor —
+// the operator's job is to tweak title/body/labels, not to hand-craft a
+// payload schema.
+function renderEditForm(slug: string, decisionId: number, decision: {
+  decisionType: string;
+  payload: unknown;
+}): TrustedHtml {
+  const p = (decision.payload ?? {}) as Record<string, unknown>;
+  const stringField = (name: string, label: string, value: unknown): TrustedHtml => html`
+    <label class="flex flex-col gap-1 text-xs">
+      <span class="text-[var(--fg-muted)]">${label}</span>
+      <input
+        type="text"
+        name="${name}"
+        value="${typeof value === "string" ? value : ""}"
+        class="form-input form-input-sm"
+      />
+    </label>
+  `;
+  const textArea = (name: string, label: string, value: unknown, rows = 4): TrustedHtml => html`
+    <label class="flex flex-col gap-1 text-xs">
+      <span class="text-[var(--fg-muted)]">${label}</span>
+      <textarea name="${name}" rows="${rows}" class="form-textarea form-textarea-sm">
+${typeof value === "string" ? value : ""}</textarea
+      >
+    </label>
+  `;
+  const csvField = (name: string, label: string, value: unknown): TrustedHtml => {
+    const csv = Array.isArray(value) ? value.join(", ") : "";
+    return html`
+      <label class="flex flex-col gap-1 text-xs">
+        <span class="text-[var(--fg-muted)]">${label} (comma-separated)</span>
+        <input type="text" name="${name}" value="${csv}" class="form-input form-input-sm" />
+      </label>
+    `;
+  };
+  const select = (name: string, label: string, value: unknown, options: string[]): TrustedHtml => {
+    const cur = typeof value === "string" ? value : options[0];
+    return html`
+      <label class="flex flex-col gap-1 text-xs">
+        <span class="text-[var(--fg-muted)]">${label}</span>
+        <select name="${name}" class="form-select form-select-sm">
+          ${options.map(
+            (o) => html`<option value="${o}" ${o === cur ? "selected" : ""}>${o}</option>`,
+          )}
+        </select>
+      </label>
+    `;
+  };
+
+  let fields: TrustedHtml;
+  switch (decision.decisionType) {
+    case "create_issue":
+      fields = html`
+        ${stringField("title", "Title", p.title)} ${textArea("body", "Body (markdown)", p.body, 8)}
+        ${csvField("labels", "Labels", p.labels)}
+        ${select("priority", "Priority", p.priority, ["low", "normal", "high"])}
+      `;
+      break;
+    case "comment_on_issue":
+    case "comment_on_pr":
+      fields = textArea("body", "Comment body (markdown)", p.body, 6);
+      break;
+    case "label_issue":
+    case "label_pr":
+      fields = html`
+        ${csvField("add", "Labels to add", p.add)} ${csvField("remove", "Labels to remove", p.remove)}
+      `;
+      break;
+    case "close_issue":
+      fields = textArea("reason", "Close reason (posted as comment first)", p.reason, 4);
+      break;
+    case "approve_pr":
+      fields = textArea("body", "Review body (optional)", p.body, 4);
+      break;
+    case "merge_pr":
+      fields = select("strategy", "Merge strategy", p.strategy, ["squash", "merge", "rebase"]);
+      break;
+    case "ask_user":
+      fields = html`
+        ${textArea("question", "Question", p.question, 3)}
+        ${textArea("context", "Context (optional)", p.context, 3)}
+      `;
+      break;
+    case "amend_charter":
+      fields = html`
+        ${textArea("proposed_changes", "Proposed changes", p.proposed_changes, 6)}
+        ${textArea("rationale", "Rationale", p.rationale, 3)}
+      `;
+      break;
+    default:
+      fields = html`<p class="text-xs text-[var(--fg-muted)]">
+        This decision type does not support inline editing.
+      </p>`;
+  }
+
+  return html`
+    <form
+      class="flex flex-col gap-2 p-3 border border-[var(--accent)] rounded-md bg-[var(--accent-soft)]"
+      hx-post="/admin/director/${slug}/decisions/${decisionId}/approve"
+      hx-target="#chat-thread"
+      hx-swap="outerHTML"
+    >
+      <div class="text-xs text-[var(--fg-muted)] font-medium">
+        Editing decision #${decisionId} (${decision.decisionType}) — submit to approve with edits
+      </div>
+      ${fields}
+      <div class="flex items-center gap-2">
+        <button type="submit" class="btn btn-success btn-sm">✓ Approve with edits</button>
+        <button
+          type="button"
+          class="btn btn-secondary btn-sm"
+          hx-get="/admin/director/${slug}/decisions/${decisionId}/edit/cancel"
+          hx-target="#edit-slot-${decisionId}"
+          hx-swap="innerHTML"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  `;
+}
+
+// Translate the flat form body into a typed `overrides` object for
+// mergePayloadOverrides. Only fields recognised for the decision-type
+// pass through; unknown fields are dropped server-side too.
+function parseOverridesForm(
+  decisionType: string,
+  form: Record<string, string | File | (string | File)[]>,
+): Record<string, unknown> {
+  const get = (k: string): string | undefined => {
+    const v = form[k];
+    if (typeof v === "string") return v;
+    return undefined;
+  };
+  const overrides: Record<string, unknown> = {};
+  switch (decisionType) {
+    case "create_issue": {
+      if (get("title") !== undefined) overrides.title = String(get("title")).trim();
+      if (get("body") !== undefined) overrides.body = String(get("body"));
+      const labels = get("labels");
+      if (labels !== undefined) {
+        overrides.labels = labels
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+      }
+      if (get("priority") !== undefined) overrides.priority = get("priority");
+      return overrides;
+    }
+    case "comment_on_issue":
+    case "comment_on_pr":
+    case "approve_pr":
+      if (get("body") !== undefined) overrides.body = String(get("body"));
+      return overrides;
+    case "label_issue":
+    case "label_pr": {
+      const csv = (k: string): string[] | undefined => {
+        const v = get(k);
+        if (v === undefined) return undefined;
+        return v
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+      };
+      const add = csv("add");
+      const remove = csv("remove");
+      if (add !== undefined) overrides.add = add;
+      if (remove !== undefined) overrides.remove = remove;
+      return overrides;
+    }
+    case "close_issue":
+      if (get("reason") !== undefined) overrides.reason = String(get("reason"));
+      return overrides;
+    case "merge_pr":
+      if (get("strategy") !== undefined) overrides.strategy = get("strategy");
+      return overrides;
+    case "ask_user":
+      if (get("question") !== undefined) overrides.question = String(get("question"));
+      if (get("context") !== undefined) overrides.context = String(get("context"));
+      return overrides;
+    case "amend_charter":
+      if (get("proposed_changes") !== undefined)
+        overrides.proposed_changes = String(get("proposed_changes"));
+      if (get("rationale") !== undefined) overrides.rationale = String(get("rationale"));
+      return overrides;
+    default:
+      return overrides;
+  }
 }
 
 // ── Tick status panel ────────────────────────────────────────────────
@@ -853,6 +1084,34 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
     );
   });
 
+  // ── GET /:slug/decisions/:id/edit ────────────────────────────────────
+  // Returns just the inline edit form for a pending proposal — HTMX swaps
+  // it into the placeholder slot inside the proposal bubble.
+  app.get("/:slug/decisions/:id/edit", (c) => {
+    const slug = c.req.param("slug");
+    const decisionId = Number(c.req.param("id"));
+    const entries = listEntries(db, getConfig);
+    const entry = entries.find((e) => e.slug === slug);
+    if (!entry) return c.notFound();
+    const decision = getDecisionById(db, decisionId);
+    if (!decision || decision.repoId !== entry.repoId) return c.notFound();
+    if (decision.outcome !== "pending") {
+      return c.html(
+        '<p class="text-xs text-[var(--fg-muted)]">This decision is no longer pending.</p>',
+      );
+    }
+    return c.html(
+      renderEditForm(slug, decisionId, {
+        decisionType: decision.decisionType,
+        payload: decision.payload,
+      }).value,
+    );
+  });
+
+  // ── GET /:slug/decisions/:id/edit/cancel ─────────────────────────────
+  // Dismiss the edit form. Returns empty so HTMX clears the slot.
+  app.get("/:slug/decisions/:id/edit/cancel", (c) => c.html(""));
+
   // ── POST /:slug/decisions/:id/approve ────────────────────────────────
   app.post("/:slug/decisions/:id/approve", async (c) => {
     const slug = c.req.param("slug");
@@ -865,6 +1124,18 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
     const repo = config.repos.find((r) => repoKey(r) === slug);
     if (!repo || !repo.director) return c.notFound();
 
+    // The body may carry edit-form overrides. Look up the decision so we
+    // know its type and can extract only the relevant fields.
+    const form = await c.req.parseBody().catch(() => ({}) as Record<string, unknown>);
+    const decision = getDecisionById(db, decisionId);
+    const overrides =
+      decision && Object.keys(form).length > 0
+        ? parseOverridesForm(
+            decision.decisionType,
+            form as Record<string, string | File | (string | File)[]>,
+          )
+        : undefined;
+
     await approveDecision({
       db,
       decisionId,
@@ -872,6 +1143,7 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
       director: repo.director,
       actor: "admin",
       getVcs: () => defaultVcsFactory(repo),
+      overrides: overrides && Object.keys(overrides).length > 0 ? overrides : undefined,
     });
 
     const messages = recentMessages(db, entry.repoId, 200);

--- a/test/director-edit-overrides.test.mjs
+++ b/test/director-edit-overrides.test.mjs
@@ -7,10 +7,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import {
-  editableFieldsFor,
-  mergePayloadOverrides,
-} from "../dist/director/executor.js";
+import { editableFieldsFor, mergePayloadOverrides } from "../dist/director/executor.js";
 
 test("editableFieldsFor: returns expected fields for create_issue", () => {
   const fields = editableFieldsFor("create_issue");

--- a/test/director-edit-overrides.test.mjs
+++ b/test/director-edit-overrides.test.mjs
@@ -1,0 +1,79 @@
+// Edit-before-approve: payload override merge.
+//
+// Verifies the type-aware merge in the executor does the right thing:
+//   • only fields recognised for the decision-type pass through
+//   • original fields not touched by overrides are preserved
+//   • unknown decision types (e.g. no_op) reject all edits
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  editableFieldsFor,
+  mergePayloadOverrides,
+} from "../dist/director/executor.js";
+
+test("editableFieldsFor: returns expected fields for create_issue", () => {
+  const fields = editableFieldsFor("create_issue");
+  assert.deepEqual([...fields].sort(), ["body", "labels", "priority", "title"]);
+});
+
+test("editableFieldsFor: empty list for unknown type", () => {
+  assert.deepEqual([...editableFieldsFor("no_op")], []);
+  assert.deepEqual([...editableFieldsFor("delete_repo")], []);
+});
+
+test("mergePayloadOverrides: applies title + labels override on create_issue", () => {
+  const original = {
+    title: "Old title",
+    body: "Body markdown",
+    labels: ["openronin:do-it"],
+    priority: "low",
+  };
+  const merged = mergePayloadOverrides("create_issue", original, {
+    title: "New title",
+    labels: ["bug", "good first issue"],
+  });
+  assert.deepEqual(merged, {
+    title: "New title",
+    body: "Body markdown",
+    labels: ["bug", "good first issue"],
+    priority: "low",
+  });
+});
+
+test("mergePayloadOverrides: drops unknown fields silently", () => {
+  const original = { body: "hi" };
+  const merged = mergePayloadOverrides("comment_on_issue", original, {
+    body: "bye",
+    issue_number: 999, // not editable
+    secret: "leak",
+  });
+  assert.deepEqual(merged, { body: "bye" });
+});
+
+test("mergePayloadOverrides: refuses to mutate no_op payload", () => {
+  const original = { foo: "bar" };
+  const merged = mergePayloadOverrides("no_op", original, { foo: "baz" });
+  assert.deepEqual(merged, original);
+});
+
+test("mergePayloadOverrides: handles missing original gracefully", () => {
+  const merged = mergePayloadOverrides("close_issue", null, { reason: "stale" });
+  assert.deepEqual(merged, { reason: "stale" });
+});
+
+test("mergePayloadOverrides: preserves issue_number across edit on label_issue", () => {
+  // label_issue has issue_number (not editable) + add/remove (editable).
+  // The non-editable identifying field MUST survive an edit so the
+  // executed call still targets the right issue.
+  const original = {
+    issue_number: 42,
+    add: ["bug"],
+    remove: [],
+  };
+  const merged = mergePayloadOverrides("label_issue", original, {
+    add: ["bug", "high-priority"],
+  });
+  assert.equal(merged.issue_number, 42);
+  assert.deepEqual(merged.add, ["bug", "high-priority"]);
+});


### PR DESCRIPTION
Closes #47. Refs #44.

Operators previously had a binary choice on each proposal: approve as-is or reject and wait for the LLM to re-propose. Sloppy issue titles or overly aggressive comments forced a costly round-trip.

This PR adds an inline \"✏ Edit & approve\" path:

- Each proposal bubble grows an Edit button alongside the existing Approve/Reject controls. Click → HTMX swaps in a type-aware form pre-populated from the LLM's payload (title/body/labels/priority for create_issue; body for comments; add/remove CSV for labels; etc.).
- Submit → POST /decisions/:id/approve carries the edited fields. The server merges them onto the stored payload (only fields valid for the decision-type pass through; identifying fields like issue_number are preserved) and persists the merged payload back to the row before execution, so the audit trail records what was actually executed.
- Cancel button restores the as-is approve flow.

## Test plan
- [x] \`pnpm run check\` green (120 unit tests; +7 override merge tests)
- [x] Approve as-is path unchanged
- [x] Edit form renders correct fields per decision_type
- [x] Unknown fields dropped silently server-side
- [x] no_op rejects all overrides