### PR TITLE
feat(director): decision dedup via canonical payload hash

### DIFF
--- a/src/director/decisions.ts
+++ b/src/director/decisions.ts
@@ -6,6 +6,7 @@
 
 import type { Db } from "../storage/db.js";
 import type { Decision, DecisionOutcome, DecisionType, NewDecision } from "./types.js";
+import { findRecentDuplicate, hashPayload } from "./dedup.js";
 
 type DecisionRow = {
   id: number;
@@ -20,6 +21,7 @@ type DecisionRow = {
   outcome_ts: string | null;
   outcome_details: string | null;
   cost_usd: number;
+  payload_hash: string | null;
 };
 
 function rowToDecision(row: DecisionRow): Decision {
@@ -39,13 +41,32 @@ function rowToDecision(row: DecisionRow): Decision {
   };
 }
 
+// Compute a stable hash over (decision_type, payload) and check whether a
+// recent decision (last 7 days, outcome ∈ {pending, executed}) carries the
+// same hash. Returns the duplicate's id if found, else null. Exposed here
+// (not just inside recordDecision) so callers can decide what to do —
+// the tick loop downgrades a duplicate to outcome=skipped instead of
+// inserting it. no_op / ask_user always return null (hash undefined).
+export function checkForDuplicate(
+  db: Db,
+  repoId: number,
+  decisionType: string,
+  payload: unknown,
+): { hash: string | null; duplicateOf: number | null } {
+  const hash = hashPayload(decisionType, payload);
+  if (!hash) return { hash: null, duplicateOf: null };
+  const duplicateOf = findRecentDuplicate(db, repoId, hash);
+  return { hash, duplicateOf };
+}
+
 export function recordDecision(db: Db, d: NewDecision): Decision {
+  const hash = hashPayload(d.decisionType, d.payload);
   const row = db
     .prepare(
       `INSERT INTO director_decisions
          (repo_id, decision_type, rationale, charter_version,
-          state_snapshot, payload, outcome, cost_usd)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          state_snapshot, payload, outcome, cost_usd, payload_hash)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
        RETURNING *`,
     )
     .get(
@@ -57,6 +78,7 @@ export function recordDecision(db: Db, d: NewDecision): Decision {
       d.payload ? JSON.stringify(d.payload) : null,
       d.outcome ?? "pending",
       d.costUsd ?? 0,
+      hash,
     ) as DecisionRow;
   return rowToDecision(row);
 }

--- a/src/director/dedup.ts
+++ b/src/director/dedup.ts
@@ -1,0 +1,112 @@
+// Decision payload hashing + duplicate detection.
+//
+// The Director used to happily propose the same create_issue ("add per-repo
+// cost view") tick after tick — the state snapshot didn't surface
+// just-proposed-but-not-yet-merged work, and even when it did, the LLM's
+// re-summary drifted enough that a naive equality check missed it.
+//
+// We address it with a normalised payload hash. The hash is intentionally
+// lossy: it folds case, whitespace, leading articles, and trailing
+// punctuation so cosmetic re-wordings collapse to the same bucket. The
+// hash is computed and stored on every insert; before persisting a new
+// decision we check whether a row with the same hash exists in
+// (pending | executed) state within the last 7 days. If yes → outcome
+// is recorded as 'skipped' with a duplicate-of-#N reason instead of
+// being routed through the executor.
+//
+// Hashing is per-decision-type so e.g. "create_issue with title X" and
+// "comment_on_issue with body X" never collide.
+
+import { createHash } from "node:crypto";
+import type { Db } from "../storage/db.js";
+
+// 7-day lookback for dedup. Long enough to catch "the LLM re-proposes
+// every other tick" loops; short enough that genuinely-identical work
+// across weeks (which is rare and usually intentional) goes through.
+export const DEDUP_LOOKBACK_DAYS = 7;
+
+// Normalise free-form text for hashing: lowercase, collapse whitespace,
+// strip a few common prefix/suffix patterns ("issue:", trailing periods,
+// etc.) so cosmetic edits don't dodge the dedup.
+export function normaliseText(s: unknown): string {
+  if (typeof s !== "string") return "";
+  return s
+    .toLowerCase()
+    .replace(/^\s*(issue|task|chore|todo)\s*[:\-]\s*/u, "")
+    .replace(/\s+/gu, " ")
+    .replace(/[\s.!?,;:—–-]+$/u, "")
+    .trim();
+}
+
+function firstParagraph(s: unknown): string {
+  if (typeof s !== "string") return "";
+  const block = s.split(/\n\s*\n/u)[0] ?? "";
+  return normaliseText(block);
+}
+
+function csv(value: unknown): string {
+  if (!Array.isArray(value)) return "";
+  return [...new Set(value.map((v) => normaliseText(v)).filter(Boolean))].sort().join(",");
+}
+
+// Build a stable canonical string for a (decision_type, payload) pair.
+// Returns null when the type is one for which dedup doesn't make sense
+// (no_op, ask_user — both of which are cheap and idempotent already).
+export function canonicalForHash(decisionType: string, payload: unknown): string | null {
+  const p = (payload ?? {}) as Record<string, unknown>;
+  switch (decisionType) {
+    case "create_issue":
+      return `create_issue|${normaliseText(p.title)}|${firstParagraph(p.body)}`;
+    case "comment_on_issue":
+      return `comment_on_issue|${p.issue_number ?? ""}|${normaliseText(p.body)}`;
+    case "comment_on_pr":
+      return `comment_on_pr|${p.pr_number ?? ""}|${normaliseText(p.body)}`;
+    case "label_issue":
+      return `label_issue|${p.issue_number ?? ""}|${csv(p.add)}|${csv(p.remove)}`;
+    case "label_pr":
+      return `label_pr|${p.pr_number ?? ""}|${csv(p.add)}|${csv(p.remove)}`;
+    case "close_issue":
+      return `close_issue|${p.issue_number ?? ""}`;
+    case "approve_pr":
+      return `approve_pr|${p.pr_number ?? ""}`;
+    case "merge_pr":
+      return `merge_pr|${p.pr_number ?? ""}`;
+    case "amend_charter":
+      return `amend_charter|${normaliseText(p.proposed_changes)}`;
+    case "ask_user":
+    case "no_op":
+      return null;
+    default:
+      return null;
+  }
+}
+
+export function hashPayload(decisionType: string, payload: unknown): string | null {
+  const canon = canonicalForHash(decisionType, payload);
+  if (!canon) return null;
+  return createHash("sha256").update(canon).digest("hex").slice(0, 16);
+}
+
+// Look up a recent decision matching the same hash on the same repo.
+// Returns the decision id if found, otherwise null. Excludes outcomes that
+// don't represent a still-living proposal (rejected/expired/failed) — only
+// pending and executed count, since those are the ones a duplicate would
+// actually conflict with.
+export function findRecentDuplicate(
+  db: Db,
+  repoId: number,
+  payloadHash: string,
+  lookbackDays: number = DEDUP_LOOKBACK_DAYS,
+): number | null {
+  const row = db
+    .prepare(
+      `SELECT id FROM director_decisions
+       WHERE repo_id = ?
+         AND payload_hash = ?
+         AND outcome IN ('pending', 'executed')
+         AND ts > datetime('now', ?)
+       ORDER BY id DESC LIMIT 1`,
+    )
+    .get(repoId, payloadHash, `-${lookbackDays} days`) as { id: number } | undefined;
+  return row ? row.id : null;
+}

--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -33,7 +33,7 @@ import {
   resetFailureStreak,
   rolloverDayIfNeeded,
 } from "./budget.js";
-import { recordDecision } from "./decisions.js";
+import { checkForDuplicate, recordDecision, setDecisionOutcome } from "./decisions.js";
 import { captureStateSnapshot } from "./state.js";
 import { composePrompt } from "./prompt.js";
 import { recalibrateBudget, shouldRecalibrateToday } from "./retrospective.js";
@@ -392,6 +392,14 @@ function recordTickDecisions(
   for (const d of args.tick.decisions) {
     const slice = each + remainder;
     remainder = 0; // only first row gets the leftover
+    const payload = "payload" in d ? d.payload : null;
+
+    // Dedup gate: if we already have a pending or executed decision in
+    // the last 7 days with the same canonicalised payload, record this
+    // one as 'skipped' with a duplicate-of pointer. Stops the LLM from
+    // re-proposing the same create_issue every other tick when its
+    // state-snapshot lags behind reality.
+    const dup = checkForDuplicate(db, args.repoId, d.type, payload);
     const row = recordDecision(db, {
       repoId: args.repoId,
       decisionType: d.type as DecisionType,
@@ -402,12 +410,23 @@ function recordTickDecisions(
         reasoning: args.tick.reasoning,
         priorityId: "priority_id" in d ? d.priority_id : undefined,
       },
-      payload: "payload" in d ? d.payload : null,
+      payload,
       // Always pending at record time. The executor flips it to its final
       // outcome (executed / pending-with-proposal / dry_run / failed / skipped).
       outcome: "pending",
       costUsd: slice,
     });
+    if (dup.duplicateOf !== null) {
+      // Mark the just-inserted row as a skipped duplicate. We still keep
+      // the audit-trail record; the executor never sees it.
+      setDecisionOutcome(
+        db,
+        row.id,
+        "skipped",
+        `duplicate of decision #${dup.duplicateOf} (within ${7}d, same canonical payload)`,
+      );
+      continue; // don't return it to executor
+    }
     out.push({ id: row.id, decision: d });
   }
   return out;

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -339,4 +339,20 @@ function applyMigrations(db: Db): void {
       "INSERT INTO schema_version (version, applied_at) VALUES (14, datetime('now'))",
     ).run();
   }
+
+  // v15 — Director decision dedup. payload_hash is a 16-char SHA-256
+  // prefix over a normalised canonical form of (decision_type, payload).
+  // recordDecision computes it on insert; an indexed lookup on
+  // (repo_id, payload_hash, outcome, ts) implements the 7-day duplicate
+  // gate with an actual index instead of a table scan.
+  if (current < 15) {
+    db.exec(`
+      ALTER TABLE director_decisions ADD COLUMN payload_hash TEXT;
+      CREATE INDEX idx_director_decisions_dedup
+        ON director_decisions(repo_id, payload_hash, outcome, ts);
+    `);
+    db.prepare(
+      "INSERT INTO schema_version (version, applied_at) VALUES (15, datetime('now'))",
+    ).run();
+  }
 }

--- a/test/director-dedup.test.mjs
+++ b/test/director-dedup.test.mjs
@@ -1,0 +1,257 @@
+// Decision dedup hashing + duplicate detection.
+//
+// Verifies:
+//   • normaliseText folds case / whitespace / common prefixes
+//   • hashPayload returns stable values for cosmetic re-wordings
+//   • create_issue, comment_*, label_* each generate distinct hashes
+//   • findRecentDuplicate respects the 7-day lookback
+//   • outcome filter excludes rejected/expired/failed
+//   • runTick records duplicates as skipped, not pending
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import {
+  canonicalForHash,
+  findRecentDuplicate,
+  hashPayload,
+  normaliseText,
+} from "../dist/director/dedup.js";
+import { recordDecision } from "../dist/director/decisions.js";
+import { runTick } from "../dist/director/tick.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-dedup-test-"));
+  const db = initDb(dir);
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+test("normaliseText: folds case + whitespace + common prefix + trailing punct", () => {
+  assert.equal(normaliseText("Issue: Add Per-Repo cost view!  "), "add per-repo cost view");
+  assert.equal(normaliseText("  add\n\nper-repo  cost view."), "add per-repo cost view");
+  assert.equal(normaliseText(""), "");
+  assert.equal(normaliseText(undefined), "");
+});
+
+test("hashPayload: same canonical title → same hash for create_issue", () => {
+  const a = hashPayload("create_issue", {
+    title: "Add Per-Repo cost view to admin dashboard.",
+    body: "## Problem\n\nFoo.",
+  });
+  const b = hashPayload("create_issue", {
+    title: "  add per-repo cost view to admin dashboard ",
+    body: "## Problem\n\nFoo.",
+  });
+  assert.equal(a, b);
+  assert.ok(typeof a === "string" && a.length > 0);
+});
+
+test("hashPayload: different decision_type → different hash even with same body", () => {
+  const issue = hashPayload("create_issue", { title: "x", body: "y" });
+  const comment = hashPayload("comment_on_issue", { issue_number: 1, body: "y" });
+  assert.notEqual(issue, comment);
+});
+
+test("hashPayload: returns null for ask_user / no_op (always idempotent)", () => {
+  assert.equal(hashPayload("ask_user", { question: "?" }), null);
+  assert.equal(hashPayload("no_op", null), null);
+});
+
+test("canonicalForHash: label_* canonicalises set semantics (order-independent)", () => {
+  const a = canonicalForHash("label_issue", {
+    issue_number: 5,
+    add: ["bug", "good first issue"],
+    remove: ["wontfix"],
+  });
+  const b = canonicalForHash("label_issue", {
+    issue_number: 5,
+    add: ["good first issue", "bug", "bug"],
+    remove: ["wontfix"],
+  });
+  assert.equal(a, b);
+});
+
+test("findRecentDuplicate: matches pending; ignores rejected/expired", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const payload = { title: "Add Per-Repo cost view", body: "## Problem\n\nFoo." };
+    const first = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "observability priority is uncovered",
+      payload,
+      outcome: "pending",
+    });
+    const hash = hashPayload("create_issue", payload);
+    assert.equal(findRecentDuplicate(db, repoId, hash), first.id);
+
+    // Reject the first; lookup should now return null (no live duplicate).
+    db.prepare(`UPDATE director_decisions SET outcome = 'rejected' WHERE id = ?`).run(first.id);
+    assert.equal(findRecentDuplicate(db, repoId, hash), null);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("findRecentDuplicate: respects 7-day lookback", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const payload = { title: "Add Per-Repo cost view" };
+    recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "old proposal that was stuck pending",
+      payload,
+      outcome: "pending",
+    });
+    const hash = hashPayload("create_issue", payload);
+    // Backdate the row to 30d ago.
+    db.prepare(
+      `UPDATE director_decisions SET ts = datetime('now', '-30 days') WHERE payload_hash = ?`,
+    ).run(hash);
+    assert.equal(findRecentDuplicate(db, repoId, hash, 7), null);
+    // But within a 60d window, it shows up again.
+    assert.notEqual(findRecentDuplicate(db, repoId, hash, 60), null);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+const sampleCharter = {
+  vision: "Reliable, observable AI dev agent.",
+  priorities: [{ id: "observability", weight: 1.0, rubric: "debuggable without SSH" }],
+  out_of_bounds: [],
+  out_of_bounds_paths: [],
+  definition_of_done: [],
+};
+
+const sampleBudget = {
+  initial_daily_usd: 2.0,
+  initial_weekly_usd: 10.0,
+  max_daily_usd: 10.0,
+  max_weekly_usd: 50.0,
+  think_daily_usd: 1.0,
+  pause_on_failure_streak: 3,
+  good_outcome_quarantine_days: 7,
+};
+
+const sampleDirector = {
+  enabled: true,
+  mode: "dry_run",
+  cadence_hours: 6,
+  bot_prefix: "👔 director:",
+  language: "English",
+  charter: sampleCharter,
+  budget: sampleBudget,
+  authority: {
+    can_create_issues: true,
+    can_label: true,
+    can_close_issues: false,
+    can_comment: true,
+    can_approve_pr: true,
+    can_merge: false,
+    can_modify_charter: false,
+  },
+};
+
+const sampleRepo = {
+  provider: "github",
+  owner: "openronin",
+  name: "openronin",
+  watched: true,
+  lanes: ["triage"],
+  director: sampleDirector,
+};
+
+const llmJsonCreateIssue = {
+  observations: "Project lacks observability into engine costs per repo.",
+  reasoning: "Per-repo cost view is missing — observability priority is at 1.0 in the charter.",
+  decisions: [
+    {
+      type: "create_issue",
+      rationale: "Charter priority observability is underserved",
+      priority_id: "observability",
+      payload: {
+        title: "Add per-repo cost view to admin dashboard",
+        body: "## Problem\n\nThe cost dashboard groups by lane and engine but not by repo.",
+        labels: [],
+        priority: "normal",
+      },
+    },
+  ],
+};
+
+function mockEngine(json) {
+  return () => ({
+    id: "mock",
+    defaultModel: "mock",
+    async run() {
+      return {
+        content: JSON.stringify(json),
+        json,
+        usage: { tokensIn: 100, tokensOut: 50, costUsd: 0.001 },
+        finishReason: "end_turn",
+        durationMs: 50,
+      };
+    },
+  });
+}
+
+test("runTick: second tick proposing the same create_issue records skipped, not pending", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    // First tick: persist as pending (we use a non-dry mode so it stays pending).
+    const proposeDirector = { ...sampleDirector, mode: "propose" };
+    const result1 = await runTick({
+      db,
+      repoId,
+      repo: { ...sampleRepo, director: proposeDirector },
+      director: proposeDirector,
+      dataDir: dir,
+      engineFactory: mockEngine(llmJsonCreateIssue),
+    });
+    assert.equal(result1.status, "ok");
+
+    // Second tick: same payload, slightly different wording → still dups.
+    const cosmeticDup = JSON.parse(JSON.stringify(llmJsonCreateIssue));
+    cosmeticDup.decisions[0].payload.title = "  Add Per-Repo cost view to admin dashboard.  ";
+    cosmeticDup.decisions[0].rationale = "again, observability priority is underserved";
+    const result2 = await runTick({
+      db,
+      repoId,
+      repo: { ...sampleRepo, director: proposeDirector },
+      director: proposeDirector,
+      dataDir: dir,
+      engineFactory: mockEngine(cosmeticDup),
+    });
+    assert.equal(result2.status, "ok");
+
+    const rows = db
+      .prepare(
+        `SELECT id, decision_type, outcome, outcome_details FROM director_decisions
+         WHERE repo_id = ? ORDER BY id`,
+      )
+      .all(repoId);
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].outcome, "pending"); // first survived as a real proposal
+    assert.equal(rows[1].outcome, "skipped"); // second got dedup'd
+    assert.match(rows[1].outcome_details, /duplicate of decision #/);
+  } finally {
+    cleanup(dir);
+  }
+});


### PR DESCRIPTION
Closes #48. Refs #44.

The Director was prone to re-proposing the same `create_issue` tick after tick — the LLM's state snapshot lagged just-proposed-but-unmerged work, and cosmetic re-wordings dodged any naive equality check.

This PR adds:

- **Schema v15**: `payload_hash` column + index on `(repo_id, payload_hash, outcome, ts)`.
- **`src/director/dedup.ts`**: a per-decision-type normalising canonicaliser (folds case / whitespace / common prefixes / set order for labels) and a 7-day lookback against `pending` or `executed` decisions.
- **`recordTickDecisions`** in `tick.ts`: every freshly-recorded decision goes through the dedup gate. A duplicate is still persisted (audit trail intact) but immediately marked `outcome=skipped` with a `duplicate of decision #N` reason and never reaches the executor.

`ask_user` and `no_op` are exempt — cheap, idempotent, fall through to executor as before.

## Test plan
- [x] `pnpm run check` green (128 tests; +8 dedup tests)
- [x] Cosmetic re-wordings collapse to the same hash
- [x] label_* canonical form is order-independent (set semantics)
- [x] 7-day lookback honoured; rejected decisions don't block re-proposals