### PR TITLE
feat(director): daily morning digest

### DIFF
--- a/prompts/templates/director-digest.md
+++ b/prompts/templates/director-digest.md
@@ -1,0 +1,20 @@
+Good morning, {{persona_name}}. Time to write the daily digest for `{{owner}}/{{name}}`.
+
+It is {{today}} ({{timezone}}). Communicate in **{{language}}**.
+
+This is a short, human-readable status update — NOT a planning tick. No decisions, no JSON, no markdown headers. 4–8 lines, plain prose with optional bullets. Tone matches your declared voice/style.
+
+Cover, in order:
+
+1. **What changed overnight** — merges, new PRs, new issues, deploys.
+2. **What's stuck** — PRs without movement >24h, issues in `awaiting-answer`, conflicts.
+3. **Budget** — if cost burn looks notable, mention it. Otherwise skip.
+4. **What you'd like the operator to do today** — at most 1–2 items, prioritised.
+
+If nothing of note happened, say so honestly in one sentence ("Тихая ночь — ничего нового. PR #41 ещё ждёт ревью.") rather than padding.
+
+Project state:
+
+```json
+{{state_json}}
+```

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   BudgetConfigSchema,
   CharterSchema,
+  DigestConfigSchema,
   DirectorAuthoritySchema,
   DirectorModeSchema,
 } from "../director/types.js";
@@ -241,6 +242,8 @@ export const RepoConfigSchema = z.object({
       charter: CharterSchema.optional(),
       budget: BudgetConfigSchema,
       authority: DirectorAuthoritySchema,
+      // Daily morning digest — see director/types.ts DigestConfigSchema.
+      digest: DigestConfigSchema,
     })
     .default({}),
 });

--- a/src/director/digest.ts
+++ b/src/director/digest.ts
@@ -1,0 +1,194 @@
+// Daily morning digest — once-per-day "good morning" status update.
+//
+// Different from a planning tick:
+//   • cheap engine (MIMO over Sonnet) — purely status, never decisions
+//   • doesn't burn the propose-budget (think_daily_usd is still charged)
+//   • posts ONE chat message, no decisions, no executor invocation
+//   • triggers on a wall-clock schedule (digest.hour, digest.timezone),
+//     not on the planning cadence
+//
+// The trigger predicate (`shouldRunDigest`) is pure & string-only — given
+// the configured hour, timezone, and the stored last-digest-date, it
+// returns true iff today's digest hasn't fired yet AND we're past the
+// configured hour in the local timezone. Service loop calls it on every
+// wake-up; cheap.
+
+import type { Db } from "../storage/db.js";
+import type { RepoConfig } from "../config/schema.js";
+import { repoKey } from "../config/schema.js";
+import type { DigestConfig, Persona } from "./types.js";
+import { PersonaSchema } from "./types.js";
+import { appendMessage } from "./chat.js";
+import { captureStateSnapshot } from "./state.js";
+import { recordThinkSpend } from "./budget.js";
+import type { Engine } from "../engines/types.js";
+import { loadTemplate, renderTemplate } from "../prompts/registry.js";
+
+// ── TZ-aware date helpers (no Date math) ─────────────────────────────────
+// Intl.DateTimeFormat is the only stable way to get "what's the local hour
+// in Europe/Moscow right now" without pulling in Luxon. Bad timezone names
+// throw here; we catch and fall back to UTC silently rather than wedge.
+//
+// Both helpers are cheap (the formatter is constructed per-call but the
+// digest tick fires at most once a day, so it doesn't matter).
+
+export function localDateInTz(d: Date, tz: string): string {
+  try {
+    // en-CA produces YYYY-MM-DD which we want for stable string comparison.
+    return new Intl.DateTimeFormat("en-CA", {
+      timeZone: tz,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(d);
+  } catch {
+    return new Intl.DateTimeFormat("en-CA", {
+      timeZone: "UTC",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(d);
+  }
+}
+
+export function localHourInTz(d: Date, tz: string): number {
+  try {
+    const txt = new Intl.DateTimeFormat("en-GB", {
+      timeZone: tz,
+      hour: "2-digit",
+      hourCycle: "h23",
+    }).format(d);
+    return parseInt(txt, 10);
+  } catch {
+    return d.getUTCHours();
+  }
+}
+
+// Pure predicate: should we fire a digest right now?
+//
+// Returns true when:
+//   • digest.enabled, AND
+//   • we're past the configured hour today in the configured timezone, AND
+//   • we haven't already fired a digest for today's local date.
+//
+// `now` is injectable for tests; production passes `new Date()`.
+export function shouldRunDigest(
+  digest: DigestConfig,
+  lastDigestDate: string | null,
+  now: Date = new Date(),
+): boolean {
+  if (!digest.enabled) return false;
+  const hour = localHourInTz(now, digest.timezone);
+  if (hour < digest.hour) return false;
+  const today = localDateInTz(now, digest.timezone);
+  return lastDigestDate !== today;
+}
+
+// Persist that we've fired today's digest. Called after a successful run
+// (and skipped on failure so we'll retry on the next loop pass).
+export function recordDigestFired(db: Db, repoId: number, today: string): void {
+  db.prepare(`UPDATE director_budget_state SET last_digest_date = ? WHERE repo_id = ?`).run(
+    today,
+    repoId,
+  );
+}
+
+export function getLastDigestDate(db: Db, repoId: number): string | null {
+  const row = db
+    .prepare(`SELECT last_digest_date FROM director_budget_state WHERE repo_id = ?`)
+    .get(repoId) as { last_digest_date: string | null } | undefined;
+  return row?.last_digest_date ?? null;
+}
+
+// ── Digest tick runner ──────────────────────────────────────────────────
+
+const DIGEST_TIMEOUT_MS = 60_000;
+
+export type DigestRunOptions = {
+  db: Db;
+  repoId: number;
+  repo: RepoConfig;
+  digest: DigestConfig;
+  persona: Persona | undefined;
+  language: string;
+  dataDir: string;
+  // Cheap engine — MIMO by default. Test override.
+  engineFactory: () => Engine;
+  // Inject "now" for tests.
+  now?: Date;
+};
+
+export type DigestRunResult = {
+  status: "ok" | "skipped" | "error";
+  detail: string;
+  costUsd: number;
+};
+
+export async function runDigest(opts: DigestRunOptions): Promise<DigestRunResult> {
+  const { db, repoId, repo, digest, language, dataDir } = opts;
+  const persona = opts.persona ?? PersonaSchema.parse({});
+  const now = opts.now ?? new Date();
+  const today = localDateInTz(now, digest.timezone);
+
+  const state = captureStateSnapshot(db, repoId, repo.owner, repo.name);
+  const template = loadTemplate("director-digest", repo, dataDir);
+  const userPrompt = renderTemplate(template, {
+    owner: repo.owner,
+    name: repo.name,
+    today,
+    timezone: digest.timezone,
+    persona_name: persona.name,
+    language,
+    state_json: JSON.stringify(state, null, 2),
+  });
+  const systemPrompt =
+    `You are ${persona.name}, the ${persona.role} for ${repo.owner}/${repo.name}. ` +
+    `Voice: ${persona.voice}. ` +
+    "Produce a SHORT morning digest — 4–8 lines, plain prose with optional bullet list. " +
+    "No JSON, no decisions, no markdown headers. " +
+    "Highlight only what changed overnight or what needs attention now. " +
+    "If nothing of note happened, say so honestly in one sentence.";
+
+  const engine = opts.engineFactory();
+  let llmResult;
+  try {
+    llmResult = await engine.run({
+      systemPrompt,
+      userPrompt,
+      timeoutMs: DIGEST_TIMEOUT_MS,
+      model: "",
+      expectJson: false,
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    appendMessage(db, {
+      repoId,
+      role: "system",
+      type: "error",
+      body: `digest failed: ${detail}`,
+      metadata: { repo: repoKey(repo), kind: "digest" },
+    });
+    return { status: "error", detail, costUsd: 0 };
+  }
+
+  const cost = llmResult.usage.costUsd ?? 0;
+  recordThinkSpend(db, repoId, cost);
+
+  appendMessage(db, {
+    repoId,
+    role: "director",
+    type: "status",
+    body: llmResult.content.trim(),
+    metadata: {
+      repo: repoKey(repo),
+      kind: "digest",
+      today,
+      timezone: digest.timezone,
+      tokensIn: llmResult.usage.tokensIn,
+      tokensOut: llmResult.usage.tokensOut,
+      costUsd: cost,
+    },
+  });
+  recordDigestFired(db, repoId, today);
+  return { status: "ok", detail: `digest posted for ${today}`, costUsd: cost };
+}

--- a/src/director/index.ts
+++ b/src/director/index.ts
@@ -19,6 +19,8 @@ import { ensureBudgetState, rolloverDayIfNeeded } from "./budget.js";
 import { appendMessage, unansweredUserDirectives } from "./chat.js";
 import { runTick, type TickReason } from "./tick.js";
 import { releaseTick, tryAcquireTick } from "./active-tick.js";
+import { getLastDigestDate, runDigest, shouldRunDigest } from "./digest.js";
+import { MimoEngine } from "../engines/mimo.js";
 import type { DirectorConfig } from "./types.js";
 
 // Wake up every 10s — tight enough that a user chat message is reacted to
@@ -124,12 +126,56 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function maybeRunDigest(db: Db, target: RepoLookup, dataDir: string): Promise<void> {
+  // Digest fires at most once per local-TZ day per repo. shouldRunDigest is
+  // pure — it checks the configured hour against the current wall-clock in
+  // the configured TZ, plus the persisted last-digest-date string.
+  const last = getLastDigestDate(db, target.repoId);
+  if (!shouldRunDigest(target.director.digest, last)) return;
+  // Use the same per-repo lock as planning ticks so a digest doesn't
+  // race with a chat-triggered planning tick.
+  if (!tryAcquireTick(db, target.repoId, "morning_digest")) return;
+  try {
+    const result = await runDigest({
+      db,
+      repoId: target.repoId,
+      repo: target.repo,
+      digest: target.director.digest,
+      persona: target.director.charter?.persona,
+      language: target.director.language,
+      dataDir,
+      // Digest is intentionally cheap — MIMO only. Failing over to a
+      // pricier engine would defeat the point of the daily digest.
+      engineFactory: () =>
+        new MimoEngine({
+          defaultModel: process.env.OPENRONIN_DIRECTOR_DIGEST_MODEL ?? "mimo-v2.5-pro",
+        }),
+    });
+    // eslint-disable-next-line no-console
+    console.log(
+      `[director] digest on ${repoKey(target.repo)}: ${result.status} — ${result.detail} ` +
+        `($${result.costUsd.toFixed(4)})`,
+    );
+  } finally {
+    releaseTick(db, target.repoId);
+  }
+}
+
 async function loopOnce(db: Db, config: RuntimeConfig): Promise<void> {
   const targets = listDirectorEnabledRepos(db, config);
   for (const t of targets) {
     if (stopping) return;
     rolloverDayIfNeeded(db, t.repoId);
     const state = ensureBudgetState(db, t.repoId, t.director.budget);
+    // Digest runs out-of-band from the planning cadence — the user wants
+    // morning context every day, even if the planning cadence is 6h+.
+    try {
+      await maybeRunDigest(db, t, config.dataDir);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`[director] digest error on ${repoKey(t.repo)}:`, err);
+    }
+    if (stopping) return;
     const reason = pickTickReason(db, t.repoId, state, t.director.cadence_hours);
     if (!reason) continue;
     try {

--- a/src/director/types.ts
+++ b/src/director/types.ts
@@ -122,6 +122,24 @@ export type BudgetState = {
   pauseReason: string | null;
 };
 
+// ── Daily digest config ─────────────────────────────────────────────────
+// Single morning report per repo. Independent from the planning cadence:
+// digest is cheap (MIMO), short, and never produces actionable decisions
+// — it's a scoped status update so the operator can triage at a glance.
+export const DigestConfigSchema = z
+  .object({
+    enabled: z.boolean().default(true),
+    // Local hour of day (0–23) in the configured timezone. Default 9 ≈
+    // first-coffee. Operators in other timezones override.
+    hour: z.number().int().min(0).max(23).default(9),
+    // IANA timezone string, e.g. "Europe/Moscow", "America/Los_Angeles".
+    // Validated only at runtime via Intl.DateTimeFormat — bad values fall
+    // back to UTC silently.
+    timezone: z.string().default("UTC"),
+  })
+  .default({});
+export type DigestConfig = z.infer<typeof DigestConfigSchema>;
+
 // ── Director config (per-repo block, lives in repo YAML) ─────────────────
 export const DirectorConfigSchema = z
   .object({
@@ -141,6 +159,11 @@ export const DirectorConfigSchema = z
     charter: CharterSchema.optional(),
     budget: BudgetConfigSchema,
     authority: DirectorAuthoritySchema,
+    // Daily digest — once-per-day "good morning" status update so the
+    // operator wakes up to a punch list of overnight changes instead of
+    // having to scrape the chat. See director-digest.md for the prompt.
+    // Skipped silently when enabled=false or charter is missing.
+    digest: DigestConfigSchema,
   })
   .default({});
 export type DirectorConfig = z.infer<typeof DirectorConfigSchema>;

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -362,9 +362,7 @@ function applyMigrations(db: Db): void {
   // ISO date (YYYY-MM-DD) in the configured digest timezone — the
   // service-loop predicate compares strings, no time math.
   if (current < 16) {
-    db.exec(
-      `ALTER TABLE director_budget_state ADD COLUMN last_digest_date TEXT`,
-    );
+    db.exec(`ALTER TABLE director_budget_state ADD COLUMN last_digest_date TEXT`);
     db.prepare(
       "INSERT INTO schema_version (version, applied_at) VALUES (16, datetime('now'))",
     ).run();

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -355,4 +355,18 @@ function applyMigrations(db: Db): void {
       "INSERT INTO schema_version (version, applied_at) VALUES (15, datetime('now'))",
     ).run();
   }
+
+  // v16 — Daily digest dedup. Records the local-TZ date of the most
+  // recent digest run so we fire at most one per calendar day per repo,
+  // independent of how often the service loop wakes up. Stored as plain
+  // ISO date (YYYY-MM-DD) in the configured digest timezone — the
+  // service-loop predicate compares strings, no time math.
+  if (current < 16) {
+    db.exec(
+      `ALTER TABLE director_budget_state ADD COLUMN last_digest_date TEXT`,
+    );
+    db.prepare(
+      "INSERT INTO schema_version (version, applied_at) VALUES (16, datetime('now'))",
+    ).run();
+  }
 }

--- a/test/director-digest.test.mjs
+++ b/test/director-digest.test.mjs
@@ -1,0 +1,137 @@
+// Daily morning digest.
+//
+// Verifies:
+//   • shouldRunDigest fires once per local-TZ day past the configured hour
+//   • timezone awareness (Moscow vs LA at the same UTC instant differ)
+//   • disabled config short-circuits
+//   • runDigest posts a single status message and persists last-digest-date
+//   • a second runDigest on the same day is gated by shouldRunDigest
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import {
+  getLastDigestDate,
+  localDateInTz,
+  localHourInTz,
+  runDigest,
+  shouldRunDigest,
+} from "../dist/director/digest.js";
+import { ensureBudgetState } from "../dist/director/budget.js";
+import { recentMessages } from "../dist/director/chat.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-digest-test-"));
+  const db = initDb(dir);
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+
+const sampleBudget = {
+  initial_daily_usd: 2.0,
+  initial_weekly_usd: 10.0,
+  max_daily_usd: 10.0,
+  max_weekly_usd: 50.0,
+  think_daily_usd: 1.0,
+  pause_on_failure_streak: 3,
+  good_outcome_quarantine_days: 7,
+};
+
+test("localHourInTz: differs across timezones at the same UTC instant", () => {
+  const t = new Date("2026-05-05T14:00:00Z"); // 14:00 UTC
+  assert.equal(localHourInTz(t, "UTC"), 14);
+  assert.equal(localHourInTz(t, "Europe/Moscow"), 17); // UTC+3
+  assert.equal(localHourInTz(t, "America/Los_Angeles"), 7); // UTC-7 (PDT in May)
+});
+
+test("localDateInTz: returns YYYY-MM-DD; rolls midnight per tz", () => {
+  const t = new Date("2026-05-05T22:30:00Z"); // 22:30 UTC
+  assert.equal(localDateInTz(t, "UTC"), "2026-05-05");
+  // 01:30 Moscow next day
+  assert.equal(localDateInTz(t, "Europe/Moscow"), "2026-05-06");
+});
+
+test("shouldRunDigest: fires past the hour, only once per local day", () => {
+  const digest = { enabled: true, hour: 9, timezone: "UTC" };
+  // 08:00 UTC → too early
+  assert.equal(shouldRunDigest(digest, null, new Date("2026-05-05T08:00:00Z")), false);
+  // 09:00 UTC → on the dot, hasn't fired today
+  assert.equal(shouldRunDigest(digest, null, new Date("2026-05-05T09:00:00Z")), true);
+  // 09:30 UTC → already fired today
+  assert.equal(shouldRunDigest(digest, "2026-05-05", new Date("2026-05-05T09:30:00Z")), false);
+  // Next day at 09:00 → fires again
+  assert.equal(shouldRunDigest(digest, "2026-05-05", new Date("2026-05-06T09:00:00Z")), true);
+});
+
+test("shouldRunDigest: enabled=false disables", () => {
+  const digest = { enabled: false, hour: 9, timezone: "UTC" };
+  assert.equal(shouldRunDigest(digest, null, new Date("2026-05-05T12:00:00Z")), false);
+});
+
+test("shouldRunDigest: timezone shifts when a day rolls", () => {
+  // 23:00 UTC = 02:00 Moscow next day. Moscow operator's "today" already rolled.
+  const digest = { enabled: true, hour: 9, timezone: "Europe/Moscow" };
+  // last fired 2026-05-04 (Moscow), now 23:00 UTC on 2026-05-04 = 02:00 Moscow on -05.
+  // Hour=2 < 9 → too early; predicate returns false even though local date moved on.
+  assert.equal(shouldRunDigest(digest, "2026-05-04", new Date("2026-05-04T23:00:00Z")), false);
+  // 06:00 UTC on -05 = 09:00 Moscow on -05 → fire.
+  assert.equal(shouldRunDigest(digest, "2026-05-04", new Date("2026-05-05T06:00:00Z")), true);
+});
+
+test("runDigest: posts a single status message and records today", async () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  const repo = {
+    provider: "github",
+    owner: "openronin",
+    name: "openronin",
+    watched: true,
+    lanes: ["triage"],
+  };
+  try {
+    const result = await runDigest({
+      db,
+      repoId,
+      repo,
+      digest: { enabled: true, hour: 9, timezone: "UTC" },
+      persona: undefined,
+      language: "Russian",
+      dataDir: dir,
+      now: new Date("2026-05-05T09:30:00Z"),
+      engineFactory: () => ({
+        id: "mock",
+        defaultModel: "mock",
+        async run(opts) {
+          assert.match(opts.systemPrompt, /Director|product owner/i);
+          assert.match(opts.userPrompt, /2026-05-05/);
+          return {
+            content: "Тихая ночь — ничего нового.",
+            json: null,
+            usage: { tokensIn: 800, tokensOut: 50, costUsd: 0.001 },
+            finishReason: "end_turn",
+            durationMs: 50,
+          };
+        },
+      }),
+    });
+    assert.equal(result.status, "ok");
+    const messages = recentMessages(db, repoId, 5);
+    const digestMsg = messages.find((m) => m.metadata?.kind === "digest");
+    assert.ok(digestMsg);
+    assert.equal(digestMsg.role, "director");
+    assert.equal(digestMsg.body, "Тихая ночь — ничего нового.");
+    assert.equal(getLastDigestDate(db, repoId), "2026-05-05");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #49. Refs #44.

Once-per-day status update so the operator wakes up to a punch list of overnight changes instead of having to scrape the chat.

## What's new

- **DigestConfigSchema** (`enabled` / `hour` / `timezone`), defaults to enabled + 09:00 UTC. Lives on `DirectorConfig` (operational), not Charter.
- **Schema v16** adds `last_digest_date` column on `director_budget_state` for once-per-local-day idempotency.
- **`shouldRunDigest`** is a pure predicate (TZ-aware via `Intl.DateTimeFormat`) so the service-loop check is cheap and string-only.
- **`runDigest`** uses MIMO directly (cheap; never falls over to Sonnet) and produces ONE chat message — no decisions, no executor invocation.
- **`prompts/templates/director-digest.md`** is the per-repo overridable template.
- Service loop fires the digest before the planning tick on each wake. Both share the per-repo lock so a chat-triggered planning tick can't race a digest into the same minute.

## Configuration example

```yaml
director:
  digest:
    enabled: true
    hour: 9
    timezone: Europe/Moscow
```

## Test plan
- [x] `pnpm run check` green (134 tests; +6 digest tests)
- [x] TZ-aware date math (Moscow vs LA differ at the same UTC instant)
- [x] Idempotency — second runDigest on the same local day doesn't fire
- [x] Disabled config short-circuits before any LLM call