### PR TITLE
feat(director): stale watchdog enriches state snapshot

### DIFF
--- a/prompts/templates/director-tick.md
+++ b/prompts/templates/director-tick.md
@@ -36,6 +36,10 @@ You are running in mode `{{mode}}`. The mode controls whether your decisions act
 
 In every mode, prefer fewer high-value decisions over many low-value ones. **An empty/no-op tick is a valid outcome** — say `no_op` and explain why, rather than inventing busywork.
 
+## Attention first
+
+The watchdog populates `state.attentionItems` with things you should look at **before** charter-driven planning: stale PRs, issues stuck in `awaiting-answer`, recent failed deploys, your own failure streak, an over-stuffed proposal queue. If that list is non-empty, address the top items in this tick — don't pile new work on top of stuck work.
+
 ## Project state right now
 
 ```json

--- a/src/director/state.ts
+++ b/src/director/state.ts
@@ -297,9 +297,9 @@ function collectAttentionItems(db: Db, repoId: number): AttentionItem[] {
   // 4. Failure streak — director's own bumpFailureStreak counter. >=2
   //    means we've had two failed ticks in a row and should slow down.
   const streak = (
-    db
-      .prepare(`SELECT failure_streak FROM director_budget_state WHERE repo_id = ?`)
-      .get(repoId) as { failure_streak: number } | undefined
+    db.prepare(`SELECT failure_streak FROM director_budget_state WHERE repo_id = ?`).get(repoId) as
+      | { failure_streak: number }
+      | undefined
   )?.failure_streak;
   if (streak && streak >= FAILURE_STREAK_ATTENTION_THRESHOLD) {
     items.push({

--- a/src/director/state.ts
+++ b/src/director/state.ts
@@ -27,6 +27,23 @@ export type StateSnapshot = {
   recentChat: MessageSummary[];
   recentDecisions: DecisionSummary[];
   pendingDecisionCount: number;
+  // Things the director should look at FIRST. Populated by the stale
+  // watchdog — PRs without movement, issues stuck in awaiting-answer,
+  // recent failed deploys. The prompt template renders these in their
+  // own section so the LLM addresses them before charter-priority work.
+  attentionItems: AttentionItem[];
+};
+
+export type AttentionItem = {
+  kind:
+    | "stale_pr"
+    | "stale_awaiting_answer"
+    | "recent_deploy_failed"
+    | "failure_streak_high"
+    | "high_pending_proposals";
+  ref: string; // PR/issue number, "deploy <sha>" or "global"
+  detail: string;
+  ageHours?: number;
 };
 
 export type RunSummary = {
@@ -191,7 +208,125 @@ export function captureStateSnapshot(
     recentChat,
     recentDecisions,
     pendingDecisionCount,
+    attentionItems: collectAttentionItems(db, repoId),
   };
+}
+
+// ── Stale watchdog ───────────────────────────────────────────────────────
+// Surfaces "things the director should look at first" before charter-driven
+// planning. Cheap aggregate queries; we cap each list so the prompt doesn't
+// balloon when a project is genuinely on fire (the LLM would just get lost
+// in 50 stale items — show it the worst 5 per category).
+
+const STALE_PR_HOURS = 24;
+const STALE_AWAITING_ANSWER_HOURS = 48;
+const FAILED_DEPLOY_LOOKBACK_HOURS = 48;
+const FAILURE_STREAK_ATTENTION_THRESHOLD = 2;
+const PENDING_PROPOSAL_ATTENTION_THRESHOLD = 5;
+
+function collectAttentionItems(db: Db, repoId: number): AttentionItem[] {
+  const items: AttentionItem[] = [];
+
+  // 1. Open PRs that haven't moved in STALE_PR_HOURS.
+  const stalePrs = db
+    .prepare(
+      `SELECT pb.pr_number AS prNumber, pb.branch, pb.updated_at AS updatedAt,
+              ROUND((julianday('now') - julianday(pb.updated_at)) * 24.0, 1) AS ageHours
+       FROM pr_branches pb JOIN tasks t ON t.id = pb.task_id
+       WHERE t.repo_id = ?
+         AND pb.status IN ('created','open')
+         AND pb.updated_at IS NOT NULL
+         AND pb.updated_at < datetime('now', '-${STALE_PR_HOURS} hours')
+       ORDER BY pb.updated_at ASC LIMIT 5`,
+    )
+    .all(repoId) as { prNumber: number; branch: string; ageHours: number }[];
+  for (const p of stalePrs) {
+    items.push({
+      kind: "stale_pr",
+      ref: `#${p.prNumber}`,
+      detail: `PR #${p.prNumber} (${p.branch}) untouched for ${p.ageHours}h`,
+      ageHours: p.ageHours,
+    });
+  }
+
+  // 2. Issues sitting in awaiting-answer for too long (label-driven —
+  //    pulled from tasks.decision_json which carries the label set
+  //    snapshot from the analyzer). Heuristic: any task last_run_at older
+  //    than the threshold whose decision_json mentions awaiting-answer.
+  const stuckAwaiting = db
+    .prepare(
+      `SELECT external_id AS issueNumber,
+              ROUND((julianday('now') - julianday(last_run_at)) * 24.0, 1) AS ageHours
+       FROM tasks
+       WHERE repo_id = ?
+         AND kind = 'issue'
+         AND last_run_at IS NOT NULL
+         AND last_run_at < datetime('now', '-${STALE_AWAITING_ANSWER_HOURS} hours')
+         AND decision_json LIKE '%awaiting-answer%'
+       ORDER BY last_run_at ASC LIMIT 5`,
+    )
+    .all(repoId) as { issueNumber: string; ageHours: number }[];
+  for (const a of stuckAwaiting) {
+    items.push({
+      kind: "stale_awaiting_answer",
+      ref: `#${a.issueNumber}`,
+      detail: `Issue #${a.issueNumber} stuck in awaiting-answer for ${a.ageHours}h — likely needs a nudge`,
+      ageHours: a.ageHours,
+    });
+  }
+
+  // 3. Recent failed deploys.
+  const failedDeploys = db
+    .prepare(
+      `SELECT sha, started_at AS ts, status
+       FROM deploys
+       WHERE repo_id = ?
+         AND status NOT IN ('ok','running')
+         AND started_at > datetime('now', '-${FAILED_DEPLOY_LOOKBACK_HOURS} hours')
+       ORDER BY id DESC LIMIT 3`,
+    )
+    .all(repoId) as { sha: string; ts: string; status: string }[];
+  for (const d of failedDeploys) {
+    items.push({
+      kind: "recent_deploy_failed",
+      ref: `deploy ${d.sha.slice(0, 7)}`,
+      detail: `Deploy ${d.sha.slice(0, 7)} failed at ${d.ts} (${d.status})`,
+    });
+  }
+
+  // 4. Failure streak — director's own bumpFailureStreak counter. >=2
+  //    means we've had two failed ticks in a row and should slow down.
+  const streak = (
+    db
+      .prepare(`SELECT failure_streak FROM director_budget_state WHERE repo_id = ?`)
+      .get(repoId) as { failure_streak: number } | undefined
+  )?.failure_streak;
+  if (streak && streak >= FAILURE_STREAK_ATTENTION_THRESHOLD) {
+    items.push({
+      kind: "failure_streak_high",
+      ref: "global",
+      detail: `Director failure streak is ${streak} — investigate before more proposals`,
+    });
+  }
+
+  // 5. Pending-proposal queue depth — if the human is buried in unreviewed
+  //    proposals, the director should slow down rather than pile on.
+  const pending = (
+    db
+      .prepare(
+        `SELECT COUNT(*) AS n FROM director_decisions WHERE repo_id = ? AND outcome = 'pending'`,
+      )
+      .get(repoId) as { n: number } | undefined
+  )?.n;
+  if (pending && pending >= PENDING_PROPOSAL_ATTENTION_THRESHOLD) {
+    items.push({
+      kind: "high_pending_proposals",
+      ref: "global",
+      detail: `${pending} proposals waiting for human approval — pause new ones until queue drains`,
+    });
+  }
+
+  return items;
 }
 
 function scalar<T>(db: Db, sql: string, params: unknown[]): T {

--- a/test/director-watchdog.test.mjs
+++ b/test/director-watchdog.test.mjs
@@ -1,0 +1,156 @@
+// Stale watchdog: collectAttentionItems via captureStateSnapshot.
+//
+// Verifies each attention category surfaces correctly:
+//   • stale_pr — open PR with no update >24h
+//   • stale_awaiting_answer — issue task with awaiting-answer label, last_run_at >48h
+//   • recent_deploy_failed — deploy with status != ok in last 48h
+//   • failure_streak_high — director_budget_state.failure_streak >= 2
+//   • high_pending_proposals — >=5 pending decisions
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import { captureStateSnapshot } from "../dist/director/state.js";
+import { ensureBudgetState, bumpFailureStreak } from "../dist/director/budget.js";
+import { recordDecision } from "../dist/director/decisions.js";
+
+const sampleBudget = {
+  initial_daily_usd: 2.0,
+  initial_weekly_usd: 10.0,
+  max_daily_usd: 10.0,
+  max_weekly_usd: 50.0,
+  think_daily_usd: 1.0,
+  pause_on_failure_streak: 3,
+  good_outcome_quarantine_days: 7,
+};
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-watchdog-test-"));
+  const db = initDb(dir);
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+test("watchdog: empty repo → no attention items", () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  try {
+    const snapshot = captureStateSnapshot(db, repoId, "openronin", "openronin");
+    assert.deepEqual(snapshot.attentionItems, []);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("watchdog: stale PR (>24h) surfaces a stale_pr item", () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  try {
+    const taskRow = db
+      .prepare(
+        `INSERT INTO tasks (repo_id, external_id, kind, status)
+         VALUES (?, '99', 'pr', 'pending') RETURNING id`,
+      )
+      .get(repoId);
+    db.prepare(
+      `INSERT INTO pr_branches (task_id, pr_number, branch, status, iterations, updated_at)
+       VALUES (?, 99, 'feat/abandoned', 'open', 0, datetime('now', '-30 hours'))`,
+    ).run(taskRow.id);
+
+    const snapshot = captureStateSnapshot(db, repoId, "openronin", "openronin");
+    const stalePrs = snapshot.attentionItems.filter((a) => a.kind === "stale_pr");
+    assert.equal(stalePrs.length, 1);
+    assert.equal(stalePrs[0].ref, "#99");
+    assert.ok(stalePrs[0].ageHours >= 29);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("watchdog: awaiting-answer issue >48h flagged", () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  try {
+    db.prepare(
+      `INSERT INTO tasks (repo_id, external_id, kind, status, last_run_at, decision_json)
+       VALUES (?, '42', 'issue', 'pending', datetime('now', '-72 hours'), ?)`,
+    ).run(repoId, JSON.stringify({ labels: ["openronin:awaiting-answer"] }));
+
+    const snapshot = captureStateSnapshot(db, repoId, "openronin", "openronin");
+    const stuck = snapshot.attentionItems.filter((a) => a.kind === "stale_awaiting_answer");
+    assert.equal(stuck.length, 1);
+    assert.equal(stuck[0].ref, "#42");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("watchdog: recent failed deploy surfaces", () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  try {
+    db.prepare(
+      `INSERT INTO deploys (repo_id, sha, branch, triggered_by, status, started_at)
+       VALUES (?, 'abcdef0123456789', 'main', 'auto', 'error', datetime('now', '-2 hours'))`,
+    ).run(repoId);
+
+    const snapshot = captureStateSnapshot(db, repoId, "openronin", "openronin");
+    const failed = snapshot.attentionItems.filter((a) => a.kind === "recent_deploy_failed");
+    assert.equal(failed.length, 1);
+    assert.match(failed[0].ref, /deploy abcdef0/);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("watchdog: failure streak >=2 flagged; <2 silent", () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  try {
+    bumpFailureStreak(db, repoId);
+    let snapshot = captureStateSnapshot(db, repoId, "openronin", "openronin");
+    assert.equal(snapshot.attentionItems.filter((a) => a.kind === "failure_streak_high").length, 0);
+
+    bumpFailureStreak(db, repoId);
+    snapshot = captureStateSnapshot(db, repoId, "openronin", "openronin");
+    assert.equal(snapshot.attentionItems.filter((a) => a.kind === "failure_streak_high").length, 1);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("watchdog: high pending proposals queue surfaces when >=5", () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  try {
+    for (let i = 0; i < 5; i++) {
+      recordDecision(db, {
+        repoId,
+        decisionType: "create_issue",
+        rationale: `pending proposal #${i} for backlog`,
+        payload: { title: `proposal ${i}` },
+        outcome: "pending",
+      });
+    }
+    const snapshot = captureStateSnapshot(db, repoId, "openronin", "openronin");
+    const queue = snapshot.attentionItems.filter((a) => a.kind === "high_pending_proposals");
+    assert.equal(queue.length, 1);
+    assert.match(queue[0].detail, /5 proposals/);
+  } finally {
+    cleanup(dir);
+  }
+});


### PR DESCRIPTION
Closes #50. Refs #44.

Adds `attentionItems[]` to the state snapshot the planner LLM consumes:

- `stale_pr` — open PRs untouched for >24h
- `stale_awaiting_answer` — issues stuck in `awaiting-answer` >48h
- `recent_deploy_failed` — failed deploys in last 48h
- `failure_streak_high` — director has had >=2 failed ticks in a row
- `high_pending_proposals` — >=5 proposals waiting for human approval

Each list capped at 3-5 items so a project genuinely on fire doesn't balloon the prompt. Surfaced in the `director-tick` template under a new "Attention first" section so the LLM addresses stuck work before piling on charter-driven items.

Cross-process event triggers (`pr_event`, `deploy_failed` reacting in <60s) remain a follow-up — they need a webhook → director signal table that's out of scope for this PR.

## Test plan
- [x] `pnpm run check` green (140 tests; +6 watchdog tests)
- [x] Each attention category surfaces correctly
- [x] Empty repo → empty list