### PR TITLE
feat(director): trust-ramp suggestion in chat

### DIFF
--- a/src/director/index.ts
+++ b/src/director/index.ts
@@ -20,6 +20,7 @@ import { appendMessage, unansweredUserDirectives } from "./chat.js";
 import { runTick, type TickReason } from "./tick.js";
 import { releaseTick, tryAcquireTick } from "./active-tick.js";
 import { getLastDigestDate, runDigest, shouldRunDigest } from "./digest.js";
+import { maybePostTrustRampSuggestion } from "./trust-ramp.js";
 import { MimoEngine } from "../engines/mimo.js";
 import type { DirectorConfig } from "./types.js";
 
@@ -174,6 +175,29 @@ async function loopOnce(db: Db, config: RuntimeConfig): Promise<void> {
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error(`[director] digest error on ${repoKey(t.repo)}:`, err);
+    }
+    if (stopping) return;
+    // Trust ramp check is cheap (one SQL aggregate + one cooldown lookup);
+    // running it on every loop tick is fine. The cooldown inside the
+    // helper means it posts to chat at most once a week per repo.
+    try {
+      const suggestion = maybePostTrustRampSuggestion(
+        db,
+        t.repoId,
+        t.director.mode,
+        t.director.language,
+      );
+      if (suggestion) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `[director] trust-ramp on ${repoKey(t.repo)}: ${suggestion.kind} ` +
+            `${suggestion.from} → ${suggestion.to} ` +
+            `(rate=${suggestion.rate.toFixed(2)}, n=${suggestion.sampleSize})`,
+        );
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`[director] trust-ramp error on ${repoKey(t.repo)}:`, err);
     }
     if (stopping) return;
     const reason = pickTickReason(db, t.repoId, state, t.director.cadence_hours);

--- a/src/director/trust-ramp.ts
+++ b/src/director/trust-ramp.ts
@@ -27,10 +27,14 @@ const DEMOTE_THRESHOLD = 0.4;
 const DEMOTE_MIN_SAMPLE = 10;
 const TRUST_RAMP_COOLDOWN_DAYS = 7;
 
-export type TrustRampSuggestion =
-  | { kind: "promote"; from: DirectorMode; to: DirectorMode; rate: number; sampleSize: number }
-  | { kind: "demote"; from: DirectorMode; to: DirectorMode; rate: number; sampleSize: number }
-  | { kind: "hold"; reason: string };
+export type TrustRampMove = {
+  kind: "promote" | "demote";
+  from: DirectorMode;
+  to: DirectorMode;
+  rate: number;
+  sampleSize: number;
+};
+export type TrustRampSuggestion = TrustRampMove | { kind: "hold"; reason: string };
 
 const PROMOTE_NEXT: Partial<Record<DirectorMode, DirectorMode>> = {
   dry_run: "propose",
@@ -127,7 +131,7 @@ export function maybePostTrustRampSuggestion(
   repoId: number,
   currentMode: DirectorMode,
   language: string,
-): TrustRampSuggestion | null {
+): TrustRampMove | null {
   if (trustRampOnCooldown(db, repoId)) return null;
   const suggestion = evaluateTrustRamp(db, repoId, currentMode);
   if (suggestion.kind === "hold") return null;

--- a/src/director/trust-ramp.ts
+++ b/src/director/trust-ramp.ts
@@ -65,7 +65,13 @@ export function evaluateTrustRamp(
     if (next === undefined) {
       return { kind: "hold", reason: `already at ${currentMode} (cannot promote further)` };
     }
-    return { kind: "promote", from: currentMode, to: next, rate: sample.successRate, sampleSize: counted };
+    return {
+      kind: "promote",
+      from: currentMode,
+      to: next,
+      rate: sample.successRate,
+      sampleSize: counted,
+    };
   }
 
   if (sample.successRate <= DEMOTE_THRESHOLD && counted >= DEMOTE_MIN_SAMPLE) {
@@ -73,7 +79,13 @@ export function evaluateTrustRamp(
     if (next === undefined) {
       return { kind: "hold", reason: `already at ${currentMode} (cannot demote further)` };
     }
-    return { kind: "demote", from: currentMode, to: next, rate: sample.successRate, sampleSize: counted };
+    return {
+      kind: "demote",
+      from: currentMode,
+      to: next,
+      rate: sample.successRate,
+      sampleSize: counted,
+    };
   }
 
   return {
@@ -103,7 +115,8 @@ export function trustRampOnCooldown(db: Db, repoId: number): boolean {
 function suggestionBody(suggestion: TrustRampSuggestion, language: string): string {
   if (suggestion.kind === "hold") return ""; // never posted
   const ru = language.toLowerCase().includes("russian") || language.toLowerCase().includes("рус");
-  const verb = suggestion.kind === "promote" ? (ru ? "повысить" : "promote") : (ru ? "понизить" : "demote");
+  const verb =
+    suggestion.kind === "promote" ? (ru ? "повысить" : "promote") : ru ? "понизить" : "demote";
   const ratePct = (suggestion.rate * 100).toFixed(0);
   if (ru) {
     return [

--- a/src/director/trust-ramp.ts
+++ b/src/director/trust-ramp.ts
@@ -1,0 +1,149 @@
+// Trust ramp suggestions.
+//
+// Mode escalation (`dry_run` → `propose` → `semi_auto` → `full_auto`) is
+// gated on operator trust. Most operators flip these by hand once and
+// forget; if the director's track record is good, suggesting "should we
+// promote you?" gets the conversation started — and gives the operator a
+// concrete data-driven prompt instead of a vague feeling.
+//
+// We don't change the mode programmatically. Mode lives in the per-repo
+// YAML and is hot-reloaded from there; mutating it from a SQLite overlay
+// would split the source of truth. So this module produces a *suggestion*
+// posted to the chat thread; the operator flips the YAML themselves.
+//
+// The suggestion fires at most once every TRUST_RAMP_COOLDOWN_DAYS so a
+// silent operator isn't pestered.
+
+import type { Db } from "../storage/db.js";
+import { appendMessage } from "./chat.js";
+import { sampleRecentOutcomes } from "./retrospective.js";
+import type { DirectorMode } from "./types.js";
+
+// Window guardrails — match retrospective so the operator sees consistent
+// numbers across "trust ramp suggested" and "budget recalibrated" notes.
+const PROMOTE_THRESHOLD = 0.9;
+const PROMOTE_MIN_SAMPLE = 30;
+const DEMOTE_THRESHOLD = 0.4;
+const DEMOTE_MIN_SAMPLE = 10;
+const TRUST_RAMP_COOLDOWN_DAYS = 7;
+
+export type TrustRampSuggestion =
+  | { kind: "promote"; from: DirectorMode; to: DirectorMode; rate: number; sampleSize: number }
+  | { kind: "demote"; from: DirectorMode; to: DirectorMode; rate: number; sampleSize: number }
+  | { kind: "hold"; reason: string };
+
+const PROMOTE_NEXT: Partial<Record<DirectorMode, DirectorMode>> = {
+  dry_run: "propose",
+  propose: "semi_auto",
+  semi_auto: "full_auto",
+};
+const DEMOTE_NEXT: Partial<Record<DirectorMode, DirectorMode>> = {
+  full_auto: "semi_auto",
+  semi_auto: "propose",
+  propose: "dry_run",
+};
+
+// Pure decision: given current mode + recent outcomes, what should we do?
+// Returns "hold" with a reason when the data doesn't justify a move.
+export function evaluateTrustRamp(
+  db: Db,
+  repoId: number,
+  currentMode: DirectorMode,
+): TrustRampSuggestion {
+  const sample = sampleRecentOutcomes(db, repoId);
+  const counted = sample.executed + sample.failed + sample.rejected;
+  if (sample.successRate === null) {
+    return { kind: "hold", reason: "no terminal outcomes in window yet" };
+  }
+
+  if (sample.successRate >= PROMOTE_THRESHOLD && counted >= PROMOTE_MIN_SAMPLE) {
+    const next = PROMOTE_NEXT[currentMode];
+    if (next === undefined) {
+      return { kind: "hold", reason: `already at ${currentMode} (cannot promote further)` };
+    }
+    return { kind: "promote", from: currentMode, to: next, rate: sample.successRate, sampleSize: counted };
+  }
+
+  if (sample.successRate <= DEMOTE_THRESHOLD && counted >= DEMOTE_MIN_SAMPLE) {
+    const next = DEMOTE_NEXT[currentMode];
+    if (next === undefined) {
+      return { kind: "hold", reason: `already at ${currentMode} (cannot demote further)` };
+    }
+    return { kind: "demote", from: currentMode, to: next, rate: sample.successRate, sampleSize: counted };
+  }
+
+  return {
+    kind: "hold",
+    reason: `success_rate ${(sample.successRate * 100).toFixed(0)}% over ${counted} decisions — neither threshold met`,
+  };
+}
+
+// Has the trust ramp suggester posted in the last cooldown window? Looks
+// for our own marker in metadata. Cheap query — lookups by repo + ts.
+export function trustRampOnCooldown(db: Db, repoId: number): boolean {
+  const row = db
+    .prepare(
+      `SELECT id FROM director_messages
+       WHERE repo_id = ?
+         AND metadata IS NOT NULL
+         AND json_extract(metadata, '$.kind') = 'trust_ramp'
+         AND ts > datetime('now', '-${TRUST_RAMP_COOLDOWN_DAYS} days')
+       ORDER BY id DESC LIMIT 1`,
+    )
+    .get(repoId);
+  return row !== undefined;
+}
+
+// Render the suggestion into a human-readable chat message body. Plain
+// text — the chat surface markdown-renders it.
+function suggestionBody(suggestion: TrustRampSuggestion, language: string): string {
+  if (suggestion.kind === "hold") return ""; // never posted
+  const ru = language.toLowerCase().includes("russian") || language.toLowerCase().includes("рус");
+  const verb = suggestion.kind === "promote" ? (ru ? "повысить" : "promote") : (ru ? "понизить" : "demote");
+  const ratePct = (suggestion.rate * 100).toFixed(0);
+  if (ru) {
+    return [
+      `**Предложение по уровню доверия.** За последние 14 дней: ${suggestion.sampleSize} решений с финальным исходом, success rate ${ratePct}%.`,
+      "",
+      `Считаю, что можно ${verb} режим: \`${suggestion.from}\` → \`${suggestion.to}\`.`,
+      "",
+      `Чтобы применить — поправь в YAML \`director.mode: ${suggestion.to}\`. Hot-reload сразу подхватит.`,
+    ].join("\n");
+  }
+  return [
+    `**Trust ramp suggestion.** Last 14 days: ${suggestion.sampleSize} terminal decisions, success rate ${ratePct}%.`,
+    "",
+    `I'd ${verb} from \`${suggestion.from}\` to \`${suggestion.to}\`.`,
+    "",
+    `To apply, edit your repo YAML \`director.mode: ${suggestion.to}\`. Hot-reload picks it up.`,
+  ].join("\n");
+}
+
+// Post the suggestion to the chat thread (if any) and return what we
+// posted. Returns null when held / on cooldown — the caller can surface
+// that in service-loop logs without writing chat noise.
+export function maybePostTrustRampSuggestion(
+  db: Db,
+  repoId: number,
+  currentMode: DirectorMode,
+  language: string,
+): TrustRampSuggestion | null {
+  if (trustRampOnCooldown(db, repoId)) return null;
+  const suggestion = evaluateTrustRamp(db, repoId, currentMode);
+  if (suggestion.kind === "hold") return null;
+  appendMessage(db, {
+    repoId,
+    role: "director",
+    type: "question",
+    body: suggestionBody(suggestion, language),
+    metadata: {
+      kind: "trust_ramp",
+      direction: suggestion.kind,
+      from: suggestion.from,
+      to: suggestion.to,
+      rate: suggestion.rate,
+      sampleSize: suggestion.sampleSize,
+    },
+  });
+  return suggestion;
+}

--- a/test/director-trust-ramp.test.mjs
+++ b/test/director-trust-ramp.test.mjs
@@ -1,0 +1,156 @@
+// Trust ramp suggestions.
+//
+// Verifies:
+//   • evaluateTrustRamp holds when sample is too small
+//   • promote suggestion fires past 0.9 rate + 30 sample
+//   • demote suggestion fires below 0.4 + 10 sample
+//   • cooldown blocks back-to-back posts
+//   • full_auto cannot promote further; dry_run cannot demote further
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import {
+  evaluateTrustRamp,
+  maybePostTrustRampSuggestion,
+  trustRampOnCooldown,
+} from "../dist/director/trust-ramp.js";
+import { recordDecision, setDecisionOutcome } from "../dist/director/decisions.js";
+import { recentMessages, appendMessage } from "../dist/director/chat.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-trust-ramp-test-"));
+  const db = initDb(dir);
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// Insert N decisions for the given repo, all of `decisionType=create_issue`,
+// with outcomes split between executed/rejected to hit a target success rate.
+function seedDecisions(db, repoId, executedN, rejectedN) {
+  for (let i = 0; i < executedN; i++) {
+    const d = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: `seed executed #${i} for trust-ramp test fixtures`,
+      payload: { title: `seed-${i}-${Math.random()}` }, // unique to avoid dedup
+      outcome: "pending",
+    });
+    setDecisionOutcome(db, d.id, "executed", "ok");
+  }
+  for (let i = 0; i < rejectedN; i++) {
+    const d = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: `seed rejected #${i} for trust-ramp test fixtures`,
+      payload: { title: `rej-${i}-${Math.random()}` },
+      outcome: "pending",
+    });
+    setDecisionOutcome(db, d.id, "rejected", "operator said no");
+  }
+}
+
+test("evaluateTrustRamp: hold when sample too small", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    seedDecisions(db, repoId, 3, 0);
+    const s = evaluateTrustRamp(db, repoId, "propose");
+    assert.equal(s.kind, "hold");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("evaluateTrustRamp: promote propose → semi_auto when 28/30 executed", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    seedDecisions(db, repoId, 28, 2);
+    const s = evaluateTrustRamp(db, repoId, "propose");
+    assert.equal(s.kind, "promote");
+    assert.equal(s.from, "propose");
+    assert.equal(s.to, "semi_auto");
+    assert.ok(s.rate > 0.9);
+    assert.equal(s.sampleSize, 30);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("evaluateTrustRamp: demote when 7/12 rejected", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    seedDecisions(db, repoId, 5, 7); // 5/12 = 41% — actually above 0.4
+    let s = evaluateTrustRamp(db, repoId, "semi_auto");
+    assert.equal(s.kind, "hold"); // borderline holds
+    seedDecisions(db, repoId, 0, 5); // now 5/17 = 29%
+    s = evaluateTrustRamp(db, repoId, "semi_auto");
+    assert.equal(s.kind, "demote");
+    assert.equal(s.from, "semi_auto");
+    assert.equal(s.to, "propose");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("evaluateTrustRamp: full_auto cannot promote further", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    seedDecisions(db, repoId, 30, 0);
+    const s = evaluateTrustRamp(db, repoId, "full_auto");
+    assert.equal(s.kind, "hold");
+    assert.match(s.reason, /cannot promote/);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("maybePostTrustRampSuggestion: posts a question + sets cooldown", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    seedDecisions(db, repoId, 28, 2);
+    const before = recentMessages(db, repoId, 50).length;
+    const result = maybePostTrustRampSuggestion(db, repoId, "propose", "English");
+    assert.ok(result);
+    assert.equal(result.kind, "promote");
+    const messages = recentMessages(db, repoId, 50);
+    assert.equal(messages.length, before + 1);
+    const posted = messages[messages.length - 1];
+    assert.equal(posted.role, "director");
+    assert.equal(posted.type, "question");
+    assert.match(posted.body, /Trust ramp suggestion|trust ramp/i);
+    assert.equal(posted.metadata?.kind, "trust_ramp");
+    assert.equal(trustRampOnCooldown(db, repoId), true);
+    // Second call should be blocked by cooldown.
+    const result2 = maybePostTrustRampSuggestion(db, repoId, "propose", "English");
+    assert.equal(result2, null);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("maybePostTrustRampSuggestion: Russian language → Russian copy", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    seedDecisions(db, repoId, 28, 2);
+    maybePostTrustRampSuggestion(db, repoId, "propose", "Russian");
+    const messages = recentMessages(db, repoId, 5);
+    const posted = messages[messages.length - 1];
+    assert.match(posted.body, /Предложение по уровню доверия|повысить/);
+  } finally {
+    cleanup(dir);
+  }
+});


### PR DESCRIPTION
Closes #51. Refs #44.

Mode escalation (`dry_run` → `propose` → `semi_auto` → `full_auto`) used to require operator inertia to overcome. With success-rate data already in hand from the retrospective, we can suggest the next step proactively.

- **`src/director/trust-ramp.ts`**: pure evaluator + chat poster. Promote when ≥30 terminal decisions in 14d at ≥90% executed; demote when ≥10 at ≤40%. Cooldown of 7d so a quiet operator isn't pestered.
- **Service loop** runs the cheap evaluator on every wake (one SQL aggregate). Posts to chat are gated by the cooldown.
- **Mode itself stays in YAML** — we never mutate it programmatically. The suggestion message tells the operator exactly what line to flip; hot-reload picks it up.
- Russian copy when `director.language` indicates Russian.

## Test plan
- [x] `pnpm run check` green (146 tests; +6 trust-ramp tests)
- [x] Below-min-sample → hold
- [x] Promote at 28/30 executed; demote at 5/17 executed
- [x] full_auto / dry_run terminal modes refuse to ramp further
- [x] Cooldown blocks back-to-back posts