### PR TITLE
feat(director): cheap engine for reactive (chat) ticks

### DIFF
--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -333,13 +333,15 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
 // are engine-specific. MIMO's quality is lower than Sonnet but its JSON-mode
 // is solid and the cost is ~10x cheaper, so it's a fine fallback for a
 // dry_run-mode director that's still being calibrated.
-export function selectThinkEngine(opts: {
-  // When the tick is reactive (user just wrote in chat) we prefer the
-  // cheap engine — chat replies don't need Sonnet's planning depth, and
-  // MIMO's response time is half. Scheduled cadence ticks (full planning
-  // round) still pull the heavy engine.
-  preferCheap?: boolean;
-} = {}): { engine: Engine; model: string } {
+export function selectThinkEngine(
+  opts: {
+    // When the tick is reactive (user just wrote in chat) we prefer the
+    // cheap engine — chat replies don't need Sonnet's planning depth, and
+    // MIMO's response time is half. Scheduled cadence ticks (full planning
+    // round) still pull the heavy engine.
+    preferCheap?: boolean;
+  } = {},
+): { engine: Engine; model: string } {
   const override = (process.env.OPENRONIN_DIRECTOR_THINK_ENGINE ?? "").toLowerCase();
   const userModel = process.env.OPENRONIN_DIRECTOR_THINK_MODEL;
   const haveAnthropic = !!process.env.ANTHROPIC_API_KEY;

--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -154,10 +154,15 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
 
   let engine: Engine;
   let model: string;
+  // Prefer the cheap engine for reactive (chat-driven) ticks. Scheduled
+  // cadence ticks still pull Sonnet because they may produce a tick's
+  // worth of careful planning decisions. user_message is roughly 10x
+  // cheaper on MIMO and reacts faster, which is what chat needs.
+  const preferCheap = reason === "user_message";
   try {
     ({ engine, model } = opts.engineFactory
       ? { engine: opts.engineFactory(), model: process.env.OPENRONIN_DIRECTOR_THINK_MODEL ?? "" }
-      : selectThinkEngine());
+      : selectThinkEngine({ preferCheap }));
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     appendMessage(db, {
@@ -328,7 +333,13 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
 // are engine-specific. MIMO's quality is lower than Sonnet but its JSON-mode
 // is solid and the cost is ~10x cheaper, so it's a fine fallback for a
 // dry_run-mode director that's still being calibrated.
-export function selectThinkEngine(): { engine: Engine; model: string } {
+export function selectThinkEngine(opts: {
+  // When the tick is reactive (user just wrote in chat) we prefer the
+  // cheap engine — chat replies don't need Sonnet's planning depth, and
+  // MIMO's response time is half. Scheduled cadence ticks (full planning
+  // round) still pull the heavy engine.
+  preferCheap?: boolean;
+} = {}): { engine: Engine; model: string } {
   const override = (process.env.OPENRONIN_DIRECTOR_THINK_ENGINE ?? "").toLowerCase();
   const userModel = process.env.OPENRONIN_DIRECTOR_THINK_MODEL;
   const haveAnthropic = !!process.env.ANTHROPIC_API_KEY;
@@ -345,6 +356,16 @@ export function selectThinkEngine(): { engine: Engine; model: string } {
     return { engine: new MimoEngine({}), model: userModel ?? DEFAULT_MIMO_MODEL };
   }
 
+  // Reactive (chat-reply) ticks prefer MIMO if available; scheduled ticks
+  // prefer Anthropic. Fall through to the other side if the preferred
+  // engine isn't configured.
+  if (opts.preferCheap && haveMimo) {
+    // userModel only honoured for the heavy engine — MIMO has its own
+    // dedicated env (OPENRONIN_DIRECTOR_CHAT_MODEL) for the chat-reply
+    // path so an operator can pin chat to a different MIMO variant.
+    const chatModel = process.env.OPENRONIN_DIRECTOR_CHAT_MODEL ?? DEFAULT_MIMO_MODEL;
+    return { engine: new MimoEngine({}), model: chatModel };
+  }
   if (haveAnthropic) {
     return { engine: new AnthropicEngine({}), model: userModel ?? DEFAULT_ANTHROPIC_MODEL };
   }

--- a/test/director-engine-split.test.mjs
+++ b/test/director-engine-split.test.mjs
@@ -1,0 +1,101 @@
+// Engine split: chat-reply ticks prefer MIMO, scheduled ticks prefer Anthropic.
+//
+// We don't actually instantiate either engine here — the test sets the
+// env-var-driven inputs and asserts on the type tag of the chosen engine
+// (`engine.id`). Production env always provides at least one key, so the
+// fallthrough behaviour matters too.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { selectThinkEngine } from "../dist/director/tick.js";
+
+function withEnv(overrides, body) {
+  const saved = {};
+  for (const k of Object.keys(overrides)) {
+    saved[k] = process.env[k];
+    if (overrides[k] === undefined) delete process.env[k];
+    else process.env[k] = overrides[k];
+  }
+  try {
+    body();
+  } finally {
+    for (const k of Object.keys(saved)) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+test("selectThinkEngine: defaults prefer Anthropic when both keys present", () => {
+  withEnv(
+    {
+      ANTHROPIC_API_KEY: "sk-test",
+      XIAOMI_MIMO_API_KEY: "mimo-test",
+      OPENRONIN_DIRECTOR_THINK_ENGINE: undefined,
+      OPENRONIN_DIRECTOR_THINK_MODEL: undefined,
+      OPENRONIN_DIRECTOR_CHAT_MODEL: undefined,
+    },
+    () => {
+      const { engine } = selectThinkEngine();
+      assert.equal(engine.id, "anthropic");
+    },
+  );
+});
+
+test("selectThinkEngine: preferCheap=true picks MIMO when both keys present", () => {
+  withEnv(
+    {
+      ANTHROPIC_API_KEY: "sk-test",
+      XIAOMI_MIMO_API_KEY: "mimo-test",
+      OPENRONIN_DIRECTOR_THINK_ENGINE: undefined,
+    },
+    () => {
+      const { engine } = selectThinkEngine({ preferCheap: true });
+      assert.equal(engine.id, "mimo");
+    },
+  );
+});
+
+test("selectThinkEngine: preferCheap honours OPENRONIN_DIRECTOR_CHAT_MODEL", () => {
+  withEnv(
+    {
+      ANTHROPIC_API_KEY: "sk-test",
+      XIAOMI_MIMO_API_KEY: "mimo-test",
+      OPENRONIN_DIRECTOR_THINK_ENGINE: undefined,
+      OPENRONIN_DIRECTOR_CHAT_MODEL: "mimo-v2.5-flash",
+    },
+    () => {
+      const { model } = selectThinkEngine({ preferCheap: true });
+      assert.equal(model, "mimo-v2.5-flash");
+    },
+  );
+});
+
+test("selectThinkEngine: explicit override beats preferCheap", () => {
+  withEnv(
+    {
+      ANTHROPIC_API_KEY: "sk-test",
+      XIAOMI_MIMO_API_KEY: "mimo-test",
+      OPENRONIN_DIRECTOR_THINK_ENGINE: "anthropic",
+    },
+    () => {
+      const { engine } = selectThinkEngine({ preferCheap: true });
+      assert.equal(engine.id, "anthropic");
+    },
+  );
+});
+
+test("selectThinkEngine: preferCheap falls through to Anthropic if MIMO unset", () => {
+  withEnv(
+    {
+      ANTHROPIC_API_KEY: "sk-test",
+      XIAOMI_MIMO_API_KEY: undefined,
+      OPENRONIN_DIRECTOR_THINK_ENGINE: undefined,
+    },
+    () => {
+      const { engine } = selectThinkEngine({ preferCheap: true });
+      assert.equal(engine.id, "anthropic");
+    },
+  );
+});


### PR DESCRIPTION
Closes #52. Refs #44.

`selectThinkEngine` grows a `preferCheap` flag; `runTick` passes it when `reason='user_message'`. The result: a chat directive triggers a MIMO call (~10× cheaper, faster) instead of Sonnet. Scheduled cadence ticks that emit careful multi-decision plans still pull the heavy engine.

`OPENRONIN_DIRECTOR_CHAT_MODEL` pins the chat-reply path to a specific MIMO variant (e.g. `mimo-v2.5-flash`) without touching the planning default.

## Test plan
- [x] `pnpm run check` green (151 tests; +5 engine-split tests)
- [x] Defaults unchanged (Anthropic when both keys present)
- [x] preferCheap picks MIMO when both keys present
- [x] Explicit OPENRONIN_DIRECTOR_THINK_ENGINE override beats preferCheap
- [x] Falls through to Anthropic when MIMO key absent