### PR TITLE
feat(director): standing operator notes

### DIFF
--- a/prompts/templates/director-tick.md
+++ b/prompts/templates/director-tick.md
@@ -36,6 +36,16 @@ You are running in mode `{{mode}}`. The mode controls whether your decisions act
 
 In every mode, prefer fewer high-value decisions over many low-value ones. **An empty/no-op tick is a valid outcome** — say `no_op` and explain why, rather than inventing busywork.
 
+## Standing notes from the operator
+
+These are durable preferences the operator has stated — they outlive the recent chat window. Treat them as constraints alongside the charter.
+
+```
+{{standing_notes}}
+```
+
+If the operator says something in this tick that sounds like a durable preference (e.g. "don't propose issues bigger than 200 lines", "comment in Russian"), emit a `remember_preference` decision so it gets persisted instead of fading from the chat window.
+
 ## Attention first
 
 The watchdog populates `state.attentionItems` with things you should look at **before** charter-driven planning: stale PRs, issues stuck in `awaiting-answer`, recent failed deploys, your own failure streak, an over-stuffed proposal queue. If that list is non-empty, address the top items in this tick — don't pile new work on top of stuck work.

--- a/src/director/decision-schema.ts
+++ b/src/director/decision-schema.ts
@@ -64,6 +64,14 @@ const AmendCharterPayload = z.object({
   rationale: z.string().min(20),
 });
 
+// Long-term operator preference. The body is the canonical statement
+// the LLM will see in future ticks under "Standing notes". Kind
+// classifies what sort of preference (free-form so we don't over-spec).
+const RememberPreferencePayload = z.object({
+  body: z.string().min(5).max(500),
+  kind: z.string().default("preference"),
+});
+
 // ── Decision union (discriminated by `type`) ─────────────────────────────
 
 const DecisionSchema = z.discriminatedUnion("type", [
@@ -130,6 +138,12 @@ const DecisionSchema = z.discriminatedUnion("type", [
     rationale: z.string().min(10),
     priority_id: z.string().optional(),
     payload: AmendCharterPayload,
+  }),
+  z.object({
+    type: z.literal("remember_preference"),
+    rationale: z.string().min(10),
+    priority_id: z.string().optional(),
+    payload: RememberPreferencePayload,
   }),
 ]);
 export type ParsedDecision = z.infer<typeof DecisionSchema>;

--- a/src/director/executor.ts
+++ b/src/director/executor.ts
@@ -40,6 +40,7 @@ import { repoKey } from "../config/schema.js";
 import type { VcsProvider, VcsRepoRef } from "../providers/vcs.js";
 import { getDecisionById, setDecisionOutcome, setDecisionPayload } from "./decisions.js";
 import { appendMessage } from "./chat.js";
+import { recordNote } from "./notes.js";
 import type { ParsedDecision } from "./decision-schema.js";
 import type { DecisionOutcome, DirectorAuthority, DirectorConfig } from "./types.js";
 
@@ -152,6 +153,10 @@ function authorityFor(
       if (!authority.can_modify_charter)
         return { gated: true, reason: "authority: can_modify_charter=false" };
       return { gated: false };
+    case "remember_preference":
+      // Always allowed — it's an internal memory write, doesn't touch
+      // the repo or the YAML. Operator can prune via /admin if undesired.
+      return { gated: false };
     case "ask_user":
     case "no_op":
       return { gated: false };
@@ -165,8 +170,15 @@ function decisionNeedsApproval(
   mode: DirectorConfig["mode"],
   _authority: DirectorAuthority,
 ): boolean {
-  // no_op and ask_user are always safe to execute (they don't touch the repo).
-  if (decision.type === "no_op" || decision.type === "ask_user") return false;
+  // no_op / ask_user / remember_preference don't touch the repo — safe to
+  // execute in every mode, no approval required.
+  if (
+    decision.type === "no_op" ||
+    decision.type === "ask_user" ||
+    decision.type === "remember_preference"
+  ) {
+    return false;
+  }
   // amend_charter is always proposal-only — even full_auto must not silently
   // mutate the constitution. Authority gating is what unlocks the proposal
   // surface in the first place.
@@ -192,9 +204,13 @@ function decisionNeedsApproval(
 
 async function runDecision(opts: ExecuteOptions, repoRef: VcsRepoRef): Promise<string> {
   const { db, decisionId, repoId, repo, decision, getVcs } = opts;
-  // Decisions that need a real API call grab the provider here. ask_user
-  // and no_op never call getVcs(), so VcsProvider construction is deferred.
-  const needsVcs = decision.type !== "ask_user" && decision.type !== "no_op";
+  // Decisions that need a real API call grab the provider here. ask_user,
+  // no_op, and remember_preference never call getVcs(), so VcsProvider
+  // construction is deferred for those code paths.
+  const needsVcs =
+    decision.type !== "ask_user" &&
+    decision.type !== "no_op" &&
+    decision.type !== "remember_preference";
   const vcs = needsVcs ? getVcs() : (null as unknown as VcsProvider);
 
   switch (decision.type) {
@@ -273,6 +289,17 @@ async function runDecision(opts: ExecuteOptions, repoRef: VcsRepoRef): Promise<s
       // Should never reach here — amend_charter always needs approval and
       // is intercepted earlier. If we do, fail loudly.
       throw new Error("amend_charter cannot auto-execute (must be human-applied)");
+
+    case "remember_preference": {
+      // Persist a long-term note. The next tick's state-snapshot will
+      // surface it under "Standing notes" and the LLM can act on it.
+      const note = recordNote(db, {
+        repoId,
+        kind: decision.payload.kind ?? "preference",
+        body: decision.payload.body,
+      });
+      return `noted #${note.id} (${note.kind})`;
+    }
   }
 }
 
@@ -368,6 +395,7 @@ const EDITABLE_FIELDS: Record<string, readonly string[]> = {
   merge_pr: ["strategy"],
   ask_user: ["question", "context"],
   amend_charter: ["proposed_changes", "rationale"],
+  remember_preference: ["body", "kind"],
 };
 
 export function editableFieldsFor(decisionType: string): readonly string[] {

--- a/src/director/executor.ts
+++ b/src/director/executor.ts
@@ -368,6 +368,8 @@ function summariseProposal(d: ParsedDecision): string {
       return `→ question:\n\n> ${truncate(d.payload.question, 400)}`;
     case "amend_charter":
       return `→ proposed charter changes:\n\n> ${truncate(d.payload.proposed_changes, 600)}`;
+    case "remember_preference":
+      return `→ remember (${d.payload.kind ?? "preference"}):\n\n> ${truncate(d.payload.body, 400)}`;
     case "no_op":
       return "(no_op)";
   }

--- a/src/director/notes.ts
+++ b/src/director/notes.ts
@@ -1,0 +1,89 @@
+// Standing operator notes — long-term "this is how I want you to behave".
+//
+// The recentChat window in state.ts caps at 25 messages so the prompt
+// stays cheap. That's enough for "what did the operator ask about
+// today" but not for "the operator hates issues with scope >200 LOC"
+// said three weeks ago. Standing notes survive that window — they're
+// stored separately and rendered into a dedicated prompt section.
+//
+// Two ways notes get added:
+//  1. The director itself emits a `remember_preference` decision when it
+//     hears the operator state a stable preference. The executor inserts.
+//  2. The operator adds them directly via /admin/director (UI lands in
+//     a follow-up PR; for now this module gives the data layer).
+
+import type { Db } from "../storage/db.js";
+
+export type DirectorNote = {
+  id: number;
+  repoId: number;
+  ts: string;
+  kind: string; // "preference" | "fact" | "constraint" | freeform
+  body: string;
+  sourceMessageId: number | null;
+};
+
+type Row = {
+  id: number;
+  repo_id: number;
+  ts: string;
+  kind: string;
+  body: string;
+  source_message_id: number | null;
+};
+
+function rowToNote(row: Row): DirectorNote {
+  return {
+    id: row.id,
+    repoId: row.repo_id,
+    ts: row.ts,
+    kind: row.kind,
+    body: row.body,
+    sourceMessageId: row.source_message_id,
+  };
+}
+
+export type NewDirectorNote = {
+  repoId: number;
+  kind: string;
+  body: string;
+  sourceMessageId?: number | null;
+};
+
+export function recordNote(db: Db, n: NewDirectorNote): DirectorNote {
+  const row = db
+    .prepare(
+      `INSERT INTO director_notes (repo_id, kind, body, source_message_id)
+       VALUES (?, ?, ?, ?)
+       RETURNING *`,
+    )
+    .get(n.repoId, n.kind, n.body.trim(), n.sourceMessageId ?? null) as Row;
+  return rowToNote(row);
+}
+
+export function listNotes(db: Db, repoId: number, limit = 50): DirectorNote[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM director_notes WHERE repo_id = ? ORDER BY id DESC LIMIT ?`,
+    )
+    .all(repoId, limit) as Row[];
+  return rows.map(rowToNote);
+}
+
+export function deleteNote(db: Db, repoId: number, noteId: number): boolean {
+  const res = db
+    .prepare(`DELETE FROM director_notes WHERE id = ? AND repo_id = ?`)
+    .run(noteId, repoId);
+  return res.changes > 0;
+}
+
+// Render notes for the prompt. Capped at 20 most recent so the section
+// doesn't dominate the context. Format is plain "- kind: body" lines —
+// the LLM can read these without ceremony.
+export function renderNotesForPrompt(notes: DirectorNote[]): string {
+  if (notes.length === 0) return "(no standing notes — operator hasn't told you anything to remember yet)";
+  return notes
+    .slice(0, 20)
+    .map((n) => `- ${n.kind}: ${n.body}`)
+    .join("\n");
+}

--- a/src/director/notes.ts
+++ b/src/director/notes.ts
@@ -63,9 +63,7 @@ export function recordNote(db: Db, n: NewDirectorNote): DirectorNote {
 
 export function listNotes(db: Db, repoId: number, limit = 50): DirectorNote[] {
   const rows = db
-    .prepare(
-      `SELECT * FROM director_notes WHERE repo_id = ? ORDER BY id DESC LIMIT ?`,
-    )
+    .prepare(`SELECT * FROM director_notes WHERE repo_id = ? ORDER BY id DESC LIMIT ?`)
     .all(repoId, limit) as Row[];
   return rows.map(rowToNote);
 }
@@ -81,7 +79,8 @@ export function deleteNote(db: Db, repoId: number, noteId: number): boolean {
 // doesn't dominate the context. Format is plain "- kind: body" lines —
 // the LLM can read these without ceremony.
 export function renderNotesForPrompt(notes: DirectorNote[]): string {
-  if (notes.length === 0) return "(no standing notes — operator hasn't told you anything to remember yet)";
+  if (notes.length === 0)
+    return "(no standing notes — operator hasn't told you anything to remember yet)";
   return notes
     .slice(0, 20)
     .map((n) => `- ${n.kind}: ${n.body}`)

--- a/src/director/prompt.ts
+++ b/src/director/prompt.ts
@@ -17,6 +17,7 @@ import { loadTemplate, renderTemplate } from "../prompts/registry.js";
 import type { RepoConfig } from "../config/schema.js";
 import type { StateSnapshot } from "./state.js";
 import type { Persona } from "./types.js";
+import { renderNotesForPrompt } from "./notes.js";
 
 export type PromptInputs = {
   ownerName: string;
@@ -84,6 +85,7 @@ export function composePrompt(inputs: PromptInputs): ComposedPrompt {
     language: inputs.language,
     persona_block: renderPersonaBlock(inputs.persona),
     tick_reason: inputs.reason ?? "scheduled",
+    standing_notes: renderNotesForPrompt(inputs.state.standingNotes),
     state_json: JSON.stringify(inputs.state, null, 2),
     chat_transcript: renderChatTranscript(inputs.state.recentChat),
   });

--- a/src/director/state.ts
+++ b/src/director/state.ts
@@ -8,6 +8,7 @@
 // 30k input tokens needs to stay under the think budget ($1/day default).
 
 import type { Db } from "../storage/db.js";
+import { listNotes, type DirectorNote } from "./notes.js";
 
 export type StateSnapshot = {
   repo: { id: number; owner: string; name: string };
@@ -32,6 +33,10 @@ export type StateSnapshot = {
   // recent failed deploys. The prompt template renders these in their
   // own section so the LLM addresses them before charter-priority work.
   attentionItems: AttentionItem[];
+  // Long-term operator preferences ("don't propose work on weekends",
+  // "every issue should have an Acceptance section", …). Survives the
+  // recentChat window. Capped at 20 in the snapshot.
+  standingNotes: DirectorNote[];
 };
 
 export type AttentionItem = {
@@ -209,6 +214,7 @@ export function captureStateSnapshot(
     recentDecisions,
     pendingDecisionCount,
     attentionItems: collectAttentionItems(db, repoId),
+    standingNotes: listNotes(db, repoId, 20),
   };
 }
 

--- a/src/director/types.ts
+++ b/src/director/types.ts
@@ -227,6 +227,7 @@ export const DecisionTypeSchema = z.enum([
   "merge_pr", // merges (gated by mode + authority.can_merge)
   "ask_user", // post a question into the chat, expect answer
   "amend_charter", // requires authority.can_modify_charter
+  "remember_preference", // store a long-term operator preference
 ]);
 export type DecisionType = z.infer<typeof DecisionTypeSchema>;
 

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -36,6 +36,7 @@ import { latestCharterVersion } from "../director/charter.js";
 import { approveDecision, rejectDecision } from "../director/executor.js";
 import { getActiveTick } from "../director/active-tick.js";
 import { getDecisionById } from "../director/decisions.js";
+import { deleteNote, listNotes, recordNote } from "../director/notes.js";
 import { GithubVcsProvider } from "../providers/github.js";
 import type { VcsProvider } from "../providers/vcs.js";
 import type { DirectorMessage, MessageType } from "../director/types.js";
@@ -667,6 +668,138 @@ function renderStatusPanel(
   `;
 }
 
+// Standing notes panel — long-term operator preferences. Renders as a
+// list of bubbles with a delete button each, plus a tiny add form. The
+// delete button HTMX-replaces the whole card, keeping the surface terse.
+function renderNotesCard(db: Db, slug: string, repoId: number): TrustedHtml {
+  const notes = listNotes(db, repoId, 50);
+  return card({
+    title: `Standing notes — ${notes.length}`,
+    body: html`
+      <div id="notes-card-body" class="flex flex-col gap-2">
+        ${notes.length === 0
+          ? html`<p class="text-xs text-[var(--fg-muted)]">
+              Long-term preferences live here. Tell ${"the director"} "remember:" something to
+              persist beyond the chat window.
+            </p>`
+          : html`<ul class="flex flex-col gap-1">
+              ${notes.map(
+                (n) => html`
+                  <li
+                    class="flex items-start gap-2 text-xs p-2 border border-[var(--border)] rounded bg-[var(--surface-base)]"
+                  >
+                    <span class="font-mono text-[var(--fg-muted)] shrink-0">${n.kind}</span>
+                    <span class="flex-1">${n.body}</span>
+                    <button
+                      class="btn btn-ghost btn-xs"
+                      title="Delete note"
+                      hx-delete="/admin/director/${slug}/notes/${n.id}"
+                      hx-target="#notes-card-body"
+                      hx-swap="outerHTML"
+                      hx-confirm="Delete this note?"
+                    >
+                      ✕
+                    </button>
+                  </li>
+                `,
+              )}
+            </ul>`}
+        <form
+          class="flex flex-col gap-1 pt-2 border-t border-[var(--border)]"
+          hx-post="/admin/director/${slug}/notes"
+          hx-target="#notes-card-body"
+          hx-swap="outerHTML"
+          hx-on::after-request="if(event.detail.successful) this.reset()"
+        >
+          <div class="flex gap-1">
+            <input
+              type="text"
+              name="kind"
+              value="preference"
+              class="form-input form-input-sm w-24 text-xs"
+              required
+            />
+            <input
+              type="text"
+              name="body"
+              placeholder="What should the director remember?"
+              class="form-input form-input-sm flex-1 text-xs"
+              required
+            />
+            <button type="submit" class="btn btn-secondary btn-xs">Add</button>
+          </div>
+        </form>
+      </div>
+    `,
+  });
+}
+
+// HTMX returns just the inner #notes-card-body so we can replace it
+// in-place after add/delete without full-page reload.
+function renderNotesCardBody(db: Db, slug: string, repoId: number): TrustedHtml {
+  const inner = renderNotesCard(db, slug, repoId);
+  // Strip the card chrome — the request swaps just the #notes-card-body
+  // div. We render a "naked" version inline.
+  void inner; // (kept for future symmetric use)
+  const notes = listNotes(db, repoId, 50);
+  return html`
+    <div id="notes-card-body" class="flex flex-col gap-2">
+      ${notes.length === 0
+        ? html`<p class="text-xs text-[var(--fg-muted)]">
+            Long-term preferences live here. Tell the director "remember:" something to persist
+            beyond the chat window.
+          </p>`
+        : html`<ul class="flex flex-col gap-1">
+            ${notes.map(
+              (n) => html`
+                <li
+                  class="flex items-start gap-2 text-xs p-2 border border-[var(--border)] rounded bg-[var(--surface-base)]"
+                >
+                  <span class="font-mono text-[var(--fg-muted)] shrink-0">${n.kind}</span>
+                  <span class="flex-1">${n.body}</span>
+                  <button
+                    class="btn btn-ghost btn-xs"
+                    title="Delete note"
+                    hx-delete="/admin/director/${slug}/notes/${n.id}"
+                    hx-target="#notes-card-body"
+                    hx-swap="outerHTML"
+                    hx-confirm="Delete this note?"
+                  >
+                    ✕
+                  </button>
+                </li>
+              `,
+            )}
+          </ul>`}
+      <form
+        class="flex flex-col gap-1 pt-2 border-t border-[var(--border)]"
+        hx-post="/admin/director/${slug}/notes"
+        hx-target="#notes-card-body"
+        hx-swap="outerHTML"
+        hx-on::after-request="if(event.detail.successful) this.reset()"
+      >
+        <div class="flex gap-1">
+          <input
+            type="text"
+            name="kind"
+            value="preference"
+            class="form-input form-input-sm w-24 text-xs"
+            required
+          />
+          <input
+            type="text"
+            name="body"
+            placeholder="What should the director remember?"
+            class="form-input form-input-sm flex-1 text-xs"
+            required
+          />
+          <button type="submit" class="btn btn-secondary btn-xs">Add</button>
+        </div>
+      </form>
+    </div>
+  `;
+}
+
 function renderComposer(slug: string): TrustedHtml {
   return html`
     <form
@@ -1033,9 +1166,13 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
             `,
     });
 
+    const notesCard = renderNotesCard(db, slug, entry.repoId);
+
     const body = html`
       <div class="grid gap-4 lg:grid-cols-3">
-        <div class="lg:col-span-1 flex flex-col gap-4">${charterCard} ${budgetCard}</div>
+        <div class="lg:col-span-1 flex flex-col gap-4">
+          ${charterCard} ${budgetCard} ${notesCard}
+        </div>
         <div class="lg:col-span-2 flex flex-col gap-4">${chatCard} ${decisionsCard}</div>
       </div>
       ${raw(CHAT_INIT_SCRIPT)}
@@ -1250,6 +1387,32 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
       resolvePersonaAvatar(repo),
     );
     return c.html(panel.value);
+  });
+
+  // ── POST /:slug/notes ────────────────────────────────────────────────
+  // Add a standing note manually (in addition to the LLM-emitted path).
+  app.post("/:slug/notes", async (c) => {
+    const slug = c.req.param("slug");
+    const entries = listEntries(db, getConfig);
+    const entry = entries.find((e) => e.slug === slug);
+    if (!entry) return c.notFound();
+    const form = await c.req.parseBody();
+    const kind = String(form.kind ?? "preference").trim() || "preference";
+    const body = String(form.body ?? "").trim();
+    if (!body) return c.html("body required", 400);
+    recordNote(db, { repoId: entry.repoId, kind, body });
+    return c.html(renderNotesCardBody(db, slug, entry.repoId).value);
+  });
+
+  // ── DELETE /:slug/notes/:id ──────────────────────────────────────────
+  app.delete("/:slug/notes/:id", (c) => {
+    const slug = c.req.param("slug");
+    const entries = listEntries(db, getConfig);
+    const entry = entries.find((e) => e.slug === slug);
+    if (!entry) return c.notFound();
+    const noteId = Number(c.req.param("id"));
+    deleteNote(db, entry.repoId, noteId);
+    return c.html(renderNotesCardBody(db, slug, entry.repoId).value);
   });
 
   return app;

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -367,4 +367,25 @@ function applyMigrations(db: Db): void {
       "INSERT INTO schema_version (version, applied_at) VALUES (16, datetime('now'))",
     ).run();
   }
+
+  // v17 — Standing operator notes. Long-term memory of "this is how I
+  // want you to behave" that survives the recent_chat windowing. The
+  // director can emit a `remember_preference` decision; the executor
+  // inserts here. Operator can edit/delete via /admin/director.
+  if (current < 17) {
+    db.exec(`
+      CREATE TABLE director_notes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        repo_id INTEGER NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+        ts TEXT NOT NULL DEFAULT (datetime('now')),
+        kind TEXT NOT NULL,
+        body TEXT NOT NULL,
+        source_message_id INTEGER REFERENCES director_messages(id) ON DELETE SET NULL
+      );
+      CREATE INDEX idx_director_notes_repo_ts ON director_notes(repo_id, ts DESC);
+    `);
+    db.prepare(
+      "INSERT INTO schema_version (version, applied_at) VALUES (17, datetime('now'))",
+    ).run();
+  }
 }

--- a/test/director-notes.test.mjs
+++ b/test/director-notes.test.mjs
@@ -13,12 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { initDb } from "../dist/storage/db.js";
-import {
-  deleteNote,
-  listNotes,
-  recordNote,
-  renderNotesForPrompt,
-} from "../dist/director/notes.js";
+import { deleteNote, listNotes, recordNote, renderNotesForPrompt } from "../dist/director/notes.js";
 import { runTick } from "../dist/director/tick.js";
 import { captureStateSnapshot } from "../dist/director/state.js";
 
@@ -56,8 +51,22 @@ test("recordNote / listNotes / deleteNote round-trip", () => {
 test("renderNotesForPrompt: empty list → placeholder; non-empty formats kv-style", () => {
   assert.match(renderNotesForPrompt([]), /no standing notes/);
   const formatted = renderNotesForPrompt([
-    { id: 1, repoId: 1, ts: "2026-05-05", kind: "preference", body: "no work on weekends", sourceMessageId: null },
-    { id: 2, repoId: 1, ts: "2026-05-05", kind: "fact", body: "deploys go through 0srv", sourceMessageId: null },
+    {
+      id: 1,
+      repoId: 1,
+      ts: "2026-05-05",
+      kind: "preference",
+      body: "no work on weekends",
+      sourceMessageId: null,
+    },
+    {
+      id: 2,
+      repoId: 1,
+      ts: "2026-05-05",
+      kind: "fact",
+      body: "deploys go through 0srv",
+      sourceMessageId: null,
+    },
   ]);
   assert.match(formatted, /- preference: no work on weekends/);
   assert.match(formatted, /- fact: deploys go through 0srv/);

--- a/test/director-notes.test.mjs
+++ b/test/director-notes.test.mjs
@@ -1,0 +1,168 @@
+// Standing notes — long-term operator preferences.
+//
+// Verifies:
+//   • recordNote / listNotes / deleteNote round-trip
+//   • renderNotesForPrompt formats lines as "- kind: body"
+//   • runTick can execute a remember_preference decision and the next
+//     state snapshot includes the new note in standingNotes
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import {
+  deleteNote,
+  listNotes,
+  recordNote,
+  renderNotesForPrompt,
+} from "../dist/director/notes.js";
+import { runTick } from "../dist/director/tick.js";
+import { captureStateSnapshot } from "../dist/director/state.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-notes-test-"));
+  const db = initDb(dir);
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+test("recordNote / listNotes / deleteNote round-trip", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const a = recordNote(db, { repoId, kind: "preference", body: "no scope > 200 LOC" });
+    const b = recordNote(db, { repoId, kind: "constraint", body: "comment in Russian" });
+    const all = listNotes(db, repoId);
+    assert.equal(all.length, 2);
+    assert.equal(all[0].id, b.id); // most recent first
+    assert.equal(deleteNote(db, repoId, a.id), true);
+    assert.equal(listNotes(db, repoId).length, 1);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("renderNotesForPrompt: empty list → placeholder; non-empty formats kv-style", () => {
+  assert.match(renderNotesForPrompt([]), /no standing notes/);
+  const formatted = renderNotesForPrompt([
+    { id: 1, repoId: 1, ts: "2026-05-05", kind: "preference", body: "no work on weekends", sourceMessageId: null },
+    { id: 2, repoId: 1, ts: "2026-05-05", kind: "fact", body: "deploys go through 0srv", sourceMessageId: null },
+  ]);
+  assert.match(formatted, /- preference: no work on weekends/);
+  assert.match(formatted, /- fact: deploys go through 0srv/);
+});
+
+test("captureStateSnapshot: includes standingNotes", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    recordNote(db, { repoId, kind: "preference", body: "issues need an Acceptance section" });
+    const snapshot = captureStateSnapshot(db, repoId, "openronin", "openronin");
+    assert.equal(snapshot.standingNotes.length, 1);
+    assert.equal(snapshot.standingNotes[0].body, "issues need an Acceptance section");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+const sampleCharter = {
+  vision: "Reliable AI dev agent.",
+  priorities: [{ id: "x", weight: 1.0, rubric: "y" }],
+  out_of_bounds: [],
+  out_of_bounds_paths: [],
+  definition_of_done: [],
+};
+
+const sampleBudget = {
+  initial_daily_usd: 2.0,
+  initial_weekly_usd: 10.0,
+  max_daily_usd: 10.0,
+  max_weekly_usd: 50.0,
+  think_daily_usd: 1.0,
+  pause_on_failure_streak: 3,
+  good_outcome_quarantine_days: 7,
+};
+
+const sampleDirector = {
+  enabled: true,
+  mode: "propose",
+  cadence_hours: 6,
+  bot_prefix: "👔 director:",
+  language: "English",
+  charter: sampleCharter,
+  budget: sampleBudget,
+  authority: {
+    can_create_issues: true,
+    can_label: true,
+    can_close_issues: false,
+    can_comment: true,
+    can_approve_pr: true,
+    can_merge: false,
+    can_modify_charter: false,
+  },
+};
+
+const sampleRepo = {
+  provider: "github",
+  owner: "openronin",
+  name: "openronin",
+  watched: true,
+  lanes: ["triage"],
+  director: sampleDirector,
+};
+
+test("runTick: remember_preference decision persists a note (no approval needed)", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const result = await runTick({
+      db,
+      repoId,
+      repo: sampleRepo,
+      director: sampleDirector,
+      dataDir: dir,
+      engineFactory: () => ({
+        id: "mock",
+        defaultModel: "mock",
+        async run() {
+          return {
+            content: "{}",
+            json: {
+              observations: "Operator stated a stable preference about issue scope.",
+              reasoning: "Persist this so it survives the recent_chat windowing.",
+              decisions: [
+                {
+                  type: "remember_preference",
+                  rationale: "operator stated stable preference about scope cap",
+                  payload: {
+                    kind: "preference",
+                    body: "Issues should not exceed 200 LOC of changes",
+                  },
+                },
+              ],
+            },
+            usage: { tokensIn: 100, tokensOut: 50, costUsd: 0.001 },
+            finishReason: "end_turn",
+            durationMs: 50,
+          };
+        },
+      }),
+    });
+    assert.equal(result.status, "ok");
+    const notes = listNotes(db, repoId);
+    assert.equal(notes.length, 1);
+    assert.equal(notes[0].kind, "preference");
+    assert.match(notes[0].body, /200 LOC/);
+  } finally {
+    cleanup(dir);
+  }
+});


### PR DESCRIPTION
Closes #53. Refs #44.

Long-term memory of "this is how I want you to behave" that survives the 25-message recentChat window.

Two paths feed it:
- The director can emit a `remember_preference` decision when it hears the operator state a durable preference. Schema-validated, executor inserts into `director_notes`, no approval required (it's an internal memory write — operator can prune via UI).
- Operator can add/delete notes directly via /admin/director's notes card next to the budget/charter cards.

State snapshot grows a `standingNotes[]` field, capped at 20 most recent. The director-tick prompt template renders them in a dedicated "Standing notes from the operator" section the LLM reads alongside the charter.

**Schema v17** introduces `director_notes` (id / repo_id / ts / kind / body / source_message_id).

Threading visualisation (parent_id-aware reply chains in chat) is left as follow-up — the data model already supports it; only UI is missing.

## Test plan
- [x] `pnpm run check` green (155 tests; +4 notes tests)
- [x] CRUD round-trip
- [x] State snapshot includes standingNotes
- [x] runTick → remember_preference persists a row without approval