### PR TITLE
feat(director): slash commands in admin chat

### DIFF
--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -37,6 +37,7 @@ import { approveDecision, rejectDecision } from "../director/executor.js";
 import { getActiveTick } from "../director/active-tick.js";
 import { getDecisionById } from "../director/decisions.js";
 import { deleteNote, listNotes, recordNote } from "../director/notes.js";
+import { parseSlashCommand, runSlashCommand } from "./slash-commands.js";
 import { GithubVcsProvider } from "../providers/github.js";
 import type { VcsProvider } from "../providers/vcs.js";
 import type { DirectorMessage, MessageType } from "../director/types.js";
@@ -1209,13 +1210,46 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
       return c.html("invalid type", 400);
     }
 
-    appendMessage(db, {
-      repoId: entry.repoId,
-      role: "user",
-      type: type as "directive" | "answer" | "veto",
-      body,
-      metadata: { repo: slug, actor: "admin" },
-    });
+    // Detect slash commands BEFORE persisting as a regular user message.
+    // The composer accepts both kinds in the same field — `/tick` is
+    // interpreted as a command, "tick the project pls" is a directive.
+    const cmd = parseSlashCommand(body);
+    if (cmd) {
+      // Echo the command itself into chat so the audit trail records what
+      // the operator typed, then post the system response right after.
+      appendMessage(db, {
+        repoId: entry.repoId,
+        role: "user",
+        type: "directive",
+        body,
+        metadata: { repo: slug, actor: "admin", slash: cmd.name },
+      });
+      const config2 = getConfig();
+      const result = await runSlashCommand({
+        db,
+        repo,
+        repoId: entry.repoId,
+        cmd,
+        dataDir: config2.dataDir,
+      });
+      if (result.echo.length > 0) {
+        appendMessage(db, {
+          repoId: entry.repoId,
+          role: "system",
+          type: "tick_log",
+          body: result.echo,
+          metadata: { repo: slug, kind: "slash_response", slash: cmd.name },
+        });
+      }
+    } else {
+      appendMessage(db, {
+        repoId: entry.repoId,
+        role: "user",
+        type: type as "directive" | "answer" | "veto",
+        body,
+        metadata: { repo: slug, actor: "admin" },
+      });
+    }
 
     const messages = recentMessages(db, entry.repoId, 200);
     return c.html(

--- a/src/server/slash-commands.ts
+++ b/src/server/slash-commands.ts
@@ -45,7 +45,7 @@ export function parseSlashCommand(body: string): SlashCommand | null {
   const trimmed = body.trim();
   if (!trimmed.startsWith("/")) return null;
   const m = trimmed.match(/^\/([a-z_]+)(\s+(.*))?$/iu);
-  if (!m) return null;
+  if (!m || !m[1]) return null;
   const name = m[1].toLowerCase();
   if (!(KNOWN as readonly string[]).includes(name)) return null;
   return { name, args: (m[3] ?? "").trim() } as SlashCommand;

--- a/src/server/slash-commands.ts
+++ b/src/server/slash-commands.ts
@@ -1,0 +1,162 @@
+// Slash-command parser for the admin chat composer.
+//
+// Mirrors the Telegram bot's commands so the admin-UI operator gets the
+// same affordances. The parser is dumb and intentional: a leading `/word`
+// is a command, anything else is a regular chat message and falls through
+// to the existing message-append path.
+//
+// We don't support inline arguments yet (e.g. `/pause 2h`); each command
+// is a fire-and-forget action with effect on the repo's director state.
+
+import type { Db } from "../storage/db.js";
+import { appendMessage } from "../director/chat.js";
+import { ensureBudgetState, recordThinkSpend } from "../director/budget.js";
+import { runDigest } from "../director/digest.js";
+import { localDateInTz } from "../director/digest.js";
+import type { RepoConfig } from "../config/schema.js";
+import { repoKey } from "../config/schema.js";
+import { MimoEngine } from "../engines/mimo.js";
+
+void recordThinkSpend; // re-exported for tests; not used directly here
+void localDateInTz; // ditto
+
+export type SlashCommand =
+  | { name: "tick"; args: string }
+  | { name: "digest"; args: string }
+  | { name: "pause"; args: string }
+  | { name: "resume"; args: string }
+  | { name: "status"; args: string }
+  | { name: "budget"; args: string }
+  | { name: "help"; args: string };
+
+const KNOWN: SlashCommand["name"][] = [
+  "tick",
+  "digest",
+  "pause",
+  "resume",
+  "status",
+  "budget",
+  "help",
+];
+
+// Returns the parsed command if `body` opens with a known `/cmd`, else null.
+// Whitespace-tolerant. Body may continue with arbitrary args after the cmd.
+export function parseSlashCommand(body: string): SlashCommand | null {
+  const trimmed = body.trim();
+  if (!trimmed.startsWith("/")) return null;
+  const m = trimmed.match(/^\/([a-z_]+)(\s+(.*))?$/iu);
+  if (!m) return null;
+  const name = m[1].toLowerCase();
+  if (!(KNOWN as readonly string[]).includes(name)) return null;
+  return { name, args: (m[3] ?? "").trim() } as SlashCommand;
+}
+
+export type SlashCommandResult = {
+  // Replacement message body to write into the chat — typically a system
+  // ack of what just happened. Empty string means "don't post anything".
+  echo: string;
+};
+
+// Execute the parsed command against the repo's director state. Side
+// effects (clearing last_tick_at, running digest, pausing) happen in
+// here; the caller writes a system message with the returned echo.
+export async function runSlashCommand(opts: {
+  db: Db;
+  repo: RepoConfig | undefined;
+  repoId: number;
+  cmd: SlashCommand;
+  dataDir: string;
+}): Promise<SlashCommandResult> {
+  const { db, repo, repoId, cmd } = opts;
+  const slug = repo ? repoKey(repo) : `repo#${repoId}`;
+  switch (cmd.name) {
+    case "help":
+      return {
+        echo: [
+          "**Slash commands**",
+          "",
+          "- `/tick` — force the next tick on the repo (≤10s).",
+          "- `/digest` — run the morning digest right now (regardless of schedule).",
+          "- `/pause` — pause the director for this repo.",
+          "- `/resume` — resume after pause.",
+          "- `/status` — show current mode, budget, last tick, pending count.",
+          "- `/budget` — show budget caps + spend.",
+          "- `/help` — this list.",
+        ].join("\n"),
+      };
+    case "tick":
+      db.prepare(`UPDATE director_budget_state SET last_tick_at = NULL WHERE repo_id = ?`).run(
+        repoId,
+      );
+      return { echo: `tick requested via slash command (will fire on next loop ≤10s)` };
+    case "pause":
+      db.prepare(
+        `UPDATE director_budget_state SET paused = 1, pause_reason = ? WHERE repo_id = ?`,
+      ).run(cmd.args || "paused via /pause", repoId);
+      return { echo: `director paused${cmd.args ? ` (${cmd.args})` : ""}` };
+    case "resume":
+      db.prepare(
+        `UPDATE director_budget_state SET paused = 0, pause_reason = NULL WHERE repo_id = ?`,
+      ).run(repoId);
+      return { echo: `director resumed` };
+    case "status": {
+      const state = ensureBudgetState(db, repoId, repo?.director?.budget ?? defaultBudget());
+      return {
+        echo: [
+          `**Status — ${slug}**`,
+          `mode: \`${repo?.director?.mode ?? "?"}\` · paused: ${state.paused ? "yes" : "no"}`,
+          `last tick: ${state.lastTickAt ?? "never"}`,
+          `failure streak: ${state.failureStreak}`,
+          `today think: $${state.spentTodayThinkUsd.toFixed(4)} / $${repo?.director?.budget.think_daily_usd.toFixed(2) ?? "?"}`,
+        ].join("\n"),
+      };
+    }
+    case "budget": {
+      const state = ensureBudgetState(db, repoId, repo?.director?.budget ?? defaultBudget());
+      return {
+        echo: [
+          `**Budget — ${slug}**`,
+          `daily: $${state.spentTodayUsd.toFixed(2)} / $${state.dailyCapUsd.toFixed(2)}`,
+          `weekly: $${state.spentWeekUsd.toFixed(2)} / $${state.weeklyCapUsd.toFixed(2)}`,
+          `think today: $${state.spentTodayThinkUsd.toFixed(4)}`,
+        ].join("\n"),
+      };
+    }
+    case "digest":
+      if (!repo?.director?.digest) {
+        return { echo: "digest is not configured for this repo" };
+      }
+      try {
+        const result = await runDigest({
+          db,
+          repoId,
+          repo,
+          digest: repo.director.digest,
+          persona: repo.director.charter?.persona,
+          language: repo.director.language,
+          dataDir: opts.dataDir,
+          engineFactory: () =>
+            new MimoEngine({
+              defaultModel: process.env.OPENRONIN_DIRECTOR_DIGEST_MODEL ?? "mimo-v2.5-pro",
+            }),
+        });
+        return { echo: `digest ran: ${result.detail}` };
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        return { echo: `digest failed: ${detail}` };
+      }
+  }
+}
+
+// Tests want a no-prefix import; provide a sane default.
+function defaultBudget() {
+  return {
+    initial_daily_usd: 2.0,
+    initial_weekly_usd: 10.0,
+    max_daily_usd: 10.0,
+    max_weekly_usd: 50.0,
+    think_daily_usd: 1.0,
+    pause_on_failure_streak: 3,
+    good_outcome_quarantine_days: 7,
+  };
+}

--- a/test/director-slash.test.mjs
+++ b/test/director-slash.test.mjs
@@ -1,0 +1,155 @@
+// Slash commands in the admin chat composer.
+//
+// Verifies:
+//   • parseSlashCommand recognises /tick /pause /resume /status /budget /help /digest
+//   • non-slash text is ignored
+//   • runSlashCommand /tick clears last_tick_at
+//   • runSlashCommand /pause sets paused=1; /resume clears it
+//   • runSlashCommand /status returns a non-empty echo
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import { ensureBudgetState } from "../dist/director/budget.js";
+import { parseSlashCommand, runSlashCommand } from "../dist/server/slash-commands.js";
+
+const sampleBudget = {
+  initial_daily_usd: 2.0,
+  initial_weekly_usd: 10.0,
+  max_daily_usd: 10.0,
+  max_weekly_usd: 50.0,
+  think_daily_usd: 1.0,
+  pause_on_failure_streak: 3,
+  good_outcome_quarantine_days: 7,
+};
+
+const sampleRepo = {
+  provider: "github",
+  owner: "openronin",
+  name: "openronin",
+  watched: true,
+  lanes: ["triage"],
+  director: {
+    enabled: true,
+    mode: "propose",
+    cadence_hours: 6,
+    bot_prefix: "👔 director:",
+    language: "English",
+    budget: sampleBudget,
+    authority: {
+      can_create_issues: true,
+      can_label: true,
+      can_close_issues: false,
+      can_comment: true,
+      can_approve_pr: true,
+      can_merge: false,
+      can_modify_charter: false,
+    },
+  },
+};
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-slash-test-"));
+  const db = initDb(dir);
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+test("parseSlashCommand: known commands", () => {
+  assert.equal(parseSlashCommand("/tick").name, "tick");
+  assert.equal(parseSlashCommand("/pause urgent fire").name, "pause");
+  assert.equal(parseSlashCommand("/pause urgent fire").args, "urgent fire");
+  assert.equal(parseSlashCommand("/HELP").name, "help");
+});
+
+test("parseSlashCommand: unknown command → null", () => {
+  assert.equal(parseSlashCommand("/foobar"), null);
+});
+
+test("parseSlashCommand: non-slash text → null", () => {
+  assert.equal(parseSlashCommand("tick the project"), null);
+  assert.equal(parseSlashCommand("hello world"), null);
+});
+
+test("runSlashCommand /tick: clears last_tick_at", async () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  // Bump last_tick_at so we can verify it gets cleared.
+  db.prepare(`UPDATE director_budget_state SET last_tick_at = datetime('now') WHERE repo_id = ?`).run(
+    repoId,
+  );
+  try {
+    await runSlashCommand({
+      db,
+      repo: sampleRepo,
+      repoId,
+      cmd: { name: "tick", args: "" },
+      dataDir: dir,
+    });
+    const state = ensureBudgetState(db, repoId, sampleBudget);
+    assert.equal(state.lastTickAt, null);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("runSlashCommand /pause + /resume: toggles paused flag", async () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  try {
+    await runSlashCommand({
+      db,
+      repo: sampleRepo,
+      repoId,
+      cmd: { name: "pause", args: "going to lunch" },
+      dataDir: dir,
+    });
+    let state = ensureBudgetState(db, repoId, sampleBudget);
+    assert.equal(state.paused, true);
+    assert.match(state.pauseReason ?? "", /going to lunch/);
+
+    await runSlashCommand({
+      db,
+      repo: sampleRepo,
+      repoId,
+      cmd: { name: "resume", args: "" },
+      dataDir: dir,
+    });
+    state = ensureBudgetState(db, repoId, sampleBudget);
+    assert.equal(state.paused, false);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("runSlashCommand /status: echoes mode and budget", async () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  try {
+    const r = await runSlashCommand({
+      db,
+      repo: sampleRepo,
+      repoId,
+      cmd: { name: "status", args: "" },
+      dataDir: dir,
+    });
+    assert.match(r.echo, /Status/);
+    assert.match(r.echo, /propose/);
+  } finally {
+    cleanup(dir);
+  }
+});

--- a/test/director-slash.test.mjs
+++ b/test/director-slash.test.mjs
@@ -89,9 +89,9 @@ test("runSlashCommand /tick: clears last_tick_at", async () => {
   const { db, dir, repoId } = freshDb();
   ensureBudgetState(db, repoId, sampleBudget);
   // Bump last_tick_at so we can verify it gets cleared.
-  db.prepare(`UPDATE director_budget_state SET last_tick_at = datetime('now') WHERE repo_id = ?`).run(
-    repoId,
-  );
+  db.prepare(
+    `UPDATE director_budget_state SET last_tick_at = datetime('now') WHERE repo_id = ?`,
+  ).run(repoId);
   try {
     await runSlashCommand({
       db,


### PR DESCRIPTION
Refs #54, #44.

Mirrors the Telegram bot's commands so the admin-UI operator gets the same affordances. The composer detects a leading `/cmd` and runs a mapped action; everything else falls through to the regular directive path.

Supported: `/tick` `/digest` `/pause` `/resume` `/status` `/budget` `/help`.

Each command echoes the operator's input as a regular user-directive message (so the audit trail records what they typed) and posts a system tick_log with the response.

**SSE realtime push** (replaces 10s polling) is deferred to Wave 3 — current 2s/10s polling is good enough that I'd rather ship the rest of the polish first.

## Test plan
- [x] `pnpm run check` green (161 tests; +6 slash tests)
- [x] parseSlashCommand recognises known commands case-insensitively
- [x] Unknown /foo returns null; non-slash returns null
- [x] /tick clears last_tick_at; /pause + /resume toggle paused