### PR TITLE
feat(director): wave 3 polish — expiry, retry, charter diff, syntax highlight

### DIFF
--- a/src/director/charter.ts
+++ b/src/director/charter.ts
@@ -10,6 +10,7 @@ import { createHash } from "node:crypto";
 import YAML from "yaml";
 import type { Db } from "../storage/db.js";
 import { CharterSchema, type Charter } from "./types.js";
+import { appendMessage } from "./chat.js";
 
 export type CharterVersion = {
   repoId: number;
@@ -32,6 +33,10 @@ export function parseCharter(input: unknown): Charter | null {
 
 // Snapshot the current charter into the versioned table if it's changed
 // since last seen. Returns the version number to stamp on decisions.
+//
+// On version transitions (i.e. v(N) → v(N+1) where N >= 1) we also post a
+// brief chat note summarising what changed — vision-level diffs are
+// important for the operator to confirm without trawling the YAML diff.
 export function captureCharterVersion(db: Db, repoId: number, charter: Charter): number {
   const yaml = YAML.stringify({ charter });
   const latest = db
@@ -47,7 +52,58 @@ export function captureCharterVersion(db: Db, repoId: number, charter: Charter):
     `INSERT INTO director_charter_versions (repo_id, version, charter_yaml)
      VALUES (?, ?, ?)`,
   ).run(repoId, nextVersion, yaml);
+
+  // First version: silent (we just captured it for the first time).
+  // Subsequent versions: surface a diff summary in chat so the operator
+  // — and the next planning tick — both know what changed.
+  if (latest) {
+    try {
+      const oldCharter = (YAML.parse(latest.charter_yaml) as { charter?: Charter })?.charter;
+      const summary = oldCharter ? summariseCharterDiff(oldCharter, charter) : "(charter updated)";
+      appendMessage(db, {
+        repoId,
+        role: "system",
+        type: "tick_log",
+        body: `📜 Charter v${latest.version} → v${nextVersion}\n\n${summary}`,
+        metadata: {
+          kind: "charter_diff",
+          oldVersion: latest.version,
+          newVersion: nextVersion,
+        },
+      });
+    } catch {
+      // Diff is best-effort — never let a render failure break the
+      // version capture itself.
+    }
+  }
+
   return nextVersion;
+}
+
+function summariseCharterDiff(prev: Charter, next: Charter): string {
+  const lines: string[] = [];
+  if (prev.vision !== next.vision) {
+    lines.push(`- Vision changed.`);
+  }
+  const prevPriIds = new Set(prev.priorities.map((p) => p.id));
+  const nextPriIds = new Set(next.priorities.map((p) => p.id));
+  const added = [...nextPriIds].filter((id) => !prevPriIds.has(id));
+  const removed = [...prevPriIds].filter((id) => !nextPriIds.has(id));
+  if (added.length > 0) lines.push(`- Priorities added: ${added.join(", ")}`);
+  if (removed.length > 0) lines.push(`- Priorities removed: ${removed.join(", ")}`);
+  // Weight changes for shared priorities.
+  const weightChanges: string[] = [];
+  for (const p of next.priorities) {
+    const old = prev.priorities.find((x) => x.id === p.id);
+    if (old && Math.abs(old.weight - p.weight) > 0.001) {
+      weightChanges.push(`${p.id}: ${old.weight.toFixed(2)} → ${p.weight.toFixed(2)}`);
+    }
+  }
+  if (weightChanges.length > 0) lines.push(`- Weight changes: ${weightChanges.join("; ")}`);
+  if ((prev.persona?.name ?? "") !== (next.persona?.name ?? "")) {
+    lines.push(`- Persona name: ${prev.persona?.name ?? "—"} → ${next.persona?.name ?? "—"}`);
+  }
+  return lines.length > 0 ? lines.join("\n") : "(no surface-level changes — body only)";
 }
 
 export function getCharterVersion(db: Db, repoId: number, version: number): CharterVersion | null {

--- a/src/director/decisions.ts
+++ b/src/director/decisions.ts
@@ -125,6 +125,25 @@ export function setDecisionPayload(db: Db, decisionId: number, payload: unknown)
   );
 }
 
+// Sweep over `pending` decisions older than `maxAgeDays` and flip them to
+// `expired`. Returns the count of rows expired so the caller can log /
+// chat-post if desired. Cheap O(rows) query — use a partial index on
+// outcome=pending if this becomes hot.
+export function expireStalePending(db: Db, repoId: number, maxAgeDays = 7): number {
+  const result = db
+    .prepare(
+      `UPDATE director_decisions
+       SET outcome = 'expired',
+           outcome_ts = datetime('now'),
+           outcome_details = 'expired after ' || ? || ' days without human action'
+       WHERE repo_id = ?
+         AND outcome = 'pending'
+         AND ts < datetime('now', '-' || ? || ' days')`,
+    )
+    .run(maxAgeDays, repoId, maxAgeDays);
+  return result.changes;
+}
+
 export function pendingDecisions(db: Db, repoId: number): Decision[] {
   const rows = db
     .prepare(

--- a/src/director/executor.ts
+++ b/src/director/executor.ts
@@ -99,10 +99,11 @@ export async function executeDecision(opts: ExecuteOptions): Promise<ExecuteResu
     return finalize(db, decisionId, "pending", "queued for human approval");
   }
 
-  // 4. Execute the side-effect via VcsProvider. Each branch is small so the
-  //    fact that we hit the API is obvious in code review.
+  // 4. Execute the side-effect via VcsProvider. Transient errors (5xx,
+  //    timeouts, secondary rate limits) get up to three retries with
+  //    exponential-ish backoff; terminal errors (404 etc.) bubble out.
   try {
-    const detail = await runDecision(opts, repoRef);
+    const detail = await withTransientRetry(() => runDecision(opts, repoRef));
     return finalize(db, decisionId, "executed", detail);
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
@@ -379,6 +380,44 @@ function truncate(s: string, n: number): string {
   return s.length <= n ? s : s.slice(0, n - 1) + "…";
 }
 
+// Best-effort retry wrapper for transient VCS errors. Retries are tried
+// at 1s / 5s / 20s — if the third attempt still fails, the error
+// surfaces and outcome=failed kicks in (operator can manually re-approve
+// later). We only retry on errors whose message smells transient: HTTP
+// 5xx, timeouts, network resets, secondary rate limits. 4xx (e.g.
+// "issue not found", "already merged") are NOT retried — they're
+// terminal and retrying is just noise.
+const TRANSIENT_PATTERNS = [
+  /\bECONN(?:RESET|REFUSED|ABORTED)\b/i,
+  /\bETIMEDOUT\b/i,
+  /\b50[0234]\b/, // 500/502/503/504
+  /timeout/i,
+  /secondary rate limit/i,
+];
+
+export function isTransientError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return TRANSIENT_PATTERNS.some((p) => p.test(msg));
+}
+
+export async function withTransientRetry<T>(
+  fn: () => Promise<T>,
+  delaysMs: readonly number[] = [1000, 5000, 20_000],
+): Promise<T> {
+  let attempt = 0;
+  // Non-tail-recursive on purpose so the await chain stays linear.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= delaysMs.length || !isTransientError(err)) throw err;
+      await new Promise((resolve) => setTimeout(resolve, delaysMs[attempt]));
+      attempt++;
+    }
+  }
+}
+
 // ── Type-aware payload merge for edit-before-approve ─────────────────────
 //
 // Operators can tweak a proposal before approving it (rename a sloppy issue
@@ -511,18 +550,20 @@ export async function approveDecision(opts: ApproveOptions): Promise<ApproveResu
   });
 
   try {
-    const detail = await runDecision(
-      {
-        db,
-        decisionId,
-        repoId: decision.repoId,
-        repo,
-        director,
-        decision: parsed,
-        getVcs: opts.getVcs,
-        charterVersion: decision.charterVersion ?? 0,
-      },
-      { owner: repo.owner, name: repo.name },
+    const detail = await withTransientRetry(() =>
+      runDecision(
+        {
+          db,
+          decisionId,
+          repoId: decision.repoId,
+          repo,
+          director,
+          decision: parsed,
+          getVcs: opts.getVcs,
+          charterVersion: decision.charterVersion ?? 0,
+        },
+        { owner: repo.owner, name: repo.name },
+      ),
     );
     setDecisionOutcome(db, decisionId, "executed", detail);
     appendMessage(db, {

--- a/src/director/index.ts
+++ b/src/director/index.ts
@@ -21,6 +21,7 @@ import { runTick, type TickReason } from "./tick.js";
 import { releaseTick, tryAcquireTick } from "./active-tick.js";
 import { getLastDigestDate, runDigest, shouldRunDigest } from "./digest.js";
 import { maybePostTrustRampSuggestion } from "./trust-ramp.js";
+import { expireStalePending } from "./decisions.js";
 import { MimoEngine } from "../engines/mimo.js";
 import type { DirectorConfig } from "./types.js";
 
@@ -167,6 +168,25 @@ async function loopOnce(db: Db, config: RuntimeConfig): Promise<void> {
   for (const t of targets) {
     if (stopping) return;
     rolloverDayIfNeeded(db, t.repoId);
+    // Expire pending proposals untouched for >7d — silent cleanup so a
+    // ghost queue doesn't block reactivity ("X proposals pending" never
+    // dropping). Cheap UPDATE with a date predicate; runs every loop
+    // iteration but only does work when there's something to expire.
+    try {
+      const expired = expireStalePending(db, t.repoId);
+      if (expired > 0) {
+        appendMessage(db, {
+          repoId: t.repoId,
+          role: "system",
+          type: "tick_log",
+          body: `expired ${expired} pending proposal(s) untouched for >7d`,
+          metadata: { repo: repoKey(t.repo), kind: "expire_pending", count: expired },
+        });
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`[director] expire-pending error on ${repoKey(t.repo)}:`, err);
+    }
     const state = ensureBudgetState(db, t.repoId, t.director.budget);
     // Digest runs out-of-band from the planning cadence — the user wants
     // morning context every day, even if the planning cadence is 6h+.

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -883,6 +883,17 @@ const CHAT_INIT_SCRIPT = `
       var raw = el.textContent || '';
       var html = window.marked.parse(raw, {breaks: true, gfm: true});
       el.innerHTML = window.DOMPurify.sanitize(html);
+      // Highlight any code blocks inside the freshly-rendered bubble.
+      // hljs.highlightAll() is global so we'd double-highlight existing
+      // bubbles — instead walk just the new pre>code elements.
+      if(window.hljs){
+        el.querySelectorAll('pre code').forEach(function(c){
+          if(!c.dataset.hljsRendered){
+            window.hljs.highlightElement(c);
+            c.dataset.hljsRendered = '1';
+          }
+        });
+      }
       el.setAttribute('data-md-rendered', '1');
     });
   }

--- a/src/server/layout.ts
+++ b/src/server/layout.ts
@@ -156,6 +156,16 @@ export function page(opts: {
 <script src="https://unpkg.com/htmx.org@2.0.4"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked@14.1.3/marked.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+<!--
+  highlight.js for code-fence syntax colour. The director's chat output
+  often contains code/yaml/json blocks; rendering them plain text is hard
+  to read. Common-only build keeps the bundle small (~30KB gzip).
+-->
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/highlight.js@11.10.0/styles/atom-one-light.min.css"
+/>
+<script src="https://cdn.jsdelivr.net/npm/highlight.js@11.10.0/lib/common.min.js"></script>
 <style>
 /* ─── Design Tokens ─────────────────────────────────────────────────────── */
 :root {

--- a/test/director-wave3-polish.test.mjs
+++ b/test/director-wave3-polish.test.mjs
@@ -1,0 +1,150 @@
+// Wave 3 polish: pending expiry, transient retry, charter diff.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import { expireStalePending, recordDecision, getDecisionById } from "../dist/director/decisions.js";
+import {
+  isTransientError,
+  withTransientRetry,
+} from "../dist/director/executor.js";
+import { captureCharterVersion } from "../dist/director/charter.js";
+import { recentMessages } from "../dist/director/chat.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-wave3-test-"));
+  const db = initDb(dir);
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+test("expireStalePending: flips pending >7d → expired; leaves recent untouched", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const old = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "old proposal nobody acted on",
+      payload: { title: "older proposal" },
+      outcome: "pending",
+    });
+    const recent = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "fresh proposal that should survive",
+      payload: { title: "newer proposal" },
+      outcome: "pending",
+    });
+    db.prepare(`UPDATE director_decisions SET ts = datetime('now', '-10 days') WHERE id = ?`).run(
+      old.id,
+    );
+
+    const expired = expireStalePending(db, repoId, 7);
+    assert.equal(expired, 1);
+    assert.equal(getDecisionById(db, old.id).outcome, "expired");
+    assert.equal(getDecisionById(db, recent.id).outcome, "pending");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("isTransientError: matches 5xx / ECONNRESET / timeout; rejects 404", () => {
+  assert.equal(isTransientError(new Error("Server returned 503 Service Unavailable")), true);
+  assert.equal(isTransientError(new Error("connect ECONNRESET 10.0.0.1:443")), true);
+  assert.equal(isTransientError(new Error("Request timeout after 30s")), true);
+  assert.equal(isTransientError(new Error("Secondary rate limit triggered")), true);
+  assert.equal(isTransientError(new Error("404 Not Found: issue does not exist")), false);
+  assert.equal(isTransientError(new Error("422 Unprocessable Entity")), false);
+});
+
+test("withTransientRetry: succeeds after transient failures", async () => {
+  let attempts = 0;
+  const result = await withTransientRetry(
+    async () => {
+      attempts++;
+      if (attempts < 3) throw new Error("503 Service Unavailable");
+      return "ok";
+    },
+    [10, 10, 10],
+  );
+  assert.equal(result, "ok");
+  assert.equal(attempts, 3);
+});
+
+test("withTransientRetry: gives up after delays exhausted", async () => {
+  let attempts = 0;
+  await assert.rejects(
+    withTransientRetry(
+      async () => {
+        attempts++;
+        throw new Error("503 still down");
+      },
+      [10, 10],
+    ),
+    /503 still down/,
+  );
+  assert.equal(attempts, 3); // initial + 2 retries
+});
+
+test("withTransientRetry: terminal error doesn't retry", async () => {
+  let attempts = 0;
+  await assert.rejects(
+    withTransientRetry(
+      async () => {
+        attempts++;
+        throw new Error("404 Not Found");
+      },
+      [10, 10],
+    ),
+    /404 Not Found/,
+  );
+  assert.equal(attempts, 1);
+});
+
+test("captureCharterVersion: posts diff message on v1 → v2 transition", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const v1 = {
+      vision: "Reliable AI dev agent.",
+      priorities: [{ id: "reliability", weight: 0.5, rubric: "graceful failure" }],
+      out_of_bounds: [],
+      out_of_bounds_paths: [],
+      definition_of_done: [],
+    };
+    const ver1 = captureCharterVersion(db, repoId, v1);
+    assert.equal(ver1, 1);
+    let messages = recentMessages(db, repoId, 5);
+    // First version is silent.
+    assert.equal(messages.filter((m) => m.metadata?.kind === "charter_diff").length, 0);
+
+    const v2 = {
+      ...v1,
+      priorities: [
+        { id: "reliability", weight: 0.7, rubric: "graceful failure" },
+        { id: "observability", weight: 0.3, rubric: "metrics endpoint" },
+      ],
+    };
+    const ver2 = captureCharterVersion(db, repoId, v2);
+    assert.equal(ver2, 2);
+    messages = recentMessages(db, repoId, 5);
+    const diff = messages.find((m) => m.metadata?.kind === "charter_diff");
+    assert.ok(diff);
+    assert.match(diff.body, /Priorities added: observability/);
+    assert.match(diff.body, /reliability: 0\.50 → 0\.70/);
+  } finally {
+    cleanup(dir);
+  }
+});

--- a/test/director-wave3-polish.test.mjs
+++ b/test/director-wave3-polish.test.mjs
@@ -8,10 +8,7 @@ import { join } from "node:path";
 
 import { initDb } from "../dist/storage/db.js";
 import { expireStalePending, recordDecision, getDecisionById } from "../dist/director/decisions.js";
-import {
-  isTransientError,
-  withTransientRetry,
-} from "../dist/director/executor.js";
+import { isTransientError, withTransientRetry } from "../dist/director/executor.js";
 import { captureCharterVersion } from "../dist/director/charter.js";
 import { recentMessages } from "../dist/director/chat.js";
 
@@ -72,14 +69,11 @@ test("isTransientError: matches 5xx / ECONNRESET / timeout; rejects 404", () => 
 
 test("withTransientRetry: succeeds after transient failures", async () => {
   let attempts = 0;
-  const result = await withTransientRetry(
-    async () => {
-      attempts++;
-      if (attempts < 3) throw new Error("503 Service Unavailable");
-      return "ok";
-    },
-    [10, 10, 10],
-  );
+  const result = await withTransientRetry(async () => {
+    attempts++;
+    if (attempts < 3) throw new Error("503 Service Unavailable");
+    return "ok";
+  }, [10, 10, 10]);
   assert.equal(result, "ok");
   assert.equal(attempts, 3);
 });
@@ -87,13 +81,10 @@ test("withTransientRetry: succeeds after transient failures", async () => {
 test("withTransientRetry: gives up after delays exhausted", async () => {
   let attempts = 0;
   await assert.rejects(
-    withTransientRetry(
-      async () => {
-        attempts++;
-        throw new Error("503 still down");
-      },
-      [10, 10],
-    ),
+    withTransientRetry(async () => {
+      attempts++;
+      throw new Error("503 still down");
+    }, [10, 10]),
     /503 still down/,
   );
   assert.equal(attempts, 3); // initial + 2 retries
@@ -102,13 +93,10 @@ test("withTransientRetry: gives up after delays exhausted", async () => {
 test("withTransientRetry: terminal error doesn't retry", async () => {
   let attempts = 0;
   await assert.rejects(
-    withTransientRetry(
-      async () => {
-        attempts++;
-        throw new Error("404 Not Found");
-      },
-      [10, 10],
-    ),
+    withTransientRetry(async () => {
+      attempts++;
+      throw new Error("404 Not Found");
+    }, [10, 10]),
     /404 Not Found/,
   );
   assert.equal(attempts, 1);


### PR DESCRIPTION
Closes #55. Refs #44.

Bundle of operational hygiene items the audit flagged. Each piece is small but compounds:

- **Pending expiry** — pending decisions untouched for 7d auto-flip to `outcome=expired` with a chat note. Stops the proposal queue from silently growing forever when the operator misses a notification.
- **Transient retry** — VCS calls (createIssue, postComment, label, …) are wrapped in `withTransientRetry`. 5xx / ECONNRESET / timeout / secondary rate limit get up to 3 attempts at 1s/5s/20s backoff. Terminal errors (404, 422) bubble out unchanged so we don't bombard the API.
- **Charter diff** — when the YAML is updated and a new version is captured, post a brief diff summary (added/removed/reweighted priorities, persona changes) to the chat. v1 is still silent.
- **Syntax highlight** — highlight.js (common build) added to the admin layout; the chat markdown renderer now colours code-fences.

Bulk approve and per-decision trace (also under the Wave 3 umbrella) are deferred — high effort, currently low pain.

## Test plan
- [x] `pnpm run check` green (167 tests; +6 wave3 tests)
- [x] expireStalePending flips >7d, leaves recent untouched
- [x] isTransientError patterns; withTransientRetry exhaustion path
- [x] charter v1→v2 transition emits a diff message