### PR TITLE
fix(db): atomic migrations + IMMEDIATE lock to prevent race

### DIFF
--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -15,7 +15,23 @@ export function initDb(dataDir: string): Db {
   return db;
 }
 
+// All migrations run inside a single IMMEDIATE transaction so:
+//   1. Two services starting at the same time (openronin + openronin-director
+//      share the data dir) serialize cleanly. SQLite's IMMEDIATE lock makes
+//      the second arrival wait until the first commits or rolls back.
+//   2. A migration that fails partway through doesn't leave a half-applied
+//      schema. The next startup retries from a known-good state.
+//
+// Production hit case (1) hard during the v14/v15 rollout: each `db.exec`
+// auto-commits per-statement, so a CREATE TABLE could succeed while the
+// matching INSERT INTO schema_version never ran, leaving sqlite_master and
+// schema_version disagreeing. Wrapping with `db.transaction()` makes that
+// impossible. better-sqlite3's transaction wrapper uses BEGIN IMMEDIATE
+// when called eagerly — exactly what we want.
 function applyMigrations(db: Db): void {
+  // schema_version itself must exist before the transaction starts so the
+  // SELECT MAX inside the body has something to read. This is idempotent
+  // and so cheap to do outside the tx.
   db.exec(`
     CREATE TABLE IF NOT EXISTS schema_version (
       version INTEGER PRIMARY KEY,
@@ -23,6 +39,13 @@ function applyMigrations(db: Db): void {
     );
   `);
 
+  const tx = db.transaction(() => applyMigrationsInner(db));
+  // .immediate() acquires a write lock immediately, blocking any sibling
+  // applyMigrations call until we commit or roll back.
+  tx.immediate();
+}
+
+function applyMigrationsInner(db: Db): void {
   const current =
     (db.prepare("SELECT MAX(version) AS v FROM schema_version").get() as { v: number | null }).v ??
     0;


### PR DESCRIPTION
## Background

Production hit a real migration race during today's Wave 1+2+3 rollout. Both `openronin` and `openronin-director` share the same SQLite database in `OPENRONIN_DATA_DIR`. When both processes restart concurrently (auto-deploy after a merge), both run `applyMigrations` against the same DB.

Without a transaction:
- `db.exec()` auto-commits per statement, so CREATE TABLE could succeed while the matching INSERT INTO schema_version never ran
- the second process would see a half-applied state — table exists, schema_version says it's not applied — and crash with `table already exists` / `duplicate column name`
- the recovery is a systemd restart loop until one process gets through cleanly

Today's logs caught this on v14 (`director_active_ticks`) and v15 (`payload_hash`):
```
SqliteError: table director_active_ticks already exists
SqliteError: duplicate column name: payload_hash
```

## Fix

Wrap `applyMigrations` body in `db.transaction().immediate()`:
- `IMMEDIATE` acquires a write lock at BEGIN, so a sibling process blocks until we commit or roll back instead of racing.
- Any throw inside rolls everything back, leaving the schema in a known-good state. Next startup retries cleanly from the same `current` it would have read in the first place.

`schema_version` itself is created outside the transaction (idempotent `CREATE TABLE IF NOT EXISTS`) so the `SELECT MAX` inside has something to read.

## Test plan
- [x] `pnpm run check` green (167 tests)
- [x] freshDb path (used by ~40 tests) exercises applyMigrations on a clean DB
- [x] Idempotent: running twice on the same DB is a no-op (covered by every test that re-opens the same data dir)