### PR TITLE
fix(digest): pass engine.defaultModel instead of empty model string

### DIFF
--- a/src/director/digest.ts
+++ b/src/director/digest.ts
@@ -152,11 +152,15 @@ export async function runDigest(opts: DigestRunOptions): Promise<DigestRunResult
   const engine = opts.engineFactory();
   let llmResult;
   try {
+    // engine.run requires a non-empty model name on most providers — passing
+    // "" sends an empty `model` field to MIMO which rejects it as
+    // "Not supported model". Use the engine's defaultModel so the call
+    // honours whatever the factory was configured with.
     llmResult = await engine.run({
       systemPrompt,
       userPrompt,
       timeoutMs: DIGEST_TIMEOUT_MS,
-      model: "",
+      model: engine.defaultModel,
       expectJson: false,
     });
   } catch (err) {


### PR DESCRIPTION
## Background

Spotted in prod journal after deploying Wave 1+2+3:
```
[director] digest on github--openronin--openronin: error
  — MIMO error 400: Not supported model
```

`runDigest` was passing `model: ""` to `engine.run()`, which MIMO rejects.

## Fix

Read `engine.defaultModel` instead — the factory in production is `new MimoEngine({ defaultModel: mimo-v2.5-pro })`, so this honours the configured value (still overridable via `OPENRONIN_DIRECTOR_DIGEST_MODEL`).

## Test plan
- [x] `pnpm run check` green (167 tests)
- [ ] After deploy, the morning digest actually posts a chat message instead of erroring.