### PR TITLE
fix(director): release fs.watch + process.exit so SIGTERM unwinds in <1s

### DIFF
--- a/src/director/index.ts
+++ b/src/director/index.ts
@@ -275,7 +275,10 @@ export async function runDirectorService(): Promise<void> {
   const db = initDb(config.dataDir);
   syncReposFromConfig(db, config.repos);
 
-  watchConfig(config.dataDir, () => {
+  // Keep a handle so we can stop the file watcher on shutdown — otherwise
+  // the fs.watch keepalive prevents Node from exiting after the main loop
+  // returns.
+  const stopWatchConfig = watchConfig(config.dataDir, () => {
     try {
       config = loadConfig({ dataDir: config.dataDir });
       syncReposFromConfig(db, config.repos);
@@ -323,7 +326,21 @@ export async function runDirectorService(): Promise<void> {
     await sleep(SERVICE_LOOP_INTERVAL_MS);
   }
 
+  // Tear down the I/O handles that keep the event loop alive otherwise.
+  // Without these, the process would log "stopped cleanly" but linger
+  // until systemd's TimeoutStopSec fires SIGKILL — the original 120s
+  // production hang we're fixing.
+  try {
+    stopWatchConfig();
+  } catch {
+    // best-effort; we're shutting down anyway
+  }
+  db.close();
   // eslint-disable-next-line no-console
   console.log("[director] stopped cleanly.");
-  db.close();
+  // Belt-and-braces: even after closing watchers and the DB, a stuck
+  // AbortSignal.timeout() inside an aborted Telegram fetch can still hold
+  // a timer ref in older Node builds. Force-exit so the deploy never has
+  // to wait for systemd's SIGKILL.
+  process.exit(0);
 }


### PR DESCRIPTION
## Background

After PR #68 (fast-shutdown), the service still took 30s on every deploy. It logged "stopped cleanly" within milliseconds of SIGTERM, but Node didn't exit until systemd's TimeoutStopSec fired SIGKILL.

Two keepalive references were blocking exit:
- `watchConfig`'s `fs.watch` + debounce setTimeout. The cleanup function it returns was being discarded.
- `AbortSignal.timeout()` inside an aborted Telegram fetch can keep a timer ref alive in some Node 22 builds.

## Fix

- Capture `watchConfig`'s cleanup; call it on stop.
- After `db.close()`, call `process.exit(0)` so any lingering Node-internal timer can't keep us alive past the logical shutdown.

The "stopped cleanly" log now matches reality.

## Test plan
- [x] `pnpm run check` green
- [ ] Empirical: `time systemctl restart openronin-director` should drop from ~30s → ~1s after deploy