### PR TITLE
docs: sweep DIRECTOR.md to reflect Wave 1+2+3 features

### DIFF
--- a/docs/DIRECTOR.md
+++ b/docs/DIRECTOR.md
@@ -1,6 +1,6 @@
 # Director — autonomous PM layer
 
-> **Status:** complete. Schema v13. Five-PR rollout landed: foundation (#21), LLM-driven dry_run tick with auto-engine selection (#24, #25), execution backend (#28), two-way admin chat with HTMX approve/reject + Telegram bridge (#29, #31), adaptive budget retrospective (#32). The director is currently running in `propose` mode on `openronin/openronin` and idle on other watched repos (no charter).
+> **Status:** in production. Schema v17. The five-PR foundation rollout was followed by a UX-focused audit (PRs #56–#66) that added persona/voice, reactive ticks, edit-before-approve, decision dedup, daily digest, stale watchdog, trust-ramp suggestions, an engine split for cheap chat replies, standing operator notes, slash commands in the admin chat, and operational polish (pending-proposal expiry, transient-error retry, charter diff in chat, syntax-highlighted code in markdown). The director is running in `propose` mode on `openronin/openronin` and idle on other watched repos (no charter).
 
 The Director is a separate systemd service (`openronin-director.service`) that runs alongside the main openronin daemon. It shares the same code, database, and `OPENRONIN_DATA_DIR` but plays a different role: where the main daemon **reacts** to events (issue created, PR comment, push), the Director **proactively** decides what the project should work on next.
 
@@ -35,7 +35,22 @@ The Director runs in one of five modes. We ramp up confidence by stepping throug
 | `semi_auto` | yes               | yes          | queued for approval | most operations autonomous; you still approve merges |
 | `full_auto` | yes               | yes          | yes    | fully autonomous; escalates only on failures |
 
-**Foundation phase (this PR) only `dry_run` is meaningful** — the LLM tick that produces real proposals lands in PR #22.
+## Persona / voice
+
+The default Director introduces itself as "Director" with a neutral product-manager voice. Add a `persona` block to the charter to give it a name, role, voice, and style — this is woven into the system prompt so the LLM actually inhabits the voice instead of producing the same templated "I propose…" boilerplate every tick:
+
+```yaml
+director:
+  charter:
+    persona:
+      name: "Лёша"
+      role: "PM / product owner"
+      voice: "конкретный, без воды; признаёт неопределённость"
+      style: "короткие сообщения, asks rather than guesses"
+      avatar: "🧑‍💼"
+```
+
+The chat-bubble label in `/admin/director` becomes `🧑‍💼 Лёша`; signed messages drop the generic `👔 director:` prefix. The persona is captured per charter version, so changes are part of the audit trail.
 
 ## Charter
 
@@ -127,6 +142,101 @@ Each director-enabled repo has one chat thread, stored in `director_messages`. I
 
 The chat is two-way at `/admin/director/<slug>` (HTMX form for posting, inline `[✓ Approve]` / `[✗ Reject]` buttons on pending proposals) and via Telegram (`@<your-bot>` polling, see "Telegram bridge" below).
 
+## Reactivity
+
+The Director loop wakes every **10 seconds** (was 60s). Two triggers fire a tick:
+
+1. **Cadence** — `cadence_hours` elapsed since `last_tick_at`. Routine planning round, uses the heavy engine.
+2. **`user_message`** — a chat directive without a director reply yet. Ticks within ~10–30s instead of waiting up to 6h. Uses the cheap engine (see "Engine split").
+
+Concurrent ticks on the same repo are serialised by `director_active_ticks` — a row exists while a tick is in flight (TTL 300s). The admin chat status panel polls this row to render `🟡 \<persona\> is thinking…` (every 2s while busy, 10s when idle). The same row works as an advisory lock: if a webhook-triggered tick lands during a scheduled tick, the second one skips silently.
+
+A `[▶ Tick now]` button in the admin UI (and `/tick` in the Telegram bridge) clears `last_tick_at`, forcing a tick on the next loop iteration.
+
+## Edit before approve
+
+For each pending `proposal`-type decision, the chat bubble grows three buttons: `✓ Approve as-is`, `✏ Edit & approve`, `✗ Reject`. Edit opens a type-aware form pre-populated from the LLM's payload — title/body/labels/priority for `create_issue`, body for comments, add/remove for labels, etc. Submit → executor merges your edits onto the stored payload before running, and the merged payload is persisted back so the audit trail records what was actually executed (not the original proposal).
+
+Identifying fields like `issue_number` are deliberately not editable; only the type-relevant content fields pass through.
+
+## Decision dedup
+
+The LLM was prone to re-proposing the same `create_issue` tick after tick when its state-snapshot lagged just-proposed-but-unmerged work. Each new decision now hashes a normalised canonical form of `(decision_type, payload)` — folded case, whitespace, common prefixes, set-order for label arrays. Before insert we check for a pending or executed match in the last 7 days; a hit becomes `outcome=skipped` with a `duplicate of decision #N` reason. The original is preserved (audit trail intact); the executor never sees the duplicate.
+
+`ask_user` and `no_op` are exempt — they're cheap and idempotent already.
+
+## Stale watchdog
+
+Each state snapshot includes an `attentionItems[]` list — things the LLM should look at *before* charter-driven planning:
+
+- **`stale_pr`** — open PRs untouched for >24h
+- **`stale_awaiting_answer`** — issues stuck in `openronin:awaiting-answer` >48h
+- **`recent_deploy_failed`** — failed deploys in last 48h
+- **`failure_streak_high`** — director's own consecutive-failure counter ≥2
+- **`high_pending_proposals`** — ≥5 proposals waiting for human approval (signal to stop piling on)
+
+Each list capped at 3–5 items so a project on fire doesn't balloon the prompt. Surfaced under an "Attention first" prompt section that explicitly tells the LLM to address these before opening new work.
+
+## Trust ramp
+
+Mode escalation usually loses to operator inertia: `dry_run` → `propose` → `semi_auto` → `full_auto` requires someone to remember to flip the YAML. Once a week per repo (cooldown), the loop posts a chat suggestion when the data justifies it:
+
+- **promote** when ≥30 terminal decisions over 14d at ≥90% executed
+- **demote** when ≥10 terminal decisions over 14d at ≤40% executed
+
+The mode itself is never mutated programmatically — the message tells the operator exactly which YAML line to flip. Hot-reload picks it up.
+
+## Engine split (chat-vs-plan)
+
+Reactive ticks (chat directives, `reason='user_message'`) prefer MIMO; scheduled cadence ticks prefer Anthropic Sonnet. Same `selectThinkEngine` function with a `preferCheap` flag. Result: a chat reply costs ~$0.001 instead of ~$0.05 and lands faster. Override via `OPENRONIN_DIRECTOR_THINK_ENGINE=anthropic` (forces heavy regardless) or `OPENRONIN_DIRECTOR_CHAT_MODEL` (pin a specific MIMO variant for chat replies, e.g. `mimo-v2.5-flash`).
+
+## Standing operator notes
+
+Long-term "this is how I want you to behave" memory that survives the 25-message recent-chat window. Stored in `director_notes` (`id / repo_id / kind / body / source_message_id`). Two paths feed it:
+
+1. The director can emit a `remember_preference` decision when it hears the operator state a durable preference. No approval needed — it's an internal memory write.
+2. Operator can add or delete notes directly via the **Standing notes** card on `/admin/director/<slug>`.
+
+State snapshot grows a `standingNotes[]` field (capped at 20). The director-tick prompt renders them in a dedicated "Standing notes from the operator" section.
+
+## Daily morning digest
+
+Once a day per repo, around `digest.hour` in `digest.timezone`, the loop runs a cheap MIMO call with a separate prompt template (`prompts/templates/director-digest.md`) and posts ONE `status` chat message. No decisions, no executor invocation — just a "good morning" rundown of overnight changes.
+
+```yaml
+director:
+  digest:
+    enabled: true
+    hour: 9
+    timezone: Europe/Moscow
+```
+
+Once-per-local-day idempotency is enforced via `last_digest_date` on `director_budget_state`. The digest never burns the proposal budget; it's tracked under the think budget like any other planning call. Trigger a manual digest with the `/digest` slash command or the Telegram bridge.
+
+## Slash commands in admin chat
+
+The composer accepts both kinds of input. A leading `/cmd` is interpreted as a command; everything else falls through to the regular `directive` path. Commands echo the operator's input as a user-directive (audit) and post the response as a system `tick_log`.
+
+| Command            | Effect |
+|--------------------|--------|
+| `/tick`            | Clears `last_tick_at` so the next loop iteration fires (≤10s). |
+| `/digest`          | Runs the morning digest right now, regardless of schedule. |
+| `/pause [reason]`  | Sets `paused=1` on the budget state. |
+| `/resume`          | Clears the paused flag. |
+| `/status`          | Shows mode, paused?, last tick, failure streak, today's think spend. |
+| `/budget`          | Shows daily/weekly cap + spend. |
+| `/help`            | Lists the commands. |
+
+The Telegram bridge has the same set plus `/repos`, `/pending`, `/approve <id>`, `/reject <id>`.
+
+## Operational polish
+
+- **Pending expiry.** Pending decisions untouched for 7d auto-flip to `outcome=expired` with a chat note. The proposal queue can't silently grow forever.
+- **Transient retry.** VCS calls in the executor wrap in `withTransientRetry`. 5xx / `ECONNRESET` / timeout / "secondary rate limit" get up to 3 attempts at 1s/5s/20s backoff. Terminal errors (404, 422) bubble out unchanged.
+- **Charter diff in chat.** When the YAML is updated and a new charter version is captured, the loop posts a brief diff summary (added/removed priorities, weight changes, persona renames) to the chat. v1 is silent; v(N+1) where N≥1 produces the note.
+- **Syntax highlight.** `highlight.js` in the admin layout colours code-fences in chat markdown.
+- **Atomic migrations.** All schema migrations run inside a single `BEGIN IMMEDIATE` transaction so two services racing on startup serialise cleanly. Earlier in development this was the source of nasty "table already exists" / "duplicate column" crashes on deploy.
+
 ## Decisions audit trail
 
 Every decision the Director takes — even no-ops — is persisted into `director_decisions` **before** any side-effect runs:
@@ -155,8 +265,9 @@ So if the service crashes mid-execution, the next tick can pick up exactly where
 
 ### Manual pause for one repo
 
-From Telegram: `/pause <slug>` (and `/resume <slug>`).
-From admin UI: not yet a button — pause via direct DB write or Telegram.
+From the admin chat composer: `/pause [reason]` and `/resume`.
+From Telegram: `/pause <slug>` and `/resume <slug>`.
+From SQL (last resort):
 
 ```bash
 sqlite3 $OPENRONIN_DATA_DIR/db/openronin.db \
@@ -259,20 +370,31 @@ The daily/weekly caps in `director_budget_state` aren't static. Once per UTC day
 
 This isn't a "good outcome retrospective" in the strong sense (would need to poll VCS for reverts and CI failures over a 7-day quarantine after each `executed` merge — out of scope). The current model uses immediate decision outcomes as a proxy and is honest about its limits.
 
-## Roadmap
+## Rollout history
 
-The five-PR rollout is complete:
+Foundation (the original 5-PR shape):
 
-- **#21** — foundation (schema, scaffolding, no-op tick)
+- **#21** — schema, scaffolding, no-op tick
 - **#24, #25** — LLM-driven dry_run tick + auto-engine selection (Anthropic / MIMO)
 - **#28** — execution backend (mode × authority × decision-type matrix)
 - **#29** — admin UI two-way chat (HTMX approve / reject / message form)
 - **#31** — Telegram bridge
 - **#32** — adaptive budget retrospective
 
-What's reasonable to add next, separately:
+UX audit follow-up (Wave 1+2+3, all merged):
 
-- **Outcome retrospective.** Poll VCS post-merge for reverts / CI failures over a 7-day window; weight that into the adaptive budget instead of (or alongside) the immediate decision outcome.
+- **Wave 1 — make the PM feel alive**: persona/voice (#56), reactive tick + per-repo lock (#57), edit-before-approve (#58), decision dedup (#59), daily morning digest (#60).
+- **Wave 2 — proactive PM**: stale watchdog (#61), trust-ramp suggestion (#62), engine split (#63), standing notes (#64), slash commands (#65).
+- **Wave 3 — operational polish**: pending expiry, transient retry, charter diff, syntax highlight (#66).
+- **Production stability**: atomic migrations (#67), fast shutdown (#68, #70), digest model fix (#69).
+
+What's reasonable to add next:
+
+- **SSE realtime push.** Replace the 2s/10s status panel polling with EventSource so the chat refreshes the moment a tick completes. The current polling works but burns context every cycle.
+- **Bulk approve.** Checkboxes on proposal bubbles + a sticky "approve N selected" bar for repetitive batches.
+- **Per-decision trace UI.** Click a decision row in `/admin/director` → full prompt + response + cost + latency. Currently you have to query SQLite.
+- **Outcome retrospective.** Poll VCS post-merge for reverts / CI failures over a 7-day window; feed that into the adaptive budget instead of (or alongside) the immediate decision outcome.
+- **Cross-process event triggers.** When the main openronin service detects a `pr_event` or `deploy_failed`, write a signal row that the director loop reacts to in <60s. Currently the director sees these only on the next scheduled tick.
 - **Quality gates.** Per-PR metrics (lint score, coverage delta, bundle size) feeding into approve/merge decisions.
 - **Plugin lanes.** External lane providers via MCP / HTTP so users can add custom decision types without forking.
 - **Multi-tenant.** Several director instances on one host (different bot identities, different repos).


### PR DESCRIPTION
Foundation-era doc was stuck at "schema v13, five-PR rollout complete". We're at v17 with persona, reactive ticks, edit-before-approve, dedup, digest, watchdog, trust-ramp, engine split, notes, slash commands, expiry, retry, charter diff. This brings the doc up to date.

New dedicated sections (with YAML knobs and operator-facing affordances):
- Persona / voice
- Reactivity (10s loop + user_message trigger + active-tick lock + thinking indicator)
- Edit before approve
- Decision dedup
- Stale watchdog (attentionItems[])
- Trust ramp
- Engine split (chat-vs-plan)
- Standing operator notes
- Daily morning digest
- Slash commands in admin chat
- Operational polish (pending expiry, transient retry, charter diff, syntax highlight, atomic migrations)

Updates the rollout history to enumerate the 11 audit-follow-up PRs (#56–#70) and reframes the roadmap to point at what's still deferred.