### PR TITLE
feat(director): bulk approve — button + /approve-all slash command

### DIFF
--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -35,7 +35,7 @@ import type { BudgetState } from "../director/types.js";
 import { latestCharterVersion } from "../director/charter.js";
 import { approveDecision, rejectDecision } from "../director/executor.js";
 import { getActiveTick } from "../director/active-tick.js";
-import { getDecisionById } from "../director/decisions.js";
+import { getDecisionById, pendingDecisions } from "../director/decisions.js";
 import { deleteNote, listNotes, recordNote } from "../director/notes.js";
 import { parseSlashCommand, runSlashCommand } from "./slash-commands.js";
 import { GithubVcsProvider } from "../providers/github.js";
@@ -613,6 +613,7 @@ function renderStatusPanel(
   // a brand-new repo and was effectively dead code.
   const active = getActiveTick(db, repoId);
   const isProcessing = active !== null;
+  const pendingCount = pendingDecisions(db, repoId).length;
 
   // Visual state.
   const stateLabel = isProcessing
@@ -653,14 +654,34 @@ function renderStatusPanel(
             })}
           </span>`
         : ""}
+      ${pendingCount > 0
+        ? html`<span class="text-xs">
+            ${badge({
+              label: `${pendingCount} pending`,
+              tone: "info",
+            })}
+          </span>`
+        : ""}
       <span class="ml-auto flex items-center gap-2">
+        ${pendingCount >= 2
+          ? html`<button
+              class="btn btn-success btn-sm"
+              hx-post="/admin/director/${slug}/decisions/approve-all"
+              hx-target="#chat-thread"
+              hx-swap="outerHTML"
+              hx-confirm="Approve and execute all ${pendingCount} pending decisions for this repo?"
+              title="Approve every pending proposal at once. Each runs through the same gating + executor as a one-by-one approve."
+            >
+              ✓ Approve all (${pendingCount})
+            </button>`
+          : ""}
         <button
           class="btn btn-primary btn-sm"
           hx-post="/admin/director/${slug}/tick-now"
           hx-target="#director-status"
           hx-swap="outerHTML"
           ${isProcessing ? "disabled" : ""}
-          title="Force the director to tick within the next 60s instead of waiting for the scheduled tick"
+          title="Force the director to tick within the next 10s instead of waiting for the scheduled tick"
         >
           ▶ Tick now
         </button>
@@ -1329,6 +1350,61 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
       actor: "admin",
       getVcs: () => defaultVcsFactory(repo),
       overrides: overrides && Object.keys(overrides).length > 0 ? overrides : undefined,
+    });
+
+    const messages = recentMessages(db, entry.repoId, 200);
+    return c.html(
+      renderChatThread(db, slug, messages, resolvePersonaName(repo), resolvePersonaAvatar(repo))
+        .value,
+    );
+  });
+
+  // ── POST /:slug/decisions/approve-all ────────────────────────────────
+  // Bulk-approve every pending decision for a repo. Each runs through
+  // the same approveDecision path (authority gate, executor, audit log)
+  // as the one-at-a-time button — we just iterate. If anything fails
+  // mid-way the rest still attempt; failures land as outcome=failed
+  // with their detail in chat (visible after the swap).
+  app.post("/:slug/decisions/approve-all", async (c) => {
+    const slug = c.req.param("slug");
+    const entries = listEntries(db, getConfig);
+    const entry = entries.find((e) => e.slug === slug);
+    if (!entry) return c.notFound();
+
+    const config = getConfig();
+    const repo = config.repos.find((r) => repoKey(r) === slug);
+    if (!repo || !repo.director) return c.notFound();
+
+    const pending = pendingDecisions(db, entry.repoId);
+    let approved = 0;
+    for (const d of pending) {
+      try {
+        const r = await approveDecision({
+          db,
+          decisionId: d.id,
+          repo,
+          director: repo.director,
+          actor: "admin:bulk",
+          getVcs: () => defaultVcsFactory(repo),
+        });
+        if (r.ok) approved++;
+      } catch {
+        // approveDecision logs into the chat itself; skip and continue.
+      }
+    }
+
+    appendMessage(db, {
+      repoId: entry.repoId,
+      role: "system",
+      type: "tick_log",
+      body: `bulk approve: ${approved}/${pending.length} processed`,
+      metadata: {
+        repo: slug,
+        kind: "bulk_approve",
+        attempted: pending.length,
+        approved,
+        actor: "admin",
+      },
     });
 
     const messages = recentMessages(db, entry.repoId, 200);

--- a/src/server/slash-commands.ts
+++ b/src/server/slash-commands.ts
@@ -13,6 +13,9 @@ import { appendMessage } from "../director/chat.js";
 import { ensureBudgetState, recordThinkSpend } from "../director/budget.js";
 import { runDigest } from "../director/digest.js";
 import { localDateInTz } from "../director/digest.js";
+import { pendingDecisions } from "../director/decisions.js";
+import { approveDecision } from "../director/executor.js";
+import { GithubVcsProvider } from "../providers/github.js";
 import type { RepoConfig } from "../config/schema.js";
 import { repoKey } from "../config/schema.js";
 import { MimoEngine } from "../engines/mimo.js";
@@ -27,6 +30,7 @@ export type SlashCommand =
   | { name: "resume"; args: string }
   | { name: "status"; args: string }
   | { name: "budget"; args: string }
+  | { name: "approve_all"; args: string }
   | { name: "help"; args: string };
 
 const KNOWN: SlashCommand["name"][] = [
@@ -36,17 +40,27 @@ const KNOWN: SlashCommand["name"][] = [
   "resume",
   "status",
   "budget",
+  "approve_all",
   "help",
 ];
+
+// Some commands have hyphenated aliases (`/approve-all`) that don't fit
+// the [a-z_]+ regex. Normalise here so the parser maps them to the
+// snake_case canonical name.
+const ALIASES: Record<string, SlashCommand["name"]> = {
+  "approve-all": "approve_all",
+  approveall: "approve_all",
+};
 
 // Returns the parsed command if `body` opens with a known `/cmd`, else null.
 // Whitespace-tolerant. Body may continue with arbitrary args after the cmd.
 export function parseSlashCommand(body: string): SlashCommand | null {
   const trimmed = body.trim();
   if (!trimmed.startsWith("/")) return null;
-  const m = trimmed.match(/^\/([a-z_]+)(\s+(.*))?$/iu);
+  const m = trimmed.match(/^\/([a-z_-]+)(\s+(.*))?$/iu);
   if (!m || !m[1]) return null;
-  const name = m[1].toLowerCase();
+  const raw = m[1].toLowerCase();
+  const name = (ALIASES[raw] ?? raw) as SlashCommand["name"];
   if (!(KNOWN as readonly string[]).includes(name)) return null;
   return { name, args: (m[3] ?? "").trim() } as SlashCommand;
 }
@@ -81,9 +95,38 @@ export async function runSlashCommand(opts: {
           "- `/resume` — resume after pause.",
           "- `/status` — show current mode, budget, last tick, pending count.",
           "- `/budget` — show budget caps + spend.",
+          "- `/approve-all` — approve every pending proposal at once.",
           "- `/help` — this list.",
         ].join("\n"),
       };
+    case "approve_all": {
+      if (!repo || !repo.director) {
+        return { echo: "repo or director config missing" };
+      }
+      const pending = pendingDecisions(db, repoId);
+      if (pending.length === 0) return { echo: "no pending decisions" };
+      let approved = 0;
+      let failed = 0;
+      for (const d of pending) {
+        try {
+          const r = await approveDecision({
+            db,
+            decisionId: d.id,
+            repo,
+            director: repo.director,
+            actor: "admin:slash",
+            getVcs: () => new GithubVcsProvider(),
+          });
+          if (r.ok && r.outcome === "executed") approved++;
+          else failed++;
+        } catch {
+          failed++;
+        }
+      }
+      return {
+        echo: `bulk approve via slash: ${approved}/${pending.length} executed, ${failed} failed/skipped`,
+      };
+    }
     case "tick":
       db.prepare(`UPDATE director_budget_state SET last_tick_at = NULL WHERE repo_id = ?`).run(
         repoId,

--- a/test/director-bulk-approve.test.mjs
+++ b/test/director-bulk-approve.test.mjs
@@ -1,0 +1,125 @@
+// Bulk approve via /approve-all slash command.
+//
+// We can't easily test the HTTP route in isolation (admin-director.ts is
+// large and pulls Hono routing). Instead, exercise the slash-command path
+// against a freshly-seeded DB with a stub VcsProvider. That covers the
+// same approveDecision loop as the HTTP handler.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import { ensureBudgetState } from "../dist/director/budget.js";
+import { recordDecision, pendingDecisions } from "../dist/director/decisions.js";
+import { parseSlashCommand, runSlashCommand } from "../dist/server/slash-commands.js";
+
+const sampleBudget = {
+  initial_daily_usd: 2.0,
+  initial_weekly_usd: 10.0,
+  max_daily_usd: 10.0,
+  max_weekly_usd: 50.0,
+  think_daily_usd: 1.0,
+  pause_on_failure_streak: 3,
+  good_outcome_quarantine_days: 7,
+};
+
+const sampleDirector = {
+  enabled: true,
+  mode: "propose",
+  cadence_hours: 6,
+  bot_prefix: "👔 director:",
+  language: "English",
+  budget: sampleBudget,
+  authority: {
+    can_create_issues: true,
+    can_label: true,
+    can_close_issues: false,
+    can_comment: true,
+    can_approve_pr: true,
+    can_merge: false,
+    can_modify_charter: false,
+  },
+};
+
+const sampleRepo = {
+  provider: "github",
+  owner: "openronin",
+  name: "openronin",
+  watched: true,
+  lanes: ["triage"],
+  director: sampleDirector,
+};
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-bulk-test-"));
+  const db = initDb(dir);
+  const result = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: result.id };
+}
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+test("parseSlashCommand: /approve-all maps to approve_all", () => {
+  assert.equal(parseSlashCommand("/approve-all").name, "approve_all");
+  assert.equal(parseSlashCommand("/approveall").name, "approve_all");
+  assert.equal(parseSlashCommand("/APPROVE-ALL").name, "approve_all");
+});
+
+test("/approve-all on empty queue echoes 'no pending decisions'", async () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  try {
+    const r = await runSlashCommand({
+      db,
+      repo: sampleRepo,
+      repoId,
+      cmd: { name: "approve_all", args: "" },
+      dataDir: dir,
+    });
+    assert.match(r.echo, /no pending decisions/);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("/approve-all with ask_user proposals: each runs (no VCS needed) → executed", async () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  try {
+    // ask_user doesn't need approval (per executor.decisionNeedsApproval),
+    // so this exercises the loop without any real network. Three rows
+    // pending, all should land executed.
+    for (let i = 0; i < 3; i++) {
+      recordDecision(db, {
+        repoId,
+        decisionType: "ask_user",
+        rationale: `clarifying question #${i} for charter ambiguity`,
+        payload: { question: `which is more important right now? (#${i})` },
+        outcome: "pending",
+      });
+    }
+    assert.equal(pendingDecisions(db, repoId).length, 3);
+
+    const r = await runSlashCommand({
+      db,
+      repo: sampleRepo,
+      repoId,
+      cmd: { name: "approve_all", args: "" },
+      dataDir: dir,
+    });
+    assert.match(r.echo, /3\/3 executed/);
+    assert.equal(pendingDecisions(db, repoId).length, 0);
+  } finally {
+    cleanup(dir);
+  }
+});


### PR DESCRIPTION
Repetitive batches of similar proposals (five small `create_issue` calls from one digest tick, say) used to require five clicks. Adds:

- **"✓ Approve all (N)" button** in the status panel (renders only when there are ≥2 pending). Confirm dialog before firing.
- **POST /admin/director/:slug/decisions/approve-all** that loops `approveDecision` over every pending row. Each runs through the same authority gating + executor as the one-by-one approve, just sequentially. Failures don't stop the loop — partial success is reported in the bulk-approve tick_log.
- **Slash command `/approve-all`** (with `/approveall` alias) for the chat composer and Telegram bridge.
- **Pending-count chip** ("N pending") in the status panel so queue depth is obvious before you fire bulk approval.

## Test plan
- [x] `pnpm run check` green (170 tests; +3 bulk approve tests)
- [x] /approve-all on empty queue echoes 'no pending decisions'
- [x] /approve-all with N ask_user proposals → all land executed without VCS calls
- [x] Slug aliases (`/approve-all` / `/approveall` / case-insensitive) all parse to `approve_all`