### PR TITLE
fix(scheduler): mark task as ~never-retry on VCS 404

### DIFF
--- a/src/scheduler/reconcile.ts
+++ b/src/scheduler/reconcile.ts
@@ -107,6 +107,18 @@ async function pollOurPrs(
       enqueue(db, prTaskId, newCount > 0 ? "high" : "normal", null);
       enqueued += 1;
     } catch (error) {
+      // 404 means the PR no longer exists on this owner — usually after
+      // a repo rename/transfer. Mark the branch as closed so reconcile
+      // stops polling it and the dashboard reflects reality.
+      if (isVcs404(error)) {
+        db.prepare(
+          "UPDATE pr_branches SET status = 'closed', updated_at = datetime('now') WHERE id = ?",
+        ).run(b.id);
+        console.warn(
+          `[reconcile] PR ${repo.owner}/${repo.name}#${b.pr_number} returned 404 — marked closed`,
+        );
+        continue;
+      }
       console.warn(
         `[reconcile] pr-poll failed for ${repo.owner}/${repo.name}#${b.pr_number}:`,
         error instanceof Error ? error.message : error,
@@ -114,6 +126,16 @@ async function pollOurPrs(
     }
   }
   return { polled, enqueued };
+}
+
+function isVcs404(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const e = error as { status?: number; message?: string };
+  if (e.status === 404) return true;
+  if (typeof e.message === "string" && /\b404\b.*Not Found|Not Found.*\b404\b/i.test(e.message)) {
+    return true;
+  }
+  return false;
 }
 
 // Reconcile Jira tracker for a repo that has jira_tracker config set.

--- a/src/scheduler/worker.ts
+++ b/src/scheduler/worker.ts
@@ -185,10 +185,33 @@ export async function processOne(
         detail: `rate-limit (cooldown ${Math.round(delayMs / 60000)}m)`,
       };
     }
+    // VCS 404 means the issue/PR doesn't exist on the current owner —
+    // typically left over from a repo rename / fork. Re-trying forever
+    // just produces journal noise (we hit prod with this on tasks #114
+    // and #115 after the openronin/openronin rename). Mark the task
+    // permanently errored so the scheduler stops polling it; an operator
+    // can re-enqueue manually if they really want to retry.
+    if (isVcs404(error)) {
+      const detail = `VCS returned 404 — issue/PR ${task.external_id} no longer exists`;
+      markError(db, task.id, detail, 365 * 24 * 60 * 60 * 1000); // ≈ never retry
+      return { taskId: task.id, status: "error", detail: "vcs-404" };
+    }
     const message = error instanceof Error ? error.message : String(error);
     markError(db, task.id, message);
     return { taskId: task.id, status: "error", detail: message.slice(0, 120) };
   }
+}
+
+// Octokit attaches `status: 404` on 404 responses; some clients only
+// surface it as a `\b404\b` substring in the message. Match either.
+function isVcs404(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const e = error as { status?: number; message?: string };
+  if (e.status === 404) return true;
+  if (typeof e.message === "string" && /\b404\b.*Not Found|Not Found.*\b404\b/i.test(e.message)) {
+    return true;
+  }
+  return false;
 }
 
 export async function drain(db: Db, config: RuntimeConfig, limit: number): Promise<WorkResult[]> {

--- a/test/stale-task-selfheal.test.mjs
+++ b/test/stale-task-selfheal.test.mjs
@@ -1,0 +1,194 @@
+// 404-driven self-heal: a task pointing at an issue/PR that no longer
+// exists on the current owner gets parked permanently instead of polling
+// forever. Production hit this on the openronin/openronin rename — issues
+// #38 and #39 produced ~10 GET /pulls/.../reviews 404s per minute until
+// we manually patched the DB.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import { processOne } from "../dist/scheduler/worker.js";
+import { upsertTask } from "../dist/storage/tasks.js";
+import { enqueue } from "../dist/scheduler/queue.js";
+
+function getTaskRow(db, id) {
+  return db.prepare("SELECT id, status, next_due_at FROM tasks WHERE id = ?").get(id);
+}
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-stale-test-"));
+  const db = initDb(dir);
+  // Minimal repo row + matching config so worker.findRepo resolves.
+  const r = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: r.id };
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+const baseRepoConfig = {
+  provider: "github",
+  owner: "openronin",
+  name: "openronin",
+  watched: true,
+  lanes: ["triage"],
+  cadence: undefined,
+  protected_labels: [],
+  skip_authors: [],
+  allowed_close_reasons: [],
+  engine_overrides: {},
+  prompt_overrides: {},
+  patch_trigger_label: "openronin:do-it",
+  patch_default_base: "main",
+  protected_paths: [],
+  max_diff_lines: 500,
+  draft_pr: true,
+  patch_multi_max_critique_iterations: 2,
+  pr_dialog_max_iterations: 10,
+  pr_dialog_skip_authors: [],
+  auto_merge: {
+    enabled: false,
+    strategy: "squash",
+    require_checks_pass: true,
+    unblock_draft: true,
+    resolve_conflicts: true,
+    resolve_conflicts_max_attempts: 3,
+  },
+  deploy: {
+    mode: "disabled",
+    trigger_branch: "main",
+    bot_login: "openronin[bot]",
+    require_bot_push: true,
+    commands: [],
+  },
+  language_for_communication: "English",
+  language_for_commits: "English",
+  language_for_code_identifiers: "English",
+  in_progress_label: "openronin:in-progress",
+  awaiting_answer_label: "openronin:awaiting-answer",
+  awaiting_action_label: "openronin:awaiting-action",
+  acknowledge_with_reaction: true,
+  acknowledge_with_comment: true,
+  director: { enabled: false },
+};
+
+// Stub out the GithubVcsProvider via the env-key path: with no GITHUB_TOKEN
+// the provider construction throws. We can't easily mock the import inside
+// worker.ts without a DI hook. Instead, isolate isVcs404 via a direct test
+// against the worker's catch path: we inject a "fetch" failure by setting
+// a known-bad GITHUB_TOKEN and observing a 401-style failure ≠ 404 →
+// task is markError'd but with a regular delay. Then we directly assert
+// on isVcs404 logic by re-exporting it... actually that's a private
+// function. Simpler: cover the predicate via a tiny isolated test that
+// imports the same code shape. For end-to-end behaviour, the manual SQL
+// fix in production already validated the path; what's tested here is
+// the isVcs404 detector and the markError-with-long-delay flag.
+
+test("worker: 404 from VCS parks the task with a year-long retry delay", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    // Build the runtime config the worker expects.
+    const config = {
+      dataDir: dir,
+      global: {
+        server: { port: 8090, baseUrl: "http://localhost:8090", adminUser: "admin" },
+        engines: { defaults: {} },
+        cadence: { hot: "5m", default: "1h", cold: "24h" },
+        cost_caps: { per_task_usd: 5, per_day_usd: 50 },
+        rate_limit_cooldown: "30m",
+        scheduler: { reconcile_interval: "15m", drain_interval: "30s", drain_batch_size: 5 },
+        telegram: { allowed_user_ids: [], poll_timeout_seconds: 30 },
+      },
+      repos: [baseRepoConfig],
+    };
+    const taskId = upsertTask(db, repoId, "9999", "issue");
+    enqueue(db, taskId, "normal", null);
+
+    // Stub provider.getItem to throw a 404. We monkey-patch GithubVcsProvider
+    // by replacing the prototype method before processOne runs.
+    const githubMod = await import("../dist/providers/github.js");
+    const orig = githubMod.GithubVcsProvider.prototype.getItem;
+    githubMod.GithubVcsProvider.prototype.getItem = function () {
+      const err = new Error("HttpError: Not Found");
+      err.status = 404;
+      throw err;
+    };
+    try {
+      const result = await processOne(db, config);
+      assert.ok(result);
+      assert.equal(result.status, "error");
+      assert.equal(result.detail, "vcs-404");
+
+      const after = getTaskRow(db, taskId);
+      // markError sets status=pending with next_due_at far in the future
+      // — a year out for our 404 case.
+      const nextMs = new Date(after.next_due_at + "Z").getTime();
+      assert.ok(
+        nextMs > Date.now() + 364 * 24 * 60 * 60 * 1000,
+        `expected next_due_at >= 364d out, got ${after.next_due_at}`,
+      );
+    } finally {
+      githubMod.GithubVcsProvider.prototype.getItem = orig;
+    }
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("worker: non-404 errors keep their normal short retry", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const config = {
+      dataDir: dir,
+      global: {
+        server: { port: 8090, baseUrl: "http://localhost:8090", adminUser: "admin" },
+        engines: { defaults: {} },
+        cadence: { hot: "5m", default: "1h", cold: "24h" },
+        cost_caps: { per_task_usd: 5, per_day_usd: 50 },
+        rate_limit_cooldown: "30m",
+        scheduler: { reconcile_interval: "15m", drain_interval: "30s", drain_batch_size: 5 },
+        telegram: { allowed_user_ids: [], poll_timeout_seconds: 30 },
+      },
+      repos: [baseRepoConfig],
+    };
+    const taskId = upsertTask(db, repoId, "1234", "issue");
+    enqueue(db, taskId, "normal", null);
+
+    const githubMod = await import("../dist/providers/github.js");
+    const orig = githubMod.GithubVcsProvider.prototype.getItem;
+    githubMod.GithubVcsProvider.prototype.getItem = function () {
+      const err = new Error("HttpError: Internal Server Error");
+      err.status = 500;
+      throw err;
+    };
+    try {
+      const result = await processOne(db, config);
+      assert.ok(result);
+      assert.equal(result.status, "error");
+      assert.notEqual(result.detail, "vcs-404");
+
+      const after = getTaskRow(db, taskId);
+      // Default error retry — within hours, NOT a year out.
+      const nextMs = new Date(after.next_due_at + "Z").getTime();
+      assert.ok(
+        nextMs < Date.now() + 24 * 60 * 60 * 1000,
+        `expected next_due_at within 24h, got ${after.next_due_at}`,
+      );
+    } finally {
+      githubMod.GithubVcsProvider.prototype.getItem = orig;
+    }
+  } finally {
+    cleanup(dir);
+  }
+});

--- a/test/stale-task-selfheal.test.mjs
+++ b/test/stale-task-selfheal.test.mjs
@@ -19,6 +19,10 @@ function getTaskRow(db, id) {
   return db.prepare("SELECT id, status, next_due_at FROM tasks WHERE id = ?").get(id);
 }
 
+// GithubVcsProvider construction throws without GITHUB_TOKEN — set a
+// dummy value so we can monkey-patch the prototype's getItem.
+process.env.GITHUB_TOKEN = process.env.GITHUB_TOKEN ?? "test-dummy-token";
+
 function freshDb() {
   const dir = mkdtempSync(join(tmpdir(), "openronin-stale-test-"));
   const db = initDb(dir);
@@ -132,8 +136,9 @@ test("worker: 404 from VCS parks the task with a year-long retry delay", async (
 
       const after = getTaskRow(db, taskId);
       // markError sets status=pending with next_due_at far in the future
-      // — a year out for our 404 case.
-      const nextMs = new Date(after.next_due_at + "Z").getTime();
+      // — a year out for our 404 case. The stored value is already ISO
+      // with a trailing Z, so feed it straight to Date.
+      const nextMs = new Date(after.next_due_at).getTime();
       assert.ok(
         nextMs > Date.now() + 364 * 24 * 60 * 60 * 1000,
         `expected next_due_at >= 364d out, got ${after.next_due_at}`,
@@ -179,8 +184,8 @@ test("worker: non-404 errors keep their normal short retry", async () => {
       assert.notEqual(result.detail, "vcs-404");
 
       const after = getTaskRow(db, taskId);
-      // Default error retry — within hours, NOT a year out.
-      const nextMs = new Date(after.next_due_at + "Z").getTime();
+      // Default error retry — within hours, NOT a year out. ISO with Z.
+      const nextMs = new Date(after.next_due_at).getTime();
       assert.ok(
         nextMs < Date.now() + 24 * 60 * 60 * 1000,
         `expected next_due_at within 24h, got ${after.next_due_at}`,


### PR DESCRIPTION
## Background

Production journals were full of `GET /repos/openronin/openronin/pulls/38/reviews 404` spam — about 10 calls/min on tasks left over from the openronin/openronin rename. The worker's catch block treated 404 as a regular transient error and re-queued with the standard hour cadence, so the noise just kept coming back. Earlier today I had to manually `UPDATE tasks SET status='error'` to make it stop.

## Fix

Two predicate-driven branches added:

- **`src/scheduler/worker.ts`**: new `isVcs404` predicate. On 404 the catch path still calls `markError` but with a ~year retry delay so the scheduler effectively forgets the task. Operator can re-enqueue manually if they really want to retry.
- **`src/scheduler/reconcile.ts`**: same predicate. A 404 on PR poll flips `pr_branches.status` to `'closed'` so the dashboard reflects reality and the next reconcile pass skips it cleanly.

The earlier-today manual SQL fix is now permanent and automatic.

## Test plan
- [x] `pnpm run check` green (172 tests; +2 stale-task tests)
- [x] 404 → year-long delay
- [x] non-404 errors keep their normal short retry