### PR TITLE
feat(director): per-decision trace UI (full prompt + response page)

### DIFF
--- a/src/director/decisions.ts
+++ b/src/director/decisions.ts
@@ -22,7 +22,25 @@ type DecisionRow = {
   outcome_details: string | null;
   cost_usd: number;
   payload_hash: string | null;
+  prompt_text: string | null;
+  response_text: string | null;
+  tokens_in: number | null;
+  tokens_out: number | null;
+  duration_ms: number | null;
+  engine_id: string | null;
+  model: string | null;
 };
+
+// Truncate-with-marker so a runaway prompt can't blow up the row.
+const TRACE_FIELD_CAP = 32 * 1024;
+function capTrace(s: string | null | undefined): string | null {
+  if (!s) return null;
+  if (s.length <= TRACE_FIELD_CAP) return s;
+  return (
+    s.slice(0, TRACE_FIELD_CAP) +
+    `\n\n[... truncated; original was ${s.length} chars, cap is ${TRACE_FIELD_CAP}]`
+  );
+}
 
 function rowToDecision(row: DecisionRow): Decision {
   return {
@@ -38,6 +56,13 @@ function rowToDecision(row: DecisionRow): Decision {
     outcomeTs: row.outcome_ts,
     outcomeDetails: row.outcome_details,
     costUsd: row.cost_usd,
+    promptText: row.prompt_text,
+    responseText: row.response_text,
+    tokensIn: row.tokens_in,
+    tokensOut: row.tokens_out,
+    durationMs: row.duration_ms,
+    engineId: row.engine_id,
+    model: row.model,
   };
 }
 
@@ -65,8 +90,10 @@ export function recordDecision(db: Db, d: NewDecision): Decision {
     .prepare(
       `INSERT INTO director_decisions
          (repo_id, decision_type, rationale, charter_version,
-          state_snapshot, payload, outcome, cost_usd, payload_hash)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          state_snapshot, payload, outcome, cost_usd, payload_hash,
+          prompt_text, response_text, tokens_in, tokens_out,
+          duration_ms, engine_id, model)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        RETURNING *`,
     )
     .get(
@@ -79,6 +106,13 @@ export function recordDecision(db: Db, d: NewDecision): Decision {
       d.outcome ?? "pending",
       d.costUsd ?? 0,
       hash,
+      capTrace(d.promptText ?? null),
+      capTrace(d.responseText ?? null),
+      d.tokensIn ?? null,
+      d.tokensOut ?? null,
+      d.durationMs ?? null,
+      d.engineId ?? null,
+      d.model ?? null,
     ) as DecisionRow;
   return rowToDecision(row);
 }

--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -247,8 +247,8 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
     trace: {
       promptText: `# system\n\n${prompt.systemPrompt}\n\n# user\n\n${prompt.userPrompt}`,
       responseText: llmResult.content,
-      tokensIn: llmResult.usage.tokensIn,
-      tokensOut: llmResult.usage.tokensOut,
+      tokensIn: llmResult.usage.tokensIn ?? 0,
+      tokensOut: llmResult.usage.tokensOut ?? 0,
       durationMs: llmResult.durationMs,
       engineId: engine.id,
       model,

--- a/src/director/tick.ts
+++ b/src/director/tick.ts
@@ -236,11 +236,23 @@ export async function runTick(opts: TickRunOptions): Promise<TickRunResult> {
 
   // 1. Persist all decisions first with outcome=pending so the audit trail
   //    is complete even if execution crashes. Cost is split across rows.
+  //    The full prompt + LLM response are stamped on every row so the
+  //    /admin/director/<slug>/decisions/<id> trace page can show what
+  //    produced this decision without a separate table.
   const recorded = recordTickDecisions(db, {
     repoId,
     tick,
     charterVersion,
     cost,
+    trace: {
+      promptText: `# system\n\n${prompt.systemPrompt}\n\n# user\n\n${prompt.userPrompt}`,
+      responseText: llmResult.content,
+      tokensIn: llmResult.usage.tokensIn,
+      tokensOut: llmResult.usage.tokensOut,
+      durationMs: llmResult.durationMs,
+      engineId: engine.id,
+      model,
+    },
   });
 
   // 2. Post the LLM's observations + reasoning + decision summary to chat
@@ -404,6 +416,17 @@ function recordTickDecisions(
     tick: TickOutput;
     charterVersion: number;
     cost: number;
+    // Trace fields shared across all decisions from this tick — they all
+    // came from the same LLM call so the prompt/response is identical.
+    trace: {
+      promptText: string;
+      responseText: string;
+      tokensIn: number;
+      tokensOut: number;
+      durationMs: number;
+      engineId: string;
+      model: string;
+    };
   },
 ): RecordedDecision[] {
   const out: RecordedDecision[] = [];
@@ -438,6 +461,14 @@ function recordTickDecisions(
       // outcome (executed / pending-with-proposal / dry_run / failed / skipped).
       outcome: "pending",
       costUsd: slice,
+      // All decisions in a single tick share the same LLM call/prompt.
+      promptText: args.trace.promptText,
+      responseText: args.trace.responseText,
+      tokensIn: args.trace.tokensIn,
+      tokensOut: args.trace.tokensOut,
+      durationMs: args.trace.durationMs,
+      engineId: args.trace.engineId,
+      model: args.trace.model,
     });
     if (dup.duplicateOf !== null) {
       // Mark the just-inserted row as a skipped duplicate. We still keep

--- a/src/director/types.ts
+++ b/src/director/types.ts
@@ -255,6 +255,16 @@ export type Decision = {
   outcomeTs: string | null;
   outcomeDetails: string | null;
   costUsd: number;
+  // Trace columns — populated only for decisions produced by an LLM tick.
+  // Manual decisions (operator-side approvals) leave them null. Each text
+  // field is capped at 32KB on insert to bound row size.
+  promptText: string | null;
+  responseText: string | null;
+  tokensIn: number | null;
+  tokensOut: number | null;
+  durationMs: number | null;
+  engineId: string | null;
+  model: string | null;
 };
 
 export type NewDecision = {
@@ -266,6 +276,13 @@ export type NewDecision = {
   payload?: unknown;
   outcome?: DecisionOutcome;
   costUsd?: number;
+  promptText?: string | null;
+  responseText?: string | null;
+  tokensIn?: number | null;
+  tokensOut?: number | null;
+  durationMs?: number | null;
+  engineId?: string | null;
+  model?: string | null;
 };
 
 // ── Tick result ──────────────────────────────────────────────────────────

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -1163,6 +1163,7 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
               <table class="data-table text-sm w-full">
                 <thead>
                   <tr>
+                    <th>#</th>
                     <th>Time</th>
                     <th>Type</th>
                     <th>Outcome</th>
@@ -1174,6 +1175,14 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
                   ${decisions.map(
                     (d) => html`
                       <tr>
+                        <td>
+                          <a
+                            class="text-[var(--brand-primary)] hover:underline"
+                            href="/admin/director/${slug}/decisions/${d.id}"
+                            title="Open per-decision trace"
+                            >#${d.id}</a
+                          >
+                        </td>
                         <td>${time(d.ts)}</td>
                         <td><code class="code-inline">${d.decisionType}</code></td>
                         <td>
@@ -1287,6 +1296,157 @@ export function directorAdminRoute({ db, getConfig }: Args): Hono {
     return c.html(
       renderChatThread(db, slug, messages, resolvePersonaName(repo), resolvePersonaAvatar(repo))
         .value,
+    );
+  });
+
+  // ── GET /:slug/decisions/:id ─────────────────────────────────────────
+  // Full per-decision trace: rendered alongside the chat thread but on a
+  // dedicated page so the prompt/response can stretch out without
+  // crowding the chat. Linked from the recent-decisions table.
+  app.get("/:slug/decisions/:id", (c) => {
+    const slug = c.req.param("slug");
+    const decisionId = Number(c.req.param("id"));
+    const entries = listEntries(db, getConfig);
+    const entry = entries.find((e) => e.slug === slug);
+    if (!entry) return c.notFound();
+    const config = getConfig();
+    const repo = config.repos.find((r) => repoKey(r) === slug);
+    const decision = getDecisionById(db, decisionId);
+    if (!decision || decision.repoId !== entry.repoId) return c.notFound();
+
+    const traceCard = card({
+      title: `Decision #${decision.id} — ${decision.decisionType}`,
+      body: html`
+        <div class="flex flex-col gap-2 text-sm">
+          <div class="grid grid-cols-2 gap-x-4 gap-y-1">
+            <div>
+              <div class="text-xs text-[var(--fg-muted)]">Outcome</div>
+              <div>
+                ${badge({
+                  label: decision.outcome,
+                  tone:
+                    decision.outcome === "executed"
+                      ? "success"
+                      : decision.outcome === "failed"
+                        ? "danger"
+                        : decision.outcome === "rejected"
+                          ? "warning"
+                          : "neutral",
+                })}
+                ${decision.outcomeDetails
+                  ? html` <span class="text-xs text-[var(--fg-muted)]"
+                      >${decision.outcomeDetails}</span
+                    >`
+                  : ""}
+              </div>
+            </div>
+            <div>
+              <div class="text-xs text-[var(--fg-muted)]">Charter</div>
+              <div>${decision.charterVersion ? `v${decision.charterVersion}` : "—"}</div>
+            </div>
+            <div>
+              <div class="text-xs text-[var(--fg-muted)]">Created</div>
+              <div>${time(decision.ts)}</div>
+            </div>
+            <div>
+              <div class="text-xs text-[var(--fg-muted)]">Resolved</div>
+              <div>${decision.outcomeTs ? time(decision.outcomeTs) : "—"}</div>
+            </div>
+            <div>
+              <div class="text-xs text-[var(--fg-muted)]">Engine</div>
+              <div>
+                ${decision.engineId ?? "—"}${decision.model
+                  ? html` <span class="text-xs text-[var(--fg-muted)]">${decision.model}</span>`
+                  : ""}
+              </div>
+            </div>
+            <div>
+              <div class="text-xs text-[var(--fg-muted)]">Cost / tokens / latency</div>
+              <div>
+                $${decision.costUsd.toFixed(4)}
+                ${decision.tokensIn !== null
+                  ? html` <span class="text-xs text-[var(--fg-muted)]"
+                      >· ${decision.tokensIn} in / ${decision.tokensOut ?? "?"} out</span
+                    >`
+                  : ""}
+                ${decision.durationMs !== null
+                  ? html` <span class="text-xs text-[var(--fg-muted)]"
+                      >· ${decision.durationMs}ms</span
+                    >`
+                  : ""}
+              </div>
+            </div>
+          </div>
+          <div>
+            <div class="text-xs text-[var(--fg-muted)]">Rationale</div>
+            <div class="md-body whitespace-pre-wrap">${decision.rationale}</div>
+          </div>
+        </div>
+      `,
+    });
+
+    const payloadCard = card({
+      title: "Payload",
+      body: html`<pre
+        class="text-xs bg-[var(--surface-base)] p-3 rounded border border-[var(--border)] overflow-auto whitespace-pre-wrap"
+      >
+${decision.payload ? JSON.stringify(decision.payload, null, 2) : "(no payload)"}</pre
+      >`,
+    });
+
+    const stateCard = card({
+      title: "State snapshot at decision time",
+      body: html`<pre
+        class="text-xs bg-[var(--surface-base)] p-3 rounded border border-[var(--border)] overflow-auto whitespace-pre-wrap"
+      >
+${decision.stateSnapshot ? JSON.stringify(decision.stateSnapshot, null, 2) : "(none)"}</pre
+      >`,
+    });
+
+    const promptCard = decision.promptText
+      ? card({
+          title: "Prompt sent to the LLM",
+          body: html`<details>
+            <summary class="cursor-pointer text-xs text-[var(--fg-muted)] mb-2">
+              Show full prompt (${decision.promptText.length} chars)
+            </summary>
+            <pre
+              class="text-xs bg-[var(--surface-base)] p-3 rounded border border-[var(--border)] overflow-auto whitespace-pre-wrap max-h-[60vh]"
+            >
+${decision.promptText}</pre
+            >
+          </details>`,
+        })
+      : "";
+
+    const responseCard = decision.responseText
+      ? card({
+          title: "Raw LLM response",
+          body: html`<pre
+            class="text-xs bg-[var(--surface-base)] p-3 rounded border border-[var(--border)] overflow-auto whitespace-pre-wrap max-h-[40vh]"
+          >
+${decision.responseText}</pre
+          >`,
+        })
+      : "";
+
+    const body = html`
+      <div class="flex flex-col gap-4">
+        ${traceCard} ${payloadCard} ${stateCard} ${promptCard} ${responseCard}
+      </div>
+    `;
+    return c.html(
+      page({
+        title: `Decision #${decision.id} — ${repo?.owner ?? entry.owner}/${repo?.name ?? entry.name}`,
+        section: "director",
+        body,
+        isHtmx: isHtmx(c.req.raw.headers),
+        breadcrumb: [
+          { label: "Director", href: "/admin/director" },
+          { label: `${entry.owner}/${entry.name}`, href: `/admin/director/${slug}` },
+          { label: `Decision #${decision.id}` },
+        ],
+      }),
     );
   });
 

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -411,4 +411,25 @@ function applyMigrationsInner(db: Db): void {
       "INSERT INTO schema_version (version, applied_at) VALUES (17, datetime('now'))",
     ).run();
   }
+
+  // v18 — Per-decision LLM trace. Adds prompt_text + response_text + a
+  // pair of token/duration columns directly on director_decisions so the
+  // /admin/director/<slug>/decisions/<id> page can show the full prompt
+  // and raw LLM output without a separate table. Capped at 32 KB each
+  // by the writer (truncated with a marker) so a runaway prompt can't
+  // bloat the row.
+  if (current < 18) {
+    db.exec(`
+      ALTER TABLE director_decisions ADD COLUMN prompt_text TEXT;
+      ALTER TABLE director_decisions ADD COLUMN response_text TEXT;
+      ALTER TABLE director_decisions ADD COLUMN tokens_in INTEGER;
+      ALTER TABLE director_decisions ADD COLUMN tokens_out INTEGER;
+      ALTER TABLE director_decisions ADD COLUMN duration_ms INTEGER;
+      ALTER TABLE director_decisions ADD COLUMN engine_id TEXT;
+      ALTER TABLE director_decisions ADD COLUMN model TEXT;
+    `);
+    db.prepare(
+      "INSERT INTO schema_version (version, applied_at) VALUES (18, datetime('now'))",
+    ).run();
+  }
 }

--- a/test/director-decision-trace.test.mjs
+++ b/test/director-decision-trace.test.mjs
@@ -1,0 +1,191 @@
+// Per-decision trace storage.
+//
+// Verifies:
+//   • recordDecision persists the trace columns (prompt, response, tokens, latency, engine, model)
+//   • capTrace truncates oversized prompts but keeps a marker
+//   • runTick stamps every decision in the same tick with the SAME prompt/response
+//     (they're all from one LLM call)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import { recordDecision, getDecisionById, recentDecisions } from "../dist/director/decisions.js";
+import { runTick } from "../dist/director/tick.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-trace-test-"));
+  const db = initDb(dir);
+  const r = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: r.id };
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+test("recordDecision: trace columns round-trip", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const created = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "exercising the trace columns end-to-end",
+      payload: { title: "test issue" },
+      outcome: "pending",
+      promptText: "system: be a director\nuser: do something",
+      responseText: '{"observations":"x","reasoning":"y","decisions":[]}',
+      tokensIn: 1234,
+      tokensOut: 567,
+      durationMs: 890,
+      engineId: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    const fetched = getDecisionById(db, created.id);
+    assert.equal(fetched.promptText, "system: be a director\nuser: do something");
+    assert.match(fetched.responseText, /observations/);
+    assert.equal(fetched.tokensIn, 1234);
+    assert.equal(fetched.tokensOut, 567);
+    assert.equal(fetched.durationMs, 890);
+    assert.equal(fetched.engineId, "anthropic");
+    assert.equal(fetched.model, "claude-sonnet-4-6");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("recordDecision: oversized prompt is capped with truncation marker", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const big = "x".repeat(50 * 1024); // 50KB > 32KB cap
+    const created = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "checking the cap behaves",
+      payload: { title: "cap test" },
+      promptText: big,
+    });
+    const fetched = getDecisionById(db, created.id);
+    assert.ok(fetched.promptText.length < big.length);
+    assert.match(fetched.promptText, /truncated; original was 51200 chars/);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("recordDecision: omitted trace fields stay null (manual decisions stay clean)", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const created = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "no trace populated by caller",
+      payload: { title: "no trace" },
+    });
+    const fetched = getDecisionById(db, created.id);
+    assert.equal(fetched.promptText, null);
+    assert.equal(fetched.responseText, null);
+    assert.equal(fetched.tokensIn, null);
+    assert.equal(fetched.engineId, null);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+const sampleCharter = {
+  vision: "Reliable AI dev agent.",
+  priorities: [{ id: "x", weight: 1.0, rubric: "y" }],
+  out_of_bounds: [],
+  out_of_bounds_paths: [],
+  definition_of_done: [],
+};
+
+const sampleBudget = {
+  initial_daily_usd: 2.0,
+  initial_weekly_usd: 10.0,
+  max_daily_usd: 10.0,
+  max_weekly_usd: 50.0,
+  think_daily_usd: 1.0,
+  pause_on_failure_streak: 3,
+  good_outcome_quarantine_days: 7,
+};
+
+const sampleDirector = {
+  enabled: true,
+  mode: "dry_run",
+  cadence_hours: 6,
+  bot_prefix: "👔 director:",
+  language: "English",
+  charter: sampleCharter,
+  budget: sampleBudget,
+  authority: {
+    can_create_issues: true,
+    can_label: true,
+    can_close_issues: false,
+    can_comment: true,
+    can_approve_pr: true,
+    can_merge: false,
+    can_modify_charter: false,
+  },
+};
+
+const sampleRepo = {
+  provider: "github",
+  owner: "openronin",
+  name: "openronin",
+  watched: true,
+  lanes: ["triage"],
+  director: sampleDirector,
+};
+
+test("runTick: stamps the same trace on every decision in one tick", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    await runTick({
+      db,
+      repoId,
+      repo: sampleRepo,
+      director: sampleDirector,
+      dataDir: dir,
+      engineFactory: () => ({
+        id: "mock",
+        defaultModel: "mock-1",
+        async run(opts) {
+          assert.match(opts.systemPrompt, /Director|product owner/);
+          return {
+            content: '{"observations":"...","reasoning":"...","decisions":[]}',
+            json: {
+              observations: "Two-decision tick exercising trace propagation.",
+              reasoning: "Both rows should carry identical prompt/response.",
+              decisions: [
+                { type: "no_op", rationale: "first no-op of the run" },
+                { type: "no_op", rationale: "second no-op of the run" },
+              ],
+            },
+            usage: { tokensIn: 100, tokensOut: 30, costUsd: 0.001 },
+            finishReason: "end_turn",
+            durationMs: 150,
+          };
+        },
+      }),
+    });
+    const decisions = recentDecisions(db, repoId, 5);
+    assert.equal(decisions.length, 2);
+    assert.equal(decisions[0].promptText, decisions[1].promptText);
+    assert.equal(decisions[0].responseText, decisions[1].responseText);
+    assert.match(decisions[0].promptText, /# system/);
+    assert.equal(decisions[0].engineId, "mock");
+    assert.equal(decisions[0].durationMs, 150);
+  } finally {
+    cleanup(dir);
+  }
+});


### PR DESCRIPTION
Operators couldn't see why the director made a particular decision — the rationale field is short and the underlying prompt + LLM response weren't stored at all. Debugging required SQL spelunking through `runs` / `state_snapshot`.

## What's new

- **Schema v18** — `director_decisions` grows seven new columns: `prompt_text`, `response_text`, `tokens_in`, `tokens_out`, `duration_ms`, `engine_id`, `model`. Each text field capped at 32 KB by the writer (truncated with marker) so a runaway prompt can't bloat the row.
- **`runTick`** stamps every decision in a tick with the SAME prompt/response (they all came from one LLM call).
- **New route** `GET /admin/director/:slug/decisions/:id` renders a full trace page: outcome timeline, payload, state snapshot, full prompt (collapsible `<details>`), raw LLM response. Linked from the recent-decisions table via a clickable `#N` column.

Manual decisions (operator-side approves) leave the trace columns null — no surprise empty pages.

## Test plan
- [x] `pnpm run check` green (176 tests; +4 trace tests)
- [x] Trace columns round-trip through recordDecision/getDecisionById
- [x] 50 KB prompt is capped to 32 KB with a truncation marker
- [x] Two decisions in one tick share identical prompt/response

## Future
- Bulk-approve / approve-via-Telegram already work; they don't populate the trace columns (intentional). If we ever need that, add a `promptText` arg to approveDecision.