### PR TITLE
feat(director): outcome follow-up — long-tail signal on executed decisions

### DIFF
--- a/src/director/index.ts
+++ b/src/director/index.ts
@@ -22,6 +22,8 @@ import { releaseTick, tryAcquireTick } from "./active-tick.js";
 import { getLastDigestDate, runDigest, shouldRunDigest } from "./digest.js";
 import { maybePostTrustRampSuggestion } from "./trust-ramp.js";
 import { expireStalePending } from "./decisions.js";
+import { runOutcomeFollowupSweep } from "./outcome-followup.js";
+import { GithubVcsProvider } from "../providers/github.js";
 import { MimoEngine } from "../engines/mimo.js";
 import type { DirectorConfig } from "./types.js";
 
@@ -29,6 +31,12 @@ import type { DirectorConfig } from "./types.js";
 // in <30s in the typical case, loose enough that an idle director burns
 // almost no CPU. Cadence-based scheduled ticks (6h+) are cheap to check.
 const SERVICE_LOOP_INTERVAL_MS = 10_000;
+
+// Outcome follow-up runs once per hour per repo. Throttled in-process via
+// this Map — keyed by repoId, value is the last sweep timestamp. Survives
+// across loop iterations because the module-level binding outlives them.
+const FOLLOWUP_INTERVAL_MS = 60 * 60 * 1000;
+const lastFollowupAt = new Map<number, number>();
 const KILL_SWITCH_ENV = "OPENRONIN_DIRECTOR_DISABLED";
 
 type RepoLookup = {
@@ -213,6 +221,34 @@ async function loopOnce(db: Db, config: RuntimeConfig): Promise<void> {
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error(`[director] digest error on ${repoKey(t.repo)}:`, err);
+    }
+    if (stopping) return;
+    // Outcome follow-up — once per hour per repo, polls VCS for the
+    // resulting state of recent executed create_issue decisions. Cheap
+    // when there's nothing to observe; capped at 5 decisions per sweep
+    // when there is. Surfaced on the per-decision trace UI.
+    try {
+      const last = lastFollowupAt.get(t.repoId) ?? 0;
+      if (Date.now() - last >= FOLLOWUP_INTERVAL_MS) {
+        lastFollowupAt.set(t.repoId, Date.now());
+        const result = await runOutcomeFollowupSweep(
+          db,
+          t.repoId,
+          t.repo.owner,
+          t.repo.name,
+          new GithubVcsProvider(),
+        );
+        if (result.observed > 0 || result.errored > 0) {
+          // eslint-disable-next-line no-console
+          console.log(
+            `[director] follow-up sweep on ${repoKey(t.repo)}: ` +
+              `${result.observed} observed, ${result.errored} errored`,
+          );
+        }
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`[director] follow-up sweep error on ${repoKey(t.repo)}:`, err);
     }
     if (stopping) return;
     // Trust ramp check is cheap (one SQL aggregate + one cooldown lookup);

--- a/src/director/outcome-followup.ts
+++ b/src/director/outcome-followup.ts
@@ -89,7 +89,7 @@ export function followupsForDecision(db: Db, decisionId: number): FollowupRow[] 
 
 export function latestFollowup(db: Db, decisionId: number): FollowupRow | null {
   const rows = followupsForDecision(db, decisionId);
-  return rows.length > 0 ? rows[0] : null;
+  return rows.length > 0 ? (rows[0] ?? null) : null;
 }
 
 // Pick decisions that are due for a fresh observation. Criteria:

--- a/src/director/outcome-followup.ts
+++ b/src/director/outcome-followup.ts
@@ -1,0 +1,228 @@
+// Outcome follow-up — long-tail check on whether director decisions held up.
+//
+// `executed` is a snapshot — at the moment we ran the side-effect it
+// looked successful. But the LLM's "good" outcomes have to survive
+// downstream reality:
+//   • create_issue → did the issue actually get worked on, or did it sit
+//     stale and get closed without a fix?
+//   • comment_on_pr / approve_pr → did the PR merge, or was the comment
+//     ignored and the PR abandoned?
+//   • merge_pr → was the merge reverted within a week?
+//
+// Each pass appends a row to `director_outcome_followups` for the
+// decisions it observed. Multiple rows per decision over time is normal
+// (a "still open" observation might later become "merged via PR #N").
+// The latest row is what the trace UI shows.
+//
+// Scope of this PR: only `create_issue` is observed (most common type
+// the director emits, and the easiest signal — issue state via VCS).
+// `merge_pr` reverts and `approve_pr` outcomes are documented as future
+// work; the schema is general enough to add them without a migration.
+
+import type { Db } from "../storage/db.js";
+import type { VcsProvider } from "../providers/vcs.js";
+
+// Don't observe the same decision more often than this. Ticks fire every
+// 10s but a real signal change happens on a day scale.
+const MIN_OBSERVATION_INTERVAL_HOURS = 6;
+
+// Stop following up after this many days. By then the issue is either
+// resolved (and we have our answer) or genuinely stale (and another
+// observation won't change that).
+const FOLLOWUP_WINDOW_DAYS = 14;
+
+export type FollowupKind =
+  | "issue_open" // initial observation: still being worked on
+  | "issue_closed_no_pr" // closed without a linked merged PR (likely won't-fix)
+  | "issue_merged_via_pr" // closed with a merged PR — the win signal
+  | "issue_pr_open" // a PR is open targeting this issue (in progress)
+  | "fetch_error"; // VCS call failed; recorded so we don't retry hot
+
+export type FollowupRow = {
+  id: number;
+  decisionId: number;
+  observedAt: string;
+  kind: FollowupKind;
+  detail: string | null;
+  refNumber: number | null;
+  refUrl: string | null;
+};
+
+export function recordFollowup(
+  db: Db,
+  args: {
+    decisionId: number;
+    kind: FollowupKind;
+    detail?: string | null;
+    refNumber?: number | null;
+    refUrl?: string | null;
+  },
+): FollowupRow {
+  const row = db
+    .prepare(
+      `INSERT INTO director_outcome_followups (decision_id, kind, detail, ref_number, ref_url)
+       VALUES (?, ?, ?, ?, ?)
+       RETURNING id, decision_id AS decisionId, observed_at AS observedAt, kind, detail, ref_number AS refNumber, ref_url AS refUrl`,
+    )
+    .get(
+      args.decisionId,
+      args.kind,
+      args.detail ?? null,
+      args.refNumber ?? null,
+      args.refUrl ?? null,
+    ) as FollowupRow;
+  return row;
+}
+
+export function followupsForDecision(db: Db, decisionId: number): FollowupRow[] {
+  const rows = db
+    .prepare(
+      `SELECT id, decision_id AS decisionId, observed_at AS observedAt, kind, detail,
+              ref_number AS refNumber, ref_url AS refUrl
+       FROM director_outcome_followups
+       WHERE decision_id = ?
+       ORDER BY id DESC`,
+    )
+    .all(decisionId) as FollowupRow[];
+  return rows;
+}
+
+export function latestFollowup(db: Db, decisionId: number): FollowupRow | null {
+  const rows = followupsForDecision(db, decisionId);
+  return rows.length > 0 ? rows[0] : null;
+}
+
+// Pick decisions that are due for a fresh observation. Criteria:
+//   • outcome=executed (we never followed-up speculatively on pending)
+//   • decisionType=create_issue (current scope)
+//   • the decision is within the FOLLOWUP_WINDOW_DAYS observation window
+//   • either: no follow-up yet, OR the latest follow-up is older than
+//     MIN_OBSERVATION_INTERVAL_HOURS AND not a terminal kind
+//
+// Cap result at 5 to keep one sweep cheap on a busy repo.
+type CandidateRow = {
+  decision_id: number;
+  payload: string | null;
+  outcome_details: string | null;
+};
+
+export function pickFollowupCandidates(db: Db, repoId: number, limit = 5): CandidateRow[] {
+  return db
+    .prepare(
+      `SELECT d.id AS decision_id, d.payload AS payload, d.outcome_details
+       FROM director_decisions d
+       WHERE d.repo_id = ?
+         AND d.outcome = 'executed'
+         AND d.decision_type = 'create_issue'
+         AND d.ts > datetime('now', '-' || ? || ' days')
+         AND NOT EXISTS (
+           SELECT 1 FROM director_outcome_followups f
+           WHERE f.decision_id = d.id
+             AND (
+               f.kind IN ('issue_closed_no_pr','issue_merged_via_pr')
+               OR f.observed_at > datetime('now', '-' || ? || ' hours')
+             )
+         )
+       ORDER BY d.id DESC
+       LIMIT ?`,
+    )
+    .all(repoId, FOLLOWUP_WINDOW_DAYS, MIN_OBSERVATION_INTERVAL_HOURS, limit) as CandidateRow[];
+}
+
+// Extract the issue number that an executed `create_issue` produced. The
+// executor records `outcome_details = "issue #N created (https://...)"`.
+export function parseIssueNumberFromOutcomeDetails(details: string | null): number | null {
+  if (!details) return null;
+  const m = details.match(/issue #(\d+)/i);
+  return m ? Number(m[1]) : null;
+}
+
+// Run one follow-up sweep for a repo. Walks the candidate list, polls
+// VCS for each, inserts a row. Caller manages cadence (we throttle here
+// per-decision, but the loop should call this at most ~hourly per repo
+// to avoid burning rate limit).
+export async function runOutcomeFollowupSweep(
+  db: Db,
+  repoId: number,
+  ownerName: string,
+  repoName: string,
+  vcs: VcsProvider,
+): Promise<{ observed: number; errored: number }> {
+  const candidates = pickFollowupCandidates(db, repoId);
+  let observed = 0;
+  let errored = 0;
+  for (const c of candidates) {
+    const issueNumber = parseIssueNumberFromOutcomeDetails(c.outcome_details);
+    if (!issueNumber) continue;
+    try {
+      const item = await vcs.getItem({ owner: ownerName, name: repoName }, issueNumber);
+      // GitHub returns issues for both real issues and PRs; if `pull_request`
+      // shows up the issue itself IS a PR. We only care about pure issues
+      // here; future work covers PR/revert tracking.
+      const isPr = item.kind === "pull_request";
+      if (isPr) {
+        // The executed create_issue produced an issue but somehow it's
+        // showing as a PR — record and move on.
+        recordFollowup(db, {
+          decisionId: c.decision_id,
+          kind: "issue_pr_open",
+          detail: `tracked item is a PR, not an issue (state=${item.state})`,
+          refNumber: issueNumber,
+          refUrl: item.url ?? null,
+        });
+      } else if (item.state === "closed") {
+        // GitHub-closed issues with `state_reason="completed"` are
+        // typically closed by a merged PR's "fixes #N" link — that's
+        // our positive signal. Anything else (`not_planned`,
+        // `duplicate`, or no reason at all) counts as closed-without-fix.
+        const reason = item.stateReason ?? "";
+        const kind: FollowupKind =
+          reason === "completed" ? "issue_merged_via_pr" : "issue_closed_no_pr";
+        recordFollowup(db, {
+          decisionId: c.decision_id,
+          kind,
+          detail: `closed${reason ? ` (state_reason=${reason})` : ""}`,
+          refNumber: issueNumber,
+          refUrl: item.url ?? null,
+        });
+      } else {
+        recordFollowup(db, {
+          decisionId: c.decision_id,
+          kind: "issue_open",
+          detail: `still open${item.title ? ` — "${item.title.slice(0, 80)}"` : ""}`,
+          refNumber: issueNumber,
+          refUrl: item.url ?? null,
+        });
+      }
+      observed++;
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      recordFollowup(db, {
+        decisionId: c.decision_id,
+        kind: "fetch_error",
+        detail: detail.slice(0, 240),
+        refNumber: issueNumber,
+        refUrl: null,
+      });
+      errored++;
+    }
+  }
+  return { observed, errored };
+}
+
+export function summariseFollowup(row: FollowupRow): string {
+  switch (row.kind) {
+    case "issue_open":
+      return `🔵 still open${row.refNumber ? ` (#${row.refNumber})` : ""}`;
+    case "issue_pr_open":
+      return `🟡 tracked as PR${row.refNumber ? ` (#${row.refNumber})` : ""}`;
+    case "issue_closed_no_pr":
+      return `⚫ closed without a PR${row.refNumber ? ` (#${row.refNumber})` : ""}`;
+    case "issue_merged_via_pr":
+      return `🟢 merged${row.refNumber ? ` (closed #${row.refNumber})` : ""}`;
+    case "fetch_error":
+      return `❓ fetch error: ${row.detail ?? "(no detail)"}`;
+    default:
+      return row.kind;
+  }
+}

--- a/src/providers/github.ts
+++ b/src/providers/github.ts
@@ -608,6 +608,7 @@ function mapReviewState(state: string | null | undefined): ReviewComment["review
 }
 
 function mapIssue(raw: RawIssue): VcsItem {
+  const stateReasonRaw = (raw as { state_reason?: string | null }).state_reason;
   return {
     number: raw.number,
     kind: raw.pull_request ? "pull_request" : "issue",
@@ -616,6 +617,7 @@ function mapIssue(raw: RawIssue): VcsItem {
     author: raw.user?.login ?? "unknown",
     authorAssociation: raw.author_association ?? "NONE",
     state: raw.state === "open" ? "open" : "closed",
+    stateReason: stateReasonRaw ?? undefined,
     labels: raw.labels.map((l) => (typeof l === "string" ? l : (l.name ?? ""))).filter(Boolean),
     createdAt: raw.created_at,
     updatedAt: raw.updated_at,

--- a/src/providers/vcs.ts
+++ b/src/providers/vcs.ts
@@ -11,6 +11,10 @@ export interface VcsItem {
   author: string;
   authorAssociation: string;
   state: "open" | "closed";
+  // GitHub's `state_reason` for closed issues: "completed" (typically
+  // closed by a merged PR) vs "not_planned" / "duplicate". Optional so
+  // providers without this field can leave it undefined.
+  stateReason?: "completed" | "not_planned" | "reopened" | "duplicate" | string;
   labels: string[];
   createdAt: string;
   updatedAt: string;

--- a/src/server/admin-director.ts
+++ b/src/server/admin-director.ts
@@ -37,6 +37,7 @@ import { approveDecision, rejectDecision } from "../director/executor.js";
 import { getActiveTick } from "../director/active-tick.js";
 import { getDecisionById, pendingDecisions } from "../director/decisions.js";
 import { deleteNote, listNotes, recordNote } from "../director/notes.js";
+import { followupsForDecision, summariseFollowup } from "../director/outcome-followup.js";
 import { parseSlashCommand, runSlashCommand } from "./slash-commands.js";
 import { GithubVcsProvider } from "../providers/github.js";
 import type { VcsProvider } from "../providers/vcs.js";
@@ -1430,9 +1431,43 @@ ${decision.responseText}</pre
         })
       : "";
 
+    const followups = followupsForDecision(db, decision.id);
+    const followupCard =
+      followups.length > 0
+        ? card({
+            title: `Outcome follow-up — ${followups.length} observation(s)`,
+            body: html`
+              <ul class="flex flex-col gap-1 text-sm">
+                ${followups.map(
+                  (f) => html`
+                    <li
+                      class="flex items-center gap-2 p-2 border border-[var(--border)] rounded text-xs"
+                    >
+                      <span class="text-[var(--fg-muted)]">${time(f.observedAt)}</span>
+                      <span class="font-medium">${summariseFollowup(f)}</span>
+                      ${f.refUrl
+                        ? html` <a
+                            class="text-[var(--brand-primary)] hover:underline ml-auto"
+                            href="${f.refUrl}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            >open ↗</a
+                          >`
+                        : ""}
+                    </li>
+                  `,
+                )}
+              </ul>
+              <p class="text-xs text-[var(--fg-muted)] mt-2">
+                Sweeper polls each executed create_issue once an hour for up to 14 days.
+              </p>
+            `,
+          })
+        : "";
+
     const body = html`
       <div class="flex flex-col gap-4">
-        ${traceCard} ${payloadCard} ${stateCard} ${promptCard} ${responseCard}
+        ${traceCard} ${followupCard} ${payloadCard} ${stateCard} ${promptCard} ${responseCard}
       </div>
     `;
     return c.html(

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -412,6 +412,32 @@ function applyMigrationsInner(db: Db): void {
     ).run();
   }
 
+  // v19 — Outcome follow-up. After a director-emitted create_issue
+  // (etc.) lands as `executed`, we want to look at the resulting issue/PR
+  // a day, three days, a week later: did it get closed without resolution?
+  // Was a PR merged for it? Was that PR reverted? Each observation is
+  // appended as a row here (multiple rows per decision is normal — one
+  // per sweep). Feeds the per-decision trace UI; doesn't yet change the
+  // adaptive-budget retrospective (that uses immediate decision outcomes).
+  if (current < 19) {
+    db.exec(`
+      CREATE TABLE director_outcome_followups (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        decision_id INTEGER NOT NULL REFERENCES director_decisions(id) ON DELETE CASCADE,
+        observed_at TEXT NOT NULL DEFAULT (datetime('now')),
+        kind TEXT NOT NULL,
+        detail TEXT,
+        ref_number INTEGER,
+        ref_url TEXT
+      );
+      CREATE INDEX idx_director_outcome_followups_decision
+        ON director_outcome_followups(decision_id, observed_at DESC);
+    `);
+    db.prepare(
+      "INSERT INTO schema_version (version, applied_at) VALUES (19, datetime('now'))",
+    ).run();
+  }
+
   // v18 — Per-decision LLM trace. Adds prompt_text + response_text + a
   // pair of token/duration columns directly on director_decisions so the
   // /admin/director/<slug>/decisions/<id> page can show the full prompt

--- a/test/director-outcome-followup.test.mjs
+++ b/test/director-outcome-followup.test.mjs
@@ -152,16 +152,26 @@ function makeStubVcs(itemByNumber) {
       }
       return item;
     },
-    async postComment() { return { id: "0", url: "" }; },
+    async postComment() {
+      return { id: "0", url: "" };
+    },
     async updateComment() {},
     async closeItem() {},
-    async listAllPrFeedback() { return []; },
-    verifyWebhookSignature() { return true; },
-    async createIssue() { return { number: 0, url: "" }; },
+    async listAllPrFeedback() {
+      return [];
+    },
+    verifyWebhookSignature() {
+      return true;
+    },
+    async createIssue() {
+      return { number: 0, url: "" };
+    },
     async addLabels() {},
     async removeLabels() {},
     async approvePullRequest() {},
-    async mergePullRequest() { return { merged: false }; },
+    async mergePullRequest() {
+      return { merged: false };
+    },
   };
 }
 
@@ -194,9 +204,56 @@ test("runOutcomeFollowupSweep: records issue_open / issue_merged_via_pr / issue_
 
     const stub = makeStubVcs(
       new Map([
-        [100, { number: 100, kind: "issue", title: "Open one", body: "", author: "x", authorAssociation: "MEMBER", state: "open", labels: [], createdAt: "2026-05-01T00:00:00Z", updatedAt: "2026-05-05T00:00:00Z", url: "https://example.test/issues/100" }],
-        [200, { number: 200, kind: "issue", title: "Merged one", body: "", author: "x", authorAssociation: "MEMBER", state: "closed", stateReason: "completed", labels: [], createdAt: "2026-05-01T00:00:00Z", updatedAt: "2026-05-05T00:00:00Z", url: "https://example.test/issues/200" }],
-        [300, { number: 300, kind: "issue", title: "Stale one", body: "", author: "x", authorAssociation: "MEMBER", state: "closed", stateReason: "not_planned", labels: [], createdAt: "2026-05-01T00:00:00Z", updatedAt: "2026-05-05T00:00:00Z", url: "https://example.test/issues/300" }],
+        [
+          100,
+          {
+            number: 100,
+            kind: "issue",
+            title: "Open one",
+            body: "",
+            author: "x",
+            authorAssociation: "MEMBER",
+            state: "open",
+            labels: [],
+            createdAt: "2026-05-01T00:00:00Z",
+            updatedAt: "2026-05-05T00:00:00Z",
+            url: "https://example.test/issues/100",
+          },
+        ],
+        [
+          200,
+          {
+            number: 200,
+            kind: "issue",
+            title: "Merged one",
+            body: "",
+            author: "x",
+            authorAssociation: "MEMBER",
+            state: "closed",
+            stateReason: "completed",
+            labels: [],
+            createdAt: "2026-05-01T00:00:00Z",
+            updatedAt: "2026-05-05T00:00:00Z",
+            url: "https://example.test/issues/200",
+          },
+        ],
+        [
+          300,
+          {
+            number: 300,
+            kind: "issue",
+            title: "Stale one",
+            body: "",
+            author: "x",
+            authorAssociation: "MEMBER",
+            state: "closed",
+            stateReason: "not_planned",
+            labels: [],
+            createdAt: "2026-05-01T00:00:00Z",
+            updatedAt: "2026-05-05T00:00:00Z",
+            url: "https://example.test/issues/300",
+          },
+        ],
       ]),
     );
 
@@ -214,11 +271,27 @@ test("runOutcomeFollowupSweep: records issue_open / issue_merged_via_pr / issue_
 
 test("summariseFollowup: human-readable strings include the ref number", () => {
   assert.match(
-    summariseFollowup({ kind: "issue_merged_via_pr", refNumber: 42, observedAt: "", id: 1, decisionId: 1, detail: "", refUrl: null }),
+    summariseFollowup({
+      kind: "issue_merged_via_pr",
+      refNumber: 42,
+      observedAt: "",
+      id: 1,
+      decisionId: 1,
+      detail: "",
+      refUrl: null,
+    }),
     /merged.*#42/,
   );
   assert.match(
-    summariseFollowup({ kind: "issue_open", refNumber: 7, observedAt: "", id: 1, decisionId: 1, detail: "", refUrl: null }),
+    summariseFollowup({
+      kind: "issue_open",
+      refNumber: 7,
+      observedAt: "",
+      id: 1,
+      decisionId: 1,
+      detail: "",
+      refUrl: null,
+    }),
     /still open.*#7/,
   );
 });

--- a/test/director-outcome-followup.test.mjs
+++ b/test/director-outcome-followup.test.mjs
@@ -1,0 +1,224 @@
+// Outcome follow-up sweep.
+//
+// Verifies:
+//   • parseIssueNumberFromOutcomeDetails extracts #N from executor output
+//   • pickFollowupCandidates respects the 14-day window and not-recently-observed
+//   • runOutcomeFollowupSweep records the right kind for open / closed-completed /
+//     closed-not_planned issues
+//   • a terminal observation (closed) prevents further sweeps from picking it
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { initDb } from "../dist/storage/db.js";
+import { recordDecision, setDecisionOutcome } from "../dist/director/decisions.js";
+import {
+  followupsForDecision,
+  parseIssueNumberFromOutcomeDetails,
+  pickFollowupCandidates,
+  recordFollowup,
+  runOutcomeFollowupSweep,
+  summariseFollowup,
+} from "../dist/director/outcome-followup.js";
+
+function freshDb() {
+  const dir = mkdtempSync(join(tmpdir(), "openronin-followup-test-"));
+  const db = initDb(dir);
+  const r = db
+    .prepare(
+      `INSERT INTO repos (provider, owner, name, watched, config_json)
+       VALUES ('github', 'openronin', 'openronin', 1, '{}')
+       RETURNING id`,
+    )
+    .get();
+  return { db, dir, repoId: r.id };
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+test("parseIssueNumberFromOutcomeDetails: pulls #N out of the executor's output", () => {
+  assert.equal(
+    parseIssueNumberFromOutcomeDetails("issue #42 created (https://github.com/o/r/issues/42)"),
+    42,
+  );
+  assert.equal(parseIssueNumberFromOutcomeDetails("issue #1234 created"), 1234);
+  assert.equal(parseIssueNumberFromOutcomeDetails(null), null);
+  assert.equal(parseIssueNumberFromOutcomeDetails("nothing matching"), null);
+});
+
+test("pickFollowupCandidates: only executed create_issue rows within the window", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const goodDecision = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "good candidate within the window",
+      payload: { title: "x" },
+    });
+    setDecisionOutcome(db, goodDecision.id, "executed", "issue #100 created");
+
+    const badNonExecuted = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "still pending — not a candidate",
+      payload: { title: "y" },
+      outcome: "pending",
+    });
+    void badNonExecuted; // explicit
+
+    const badCommentDecision = recordDecision(db, {
+      repoId,
+      decisionType: "comment_on_issue",
+      rationale: "wrong type — not a candidate",
+      payload: { issue_number: 1, body: "hi" },
+    });
+    setDecisionOutcome(db, badCommentDecision.id, "executed", "comment posted on #1");
+
+    const candidates = pickFollowupCandidates(db, repoId);
+    assert.equal(candidates.length, 1);
+    assert.equal(candidates[0].decision_id, goodDecision.id);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("pickFollowupCandidates: hides decisions with a recent observation", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const d = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "candidate that already had a recent observation",
+      payload: { title: "x" },
+    });
+    setDecisionOutcome(db, d.id, "executed", "issue #100 created");
+
+    recordFollowup(db, {
+      decisionId: d.id,
+      kind: "issue_open",
+      detail: "still open",
+      refNumber: 100,
+    });
+
+    assert.equal(pickFollowupCandidates(db, repoId).length, 0);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("pickFollowupCandidates: terminal observation hides forever (within window)", () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const d = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "candidate that already terminally resolved",
+      payload: { title: "x" },
+    });
+    setDecisionOutcome(db, d.id, "executed", "issue #100 created");
+
+    recordFollowup(db, {
+      decisionId: d.id,
+      kind: "issue_merged_via_pr",
+      detail: "closed",
+      refNumber: 100,
+    });
+    // Backdate the observation to make it "old" — but the kind is terminal
+    // so the row should still be hidden.
+    db.prepare(
+      `UPDATE director_outcome_followups SET observed_at = datetime('now', '-3 days')`,
+    ).run();
+    assert.equal(pickFollowupCandidates(db, repoId).length, 0);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+function makeStubVcs(itemByNumber) {
+  return {
+    id: "stub",
+    listOpenItems: async function* () {},
+    async getItem(_repo, n) {
+      const item = itemByNumber.get(n);
+      if (!item) {
+        const err = new Error("404 Not Found");
+        err.status = 404;
+        throw err;
+      }
+      return item;
+    },
+    async postComment() { return { id: "0", url: "" }; },
+    async updateComment() {},
+    async closeItem() {},
+    async listAllPrFeedback() { return []; },
+    verifyWebhookSignature() { return true; },
+    async createIssue() { return { number: 0, url: "" }; },
+    async addLabels() {},
+    async removeLabels() {},
+    async approvePullRequest() {},
+    async mergePullRequest() { return { merged: false }; },
+  };
+}
+
+test("runOutcomeFollowupSweep: records issue_open / issue_merged_via_pr / issue_closed_no_pr", async () => {
+  const { db, dir, repoId } = freshDb();
+  try {
+    const dOpen = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "issue is still open in stub VCS",
+      payload: { title: "open" },
+    });
+    setDecisionOutcome(db, dOpen.id, "executed", "issue #100 created");
+
+    const dMerged = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "issue closed by a merged PR (state_reason=completed)",
+      payload: { title: "merged" },
+    });
+    setDecisionOutcome(db, dMerged.id, "executed", "issue #200 created");
+
+    const dStale = recordDecision(db, {
+      repoId,
+      decisionType: "create_issue",
+      rationale: "issue closed without resolution",
+      payload: { title: "stale" },
+    });
+    setDecisionOutcome(db, dStale.id, "executed", "issue #300 created");
+
+    const stub = makeStubVcs(
+      new Map([
+        [100, { number: 100, kind: "issue", title: "Open one", body: "", author: "x", authorAssociation: "MEMBER", state: "open", labels: [], createdAt: "2026-05-01T00:00:00Z", updatedAt: "2026-05-05T00:00:00Z", url: "https://example.test/issues/100" }],
+        [200, { number: 200, kind: "issue", title: "Merged one", body: "", author: "x", authorAssociation: "MEMBER", state: "closed", stateReason: "completed", labels: [], createdAt: "2026-05-01T00:00:00Z", updatedAt: "2026-05-05T00:00:00Z", url: "https://example.test/issues/200" }],
+        [300, { number: 300, kind: "issue", title: "Stale one", body: "", author: "x", authorAssociation: "MEMBER", state: "closed", stateReason: "not_planned", labels: [], createdAt: "2026-05-01T00:00:00Z", updatedAt: "2026-05-05T00:00:00Z", url: "https://example.test/issues/300" }],
+      ]),
+    );
+
+    const result = await runOutcomeFollowupSweep(db, repoId, "openronin", "openronin", stub);
+    assert.equal(result.observed, 3);
+    assert.equal(result.errored, 0);
+
+    assert.equal(followupsForDecision(db, dOpen.id)[0].kind, "issue_open");
+    assert.equal(followupsForDecision(db, dMerged.id)[0].kind, "issue_merged_via_pr");
+    assert.equal(followupsForDecision(db, dStale.id)[0].kind, "issue_closed_no_pr");
+  } finally {
+    cleanup(dir);
+  }
+});
+
+test("summariseFollowup: human-readable strings include the ref number", () => {
+  assert.match(
+    summariseFollowup({ kind: "issue_merged_via_pr", refNumber: 42, observedAt: "", id: 1, decisionId: 1, detail: "", refUrl: null }),
+    /merged.*#42/,
+  );
+  assert.match(
+    summariseFollowup({ kind: "issue_open", refNumber: 7, observedAt: "", id: 1, decisionId: 1, detail: "", refUrl: null }),
+    /still open.*#7/,
+  );
+});


### PR DESCRIPTION
`executed` is a snapshot — at the moment we ran the side-effect it looked successful. But the LLM's "good" outcomes have to survive downstream reality. Did the issue we created actually get worked on, or did it sit stale and get closed unresolved?

## What's new

- **Schema v19** — `director_outcome_followups` (decision_id, observed_at, kind, detail, ref_number, ref_url). Multiple rows per decision over time is normal — one per sweep.
- **`src/director/outcome-followup.ts`** — `pickFollowupCandidates` + `runOutcomeFollowupSweep`. Polls VCS for executed `create_issue` decisions in a 14-day window, throttled to once-per-6h per decision and capped at 5 per sweep. Records:
  - `issue_open` — still being worked on
  - `issue_merged_via_pr` — closed with `state_reason=completed` (the win signal)
  - `issue_closed_no_pr` — closed without resolution (won't-fix etc.)
  - `issue_pr_open` — tracked item is a PR
  - `fetch_error` — VCS call failed; recorded so we don't retry hot
- **VcsItem grows an optional `stateReason` field**; `mapIssue` propagates GitHub's `state_reason` ("completed" / "not_planned" / etc.) so the sweep can distinguish merged-via-PR closes from won't-fix closes.
- **Service loop** calls the sweeper once per hour per repo with an in-memory throttle. Cheap when there's nothing to observe.
- **Per-decision trace UI** gains an "Outcome follow-up" card showing the observation timeline (most recent first) with deep links into VCS.

Doesn't yet feed into the adaptive-budget retrospective — that still uses immediate decision outcomes. Documented as future work in the code.

## Test plan
- [x] `pnpm run check` green (182 tests; +6 follow-up tests)
- [x] parseIssueNumberFromOutcomeDetails extracts #N from executor output
- [x] candidate picker excludes pending / non-create_issue / recently-observed / terminal
- [x] sweeper records correct kind for open / merged_via_pr / closed_no_pr

Closes the last "deferred from Wave 3" item on the audit roadmap.