### PR TITLE
[openronin] fix(scheduler): lift transient pr_branches parks on human webhook events

### DIFF
--- a/src/scheduler/worker.ts
+++ b/src/scheduler/worker.ts
@@ -16,19 +16,15 @@ import { RateLimited } from "../engines/types.js";
 import { ensureRepo } from "../storage/tasks.js";
 import { getPrBranchByPrNumber, getPrBranchByTask } from "../storage/pr-branches.js";
 
-// Statuses on pr_branches that mean "this attempt is parked, don't redo it
-// from scratch on the next reconcile". Lifted only by human action (label
-// removal / new comment that webhook re-enqueues / explicit retry button).
-const TERMINAL_BRANCH_STATUSES = new Set([
-  "guardrail_blocked",
-  "dirty",
-  "no_changes",
-  "needs_human",
-  // "error" is set by the patch lane's catch block (e.g. clone failed,
-  // setIdentity failed, agent threw before producing a commit). Without
-  // this entry we'd loop the same failure every reconcile cycle.
-  "error",
-]);
+// Statuses caused by infra/agent failure, not by a human-gated decision.
+// A verified non-bot webhook comment lifts these to 'cancelled' so that
+// pickLane can re-route on the next drain (see webhooks.ts).
+export const TRANSIENT_PARK_STATUSES = new Set(["error", "dirty"]);
+
+// Statuses that require explicit human action to lift:
+// admin Retry button (guardrail_blocked), patch_trigger_label removal
+// (guardrail_blocked), or 24h TTL (no_changes / needs_human).
+const TERMINAL_BRANCH_STATUSES = new Set(["guardrail_blocked", "no_changes", "needs_human"]);
 
 export interface WorkResult {
   taskId: number;
@@ -264,11 +260,13 @@ function pickLane(
   const hasPatch = repo.lanes.includes("patch");
   const hasTrigger = (hasPatch || hasPatchMulti) && item.labels.includes(repo.patch_trigger_label);
 
-  // If a previous patch attempt parked the work in a terminal state
-  // (guardrail_blocked, dirty, no_changes, needs_human) — do NOT loop into
-  // analyze/patch again. The user must remove the label or otherwise unstick
-  // it. Webhook on a fresh non-bot comment will re-enqueue, and at that
-  // point the user has presumably acted.
+  // If a previous patch attempt parked the work in a human-gated terminal
+  // state (guardrail_blocked, no_changes, needs_human) — do NOT loop into
+  // analyze/patch again. The user must remove the label, use the Retry
+  // button, or wait for the 24h TTL.
+  // Transient infra parks (error, dirty) are lifted to 'cancelled' in the
+  // webhook handler on receipt of a real non-bot comment, so they will not
+  // appear here once lifted.
   if (hasTrigger) {
     const taskRow = db
       .prepare("SELECT id FROM tasks WHERE repo_id = ? AND external_id = ?")

--- a/src/server/webhooks.ts
+++ b/src/server/webhooks.ts
@@ -6,6 +6,7 @@ import { GitlabVcsProvider } from "../providers/gitlab.js";
 import { JiraTrackerProvider } from "../providers/jira.js";
 import { TodoistTrackerProvider } from "../providers/todoist.js";
 import { ensureRepo, upsertTask, upsertJiraTask, upsertTodoistTask } from "../storage/tasks.js";
+import { liftTransientPark } from "../storage/pr-branches.js";
 import { enqueue } from "../scheduler/queue.js";
 
 interface Args {
@@ -155,9 +156,21 @@ export function webhooksRoute({ db, getConfig, scheduler }: Args): Hono {
       name: repoCfg.name,
     });
     const taskId = upsertTask(db, dbRepoId, String(number), kind);
+
+    // A non-bot comment on an issue lifts any transient infra park (error /
+    // dirty) to 'cancelled' so pickLane can re-route on the next drain.
+    // Label/edit events have an empty body — this only fires on real comments.
+    let lifted = false;
+    if (candidateBody && kind === "issue") {
+      lifted = liftTransientPark(db, taskId);
+      if (lifted) {
+        console.log(`[webhook] lifted transient park for task #${taskId} (issue #${number})`);
+      }
+    }
+
     enqueue(db, taskId, "high", null);
 
-    return c.json({ status: "queued", taskId, event, action: payload.action });
+    return c.json({ status: "queued", taskId, event, action: payload.action, lifted });
   });
 
   // -------- GitLab webhook --------

--- a/src/storage/pr-branches.ts
+++ b/src/storage/pr-branches.ts
@@ -109,6 +109,19 @@ export function listBlockedPatches(db: Db): BlockedPatchRow[] {
     .all() as BlockedPatchRow[];
 }
 
+// Lift a transient infra park (error / dirty) to 'cancelled' so the
+// scheduler can re-route the task normally on the next drain.
+// Returns true if a row was actually updated.
+export function liftTransientPark(db: Db, taskId: number): boolean {
+  const result = db
+    .prepare(
+      `UPDATE pr_branches SET status = 'cancelled', updated_at = datetime('now')
+       WHERE task_id = ? AND status IN ('error', 'dirty')`,
+    )
+    .run(taskId);
+  return result.changes > 0;
+}
+
 // Find a pr_branches row by PR number, scoped to a repo. The PR has its own
 // task (external_id=PR number), but the row was created against the source
 // issue's task — so we join through tasks → repos.

--- a/test/scheduler.test.mjs
+++ b/test/scheduler.test.mjs
@@ -30,6 +30,56 @@ test("cadence: isDue treats null as due, future as not-due", async () => {
   assert.equal(isDue(new Date(now.getTime() + 60_000).toISOString(), now), false);
 });
 
+test("liftTransientPark: lifts error/dirty to cancelled, leaves human-gated statuses untouched", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "aidev-lift-"));
+  try {
+    const { initDb } = await import("../dist/storage/db.js");
+    const { ensureRepo, upsertTask } = await import("../dist/storage/tasks.js");
+    const { recordPrBranch, liftTransientPark, getPrBranchByTask } =
+      await import("../dist/storage/pr-branches.js");
+
+    const db = initDb(tmp);
+    const repoId = ensureRepo(db, { provider: "github", owner: "o", name: "n" });
+
+    // Task with error status — should be lifted
+    const t1 = upsertTask(db, repoId, "11", "issue");
+    recordPrBranch(db, { taskId: t1, branch: "openronin/11", status: "error" });
+    assert.equal(liftTransientPark(db, t1), true, "returns true when a row was updated");
+    assert.equal(getPrBranchByTask(db, t1)?.status, "cancelled");
+
+    // Task with dirty status — should be lifted
+    const t2 = upsertTask(db, repoId, "12", "issue");
+    recordPrBranch(db, { taskId: t2, branch: "openronin/12", status: "dirty" });
+    assert.equal(liftTransientPark(db, t2), true);
+    assert.equal(getPrBranchByTask(db, t2)?.status, "cancelled");
+
+    // Task with guardrail_blocked — must NOT be lifted
+    const t3 = upsertTask(db, repoId, "13", "issue");
+    recordPrBranch(db, { taskId: t3, branch: "openronin/13", status: "guardrail_blocked" });
+    assert.equal(liftTransientPark(db, t3), false, "returns false when nothing changed");
+    assert.equal(getPrBranchByTask(db, t3)?.status, "guardrail_blocked");
+
+    // Task with needs_human — must NOT be lifted
+    const t4 = upsertTask(db, repoId, "14", "issue");
+    recordPrBranch(db, { taskId: t4, branch: "openronin/14", status: "needs_human" });
+    assert.equal(liftTransientPark(db, t4), false);
+    assert.equal(getPrBranchByTask(db, t4)?.status, "needs_human");
+
+    db.close();
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("TRANSIENT_PARK_STATUSES excludes human-gated statuses", async () => {
+  const { TRANSIENT_PARK_STATUSES } = await import("../dist/scheduler/worker.js");
+  assert.ok(TRANSIENT_PARK_STATUSES.has("error"));
+  assert.ok(TRANSIENT_PARK_STATUSES.has("dirty"));
+  assert.ok(!TRANSIENT_PARK_STATUSES.has("guardrail_blocked"));
+  assert.ok(!TRANSIENT_PARK_STATUSES.has("needs_human"));
+  assert.ok(!TRANSIENT_PARK_STATUSES.has("no_changes"));
+});
+
 test("queue: dequeue picks high priority then earliest due, marks running", async () => {
   const tmp = mkdtempSync(join(tmpdir(), "aidev-queue-"));
   try {


### PR DESCRIPTION
🤖 openronin: автоматический PR.

Closes #83.

This PR was opened automatically by [openronin](https://github.com/openronin/openronin) in response to issue #83.

## Agent summary

## Summary

**Problem:** When the `patch` lane threw an exception, it recorded `pr_branches.status='error'`. This status was in `TERMINAL_BRANCH_STATUSES`, so `pickLane` silently dropped re-enqueued tasks forever. Operators had no path to recovery except hand-editing SQLite.

**Fix — three files changed:**

### `src/scheduler/worker.ts`
- Exported `TRANSIENT_PARK_STATUSES = new Set(["error", "dirty"])` — statuses caused by infra/agent failure.
- Shrunk `TERMINAL_BRANCH_STATUSES` to only human-gated statuses: `guardrail_blocked`, `no_changes`, `needs_human`.
- Updated the `pickLane` comment to describe the new two-cohort model.

### `src/storage/pr-branches.ts`
- Added `liftTransientPark(db, taskId): boolean` — runs a single `UPDATE … SET status = 'cancelled' WHERE status IN ('error', 'dirty')` and returns whether any row was changed.

### `src/server/webhooks.ts`
- Added import for `liftTransientPark`.
- In the GitHub webhook handler, after the bot self-event check, calls `liftTransientPark` when `candidateBody` is non-empty and `kind === "issue"`. Label/edit events have no body text, so the bot's own label removal after a failure cannot cause a re-run loop. A `console.log` line records each lift.

### `test/scheduler.test.mjs`
- Two new tests: one verifying `liftTransientPark` lifts `error`/`dirty` to `cancelled` and leaves `guardrail_blocked`/`needs_human` untouched; one verifying `TRANSIENT_PARK_STATUSES` contains exactly the right members.

**Tests:** 184 passed, 0 failed. `pnpm run check` clean (build + lint + test:unit + format).

## Diff stats

- Files changed: 4
- Lines: +93 / -19

---
*Marked as draft for human review. The agent (claude_code) wrote this; please review before merging.*