### PR TITLE
[openronin] Observability: видимость живых и зависших runs в admin UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,12 @@ TELEGRAM_BOT_TOKEN=
 #   mimo      → mimo-v2.5-pro
 # OPENRONIN_DIRECTOR_THINK_MODEL=claude-sonnet-4-6
 
+# ── Observability ──────────────────────────────────────────────────────────
+# Runs with status='running' that stay active longer than this many minutes are
+# highlighted as "stale" in the admin UI (/admin/logs, dashboard worker cards).
+# Default: 30 minutes.
+# OPENRONIN_STALE_RUN_THRESHOLD_MINUTES=30
+
 # ── Backups (optional) ─────────────────────────────────────────────────────
 # rsync destination for daily off-host backups. See deploy/openronin-backup-*
 # systemd units. Format: user@remote:/path/to/dest

--- a/src/server/admin.ts
+++ b/src/server/admin.ts
@@ -228,10 +228,21 @@ export function adminRoute({ db, getConfig, scheduler, startedAt }: Args): Hono 
         const kickBtn =
           `<button type="button" hx-post="/admin/api/drain-now" hx-target="#dash-flash" hx-swap="innerHTML"` +
           ` class="btn btn-ghost btn-sm px-2 ml-1" title="Drain queue now">↻</button>`;
+        const busyAge =
+          w.busy && w.lastStartedAt
+            ? (() => {
+                const age = runAge(w.lastStartedAt);
+                const stale = isStaleRun(w.lastStartedAt);
+                return (
+                  `<span class="text-xs ${stale ? "text-yellow-600 font-semibold" : "text-blue-600"}" title="drain started ${escapeHtml(w.lastStartedAt)}">` +
+                  `${escapeHtml(age)}${stale ? " stale" : ""}</span>`
+                );
+              })()
+            : "";
         return (
           `<li class="flex items-center gap-2 py-1.5 border-b border-subtle last:border-0">` +
           `${dot}<code class="text-xs flex-1 min-w-0 truncate">${escapeHtml(w.repoKey)}</code>` +
-          `${lastTs}${kickBtn}</li>`
+          `${busyAge}${lastTs}${kickBtn}</li>`
         );
       })
       .join("");
@@ -735,7 +746,16 @@ export function adminRoute({ db, getConfig, scheduler, startedAt }: Args): Hono 
                 <td class="px-3 py-2 text-xs">${r.lane}</td>
                 <td class="px-3 py-2 text-xs text-muted">${r.engine}/${r.model ?? "?"}</td>
                 <td class="px-3 py-2">
-                  ${badge({ label: r.status, tone: runStatusTone(r.status) })}
+                  ${r.status === "running"
+                    ? html`${badge({
+                          label: r.status,
+                          tone: isStaleRun(r.started_at) ? "warning" : "info",
+                        })}
+                        <span class="text-xs text-muted ml-1">for ${runAge(r.started_at)}</span
+                        >${isStaleRun(r.started_at)
+                          ? raw(' <span class="text-xs font-semibold text-yellow-600">stale</span>')
+                          : raw("")}`
+                    : badge({ label: r.status, tone: runStatusTone(r.status) })}
                 </td>
                 <td class="px-3 py-2 text-xs text-muted">
                   ${r.tokens_in ?? "—"}/${r.tokens_out ?? "—"}
@@ -3166,7 +3186,17 @@ ${decisionPretty}</pre
                 <td class="px-2 py-2 text-xs">${r.lane}</td>
                 <td class="px-2 py-2 text-xs">${r.engine}/${r.model ?? "?"}</td>
                 <td class="px-2 py-2">
-                  ${badge({ label: r.status, tone: runStatusTone(r.status) })}
+                  ${r.status === "running"
+                    ? html`${badge({
+                          label: r.status,
+                          tone: isStaleRun(r.started_at) ? "warning" : "info",
+                        })}
+                        <span class="text-xs text-muted ml-1" title="started ${r.started_at}"
+                          >for ${runAge(r.started_at)}</span
+                        >${isStaleRun(r.started_at)
+                          ? raw(' <span class="text-xs font-semibold text-yellow-600">stale</span>')
+                          : raw("")}`
+                    : badge({ label: r.status, tone: runStatusTone(r.status) })}
                 </td>
                 <td class="px-2 py-2 text-xs">${r.repo ?? "—"}</td>
                 <td class="px-2 py-2 text-xs whitespace-nowrap">
@@ -4401,6 +4431,19 @@ function runStatusTone(status: string): BadgeTone {
   if (status === "running") return "info";
   if (status === "error") return "danger";
   return "neutral";
+}
+
+function runAge(startedAt: string): string {
+  const sec = Math.max(0, Math.floor((Date.now() - parseSqliteUtc(startedAt).getTime()) / 1000));
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+function isStaleRun(startedAt: string): boolean {
+  const thresholdMs =
+    parseInt(process.env.OPENRONIN_STALE_RUN_THRESHOLD_MINUTES ?? "30", 10) * 60_000;
+  return Date.now() - parseSqliteUtc(startedAt).getTime() > thresholdMs;
 }
 
 function taskStatusClass(status: string): string {


### PR DESCRIPTION
🤖 openronin: автоматический PR.

Closes #86.

This PR was opened automatically by [openronin](https://github.com/openronin/openronin) in response to issue #86.

## Agent summary

`pnpm run check` green (184/184 tests). Working tree clean.

---

## Summary

### What changed

**`src/server/admin.ts`** — two new module-level helpers + three UI call sites:

- `runAge(startedAt)` — computes a human-readable "Nm Ss" duration from a SQLite UTC timestamp to now using the existing `parseSqliteUtc()`.
- `isStaleRun(startedAt)` — returns `true` if the run has been active longer than `OPENRONIN_STALE_RUN_THRESHOLD_MINUTES` (default 30 min).
- **`/logs` table rows** — for `status='running'` rows, the status cell now renders `running` badge (warning-tone if stale) + "for Nm Ss" + "stale" label.
- **Dashboard recent-runs table** — same treatment for the `status` column.
- **`/api/workers` panel** — busy workers now show how long the drain worker has been running (with stale colouring).

**`.env.example`** — new `OPENRONIN_STALE_RUN_THRESHOLD_MINUTES` entry (commented-out, default 30) under a new `── Observability` section.

### What was already done

`recoverStuckTasks()` in `src/scheduler/index.ts` already writes `[crash recovery: orphaned run, process exited mid-call]` into `runs.error` for every orphaned run it closes. That text is rendered in the existing error sub-row beneath each run in `/admin/logs`, so recovered runs are already distinguishable — no change needed there.

### Tests

- `pnpm run check`: build ✓ · lint ✓ · 184 unit tests ✓ · format ✓

## Diff stats

- Files changed: 2
- Lines: +52 / -3

---
*Marked as draft for human review. The agent (claude_code) wrote this; please review before merging.*