### PR TITLE
[openronin] Observability: метрика latency per lane (+ явный error rate по lane)

### DIFF
--- a/src/server/admin.ts
+++ b/src/server/admin.ts
@@ -22,6 +22,8 @@ import {
   getTasksPerDay,
   getSuccessRateByLane,
   getAvgLatencyByModel,
+  getAvgLatencyByLane,
+  getErrorRateByLane,
   getTokensPerDay,
 } from "../storage/runs.js";
 import { listPendingJiraTasks, listPendingTodoistTasks } from "../storage/tasks.js";
@@ -3001,6 +3003,8 @@ ${decisionPretty}</pre
       tasksPerDay: getTasksPerDay(db, since30d),
       successRate: getSuccessRateByLane(db, since12w),
       latency: getAvgLatencyByModel(db, since30d),
+      latencyByLane: getAvgLatencyByLane(db, since30d),
+      errorRateByLane: getErrorRateByLane(db, since30d),
       tokens: getTokensPerDay(db, since30d),
     });
   });
@@ -3027,6 +3031,47 @@ ${decisionPretty}</pre
           Success rate by lane (per week, last 12 weeks)
         </h2>
         <canvas id="chart-success-rate"></canvas>
+      </div>
+
+      <div class="grid grid-cols-2 gap-6 mb-6">
+        <div class="bg-elevated rounded shadow-sm border">
+          <h2 class="text-sm font-semibold px-3 py-2 border-b bg-surface">
+            Avg latency by lane (last 30 days)
+          </h2>
+          <table class="w-full text-sm">
+            <thead class="text-left text-muted text-xs bg-surface">
+              <tr>
+                <th class="px-3 py-2">Lane</th>
+                <th class="px-3 py-2">Avg duration</th>
+                <th class="px-3 py-2">Runs</th>
+              </tr>
+            </thead>
+            <tbody id="latency-lane-table">
+              <tr>
+                <td colspan="3" class="px-3 py-4 text-muted text-xs">Loading…</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="bg-elevated rounded shadow-sm border">
+          <h2 class="text-sm font-semibold px-3 py-2 border-b bg-surface">
+            Error rate by lane (last 30 days)
+          </h2>
+          <table class="w-full text-sm">
+            <thead class="text-left text-muted text-xs bg-surface">
+              <tr>
+                <th class="px-3 py-2">Lane</th>
+                <th class="px-3 py-2">Error rate</th>
+                <th class="px-3 py-2">Total runs</th>
+              </tr>
+            </thead>
+            <tbody id="error-rate-table">
+              <tr>
+                <td colspan="3" class="px-3 py-4 text-muted text-xs">Loading…</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
 
       <div class="bg-elevated rounded shadow-sm border mb-6">
@@ -3107,6 +3152,32 @@ ${decisionPretty}</pre
           }
         }
       });
+
+      var laneLatTbody = document.getElementById('latency-lane-table');
+      if (!d.latencyByLane.length) {
+        laneLatTbody.innerHTML = '<tr><td colspan="3" class="px-3 py-4 text-muted text-xs">no data</td></tr>';
+      } else {
+        laneLatTbody.innerHTML = d.latencyByLane.map(function(r) {
+          var secs = r.avg_seconds != null ? r.avg_seconds.toFixed(1) + 's' : '—';
+          return '<tr class="border-t">' +
+            '<td class="px-3 py-2 text-sm font-mono">' + r.lane + '</td>' +
+            '<td class="px-3 py-2 text-sm font-mono">' + secs + '</td>' +
+            '<td class="px-3 py-2 text-sm text-muted">' + r.runs + '</td></tr>';
+        }).join('');
+      }
+
+      var errTbody = document.getElementById('error-rate-table');
+      if (!d.errorRateByLane.length) {
+        errTbody.innerHTML = '<tr><td colspan="3" class="px-3 py-4 text-muted text-xs">no data</td></tr>';
+      } else {
+        errTbody.innerHTML = d.errorRateByLane.map(function(r) {
+          var pct = r.error_rate != null ? (r.error_rate * 100).toFixed(1) + '%' : '—';
+          return '<tr class="border-t">' +
+            '<td class="px-3 py-2 text-sm font-mono">' + r.lane + '</td>' +
+            '<td class="px-3 py-2 text-sm font-mono">' + pct + '</td>' +
+            '<td class="px-3 py-2 text-sm text-muted">' + r.total + '</td></tr>';
+        }).join('');
+      }
 
       var tbody = document.getElementById('latency-table');
       if (!d.latency.length) {

--- a/src/storage/runs.ts
+++ b/src/storage/runs.ts
@@ -164,6 +164,42 @@ export interface LatencyRow {
   runs: number;
 }
 
+export interface LaneLatencyRow {
+  lane: string;
+  avg_seconds: number;
+  runs: number;
+}
+
+export function getAvgLatencyByLane(db: Db, sinceIso: string): LaneLatencyRow[] {
+  return db
+    .prepare(
+      `SELECT lane,
+              AVG((julianday(finished_at) - julianday(started_at)) * 86400) AS avg_seconds,
+              COUNT(*) AS runs
+       FROM runs WHERE finished_at IS NOT NULL AND started_at >= ?
+       GROUP BY lane ORDER BY avg_seconds DESC`,
+    )
+    .all(sinceIso) as LaneLatencyRow[];
+}
+
+export interface LaneErrorRateRow {
+  lane: string;
+  error_rate: number;
+  total: number;
+}
+
+export function getErrorRateByLane(db: Db, sinceIso: string): LaneErrorRateRow[] {
+  return db
+    .prepare(
+      `SELECT lane,
+              SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) * 1.0 / COUNT(*) AS error_rate,
+              COUNT(*) AS total
+       FROM runs WHERE started_at >= ?
+       GROUP BY lane ORDER BY error_rate DESC`,
+    )
+    .all(sinceIso) as LaneErrorRateRow[];
+}
+
 export function getAvgLatencyByModel(db: Db, sinceIso: string): LatencyRow[] {
   return db
     .prepare(

--- a/test/runs-latency.test.mjs
+++ b/test/runs-latency.test.mjs
@@ -1,0 +1,112 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+test("getAvgLatencyByLane: groups by lane, excludes running rows", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "aidev-latency-"));
+  try {
+    const { initDb } = await import("../dist/storage/db.js");
+    const { ensureRepo, upsertTask } = await import("../dist/storage/tasks.js");
+    const { createRun, getAvgLatencyByLane } = await import("../dist/storage/runs.js");
+
+    const db = initDb(tmp);
+    const repoId = ensureRepo(db, { provider: "github", owner: "o", name: "n" });
+    const taskId = upsertTask(db, repoId, "1", "issue");
+
+    // Insert a completed patch run (~10 s) via raw SQL for precise timing control
+    db.prepare(
+      `INSERT INTO runs (task_id, lane, engine, started_at, finished_at, status)
+       VALUES (?, 'patch', 'claude_code', '2026-05-29T10:00:00Z', '2026-05-29T10:00:10Z', 'ok')`,
+    ).run(taskId);
+
+    // Insert another completed patch run (~20 s)
+    db.prepare(
+      `INSERT INTO runs (task_id, lane, engine, started_at, finished_at, status)
+       VALUES (?, 'patch', 'claude_code', '2026-05-29T10:01:00Z', '2026-05-29T10:01:20Z', 'ok')`,
+    ).run(taskId);
+
+    // Insert a triage run (~5 s)
+    db.prepare(
+      `INSERT INTO runs (task_id, lane, engine, started_at, finished_at, status)
+       VALUES (?, 'triage', 'mimo', '2026-05-29T10:00:00Z', '2026-05-29T10:00:05Z', 'ok')`,
+    ).run(taskId);
+
+    // Insert a running row (finished_at IS NULL) — must be excluded from latency
+    db.prepare(
+      `INSERT INTO runs (task_id, lane, engine, started_at, finished_at, status)
+       VALUES (?, 'patch', 'claude_code', '2026-05-29T10:02:00Z', NULL, 'running')`,
+    ).run(taskId);
+
+    const since = "2026-01-01T00:00:00Z";
+    const rows = getAvgLatencyByLane(db, since);
+
+    // patch: avg of 10 and 20 = 15 s
+    const patch = rows.find((r) => r.lane === "patch");
+    assert.ok(patch, "patch lane present");
+    assert.ok(Math.abs(patch.avg_seconds - 15) < 0.5, `patch avg ~15s, got ${patch.avg_seconds}`);
+    assert.equal(patch.runs, 2, "running row excluded");
+
+    // triage: 5 s
+    const triage = rows.find((r) => r.lane === "triage");
+    assert.ok(triage, "triage lane present");
+    assert.ok(Math.abs(triage.avg_seconds - 5) < 0.5, `triage avg ~5s, got ${triage.avg_seconds}`);
+    assert.equal(triage.runs, 1);
+
+    db.close();
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("getErrorRateByLane: computes error_rate per lane", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "aidev-errrate-"));
+  try {
+    const { initDb } = await import("../dist/storage/db.js");
+    const { ensureRepo, upsertTask } = await import("../dist/storage/tasks.js");
+    const { getErrorRateByLane } = await import("../dist/storage/runs.js");
+
+    const db = initDb(tmp);
+    const repoId = ensureRepo(db, { provider: "github", owner: "o", name: "n" });
+    const taskId = upsertTask(db, repoId, "2", "issue");
+
+    // patch: 1 ok + 1 error → 50%
+    db.prepare(
+      `INSERT INTO runs (task_id, lane, engine, started_at, status)
+       VALUES (?, 'patch', 'claude_code', '2026-05-29T10:00:00Z', 'ok')`,
+    ).run(taskId);
+    db.prepare(
+      `INSERT INTO runs (task_id, lane, engine, started_at, status)
+       VALUES (?, 'patch', 'claude_code', '2026-05-29T10:01:00Z', 'error')`,
+    ).run(taskId);
+
+    // triage: 3 ok → 0%
+    for (let i = 0; i < 3; i++) {
+      db.prepare(
+        `INSERT INTO runs (task_id, lane, engine, started_at, status)
+         VALUES (?, 'triage', 'mimo', '2026-05-29T10:0${i}:00Z', 'ok')`,
+      ).run(taskId);
+    }
+
+    const since = "2026-01-01T00:00:00Z";
+    const rows = getErrorRateByLane(db, since);
+
+    const patch = rows.find((r) => r.lane === "patch");
+    assert.ok(patch, "patch lane present");
+    assert.ok(
+      Math.abs(patch.error_rate - 0.5) < 0.01,
+      `patch error_rate ~0.5, got ${patch.error_rate}`,
+    );
+    assert.equal(patch.total, 2);
+
+    const triage = rows.find((r) => r.lane === "triage");
+    assert.ok(triage, "triage lane present");
+    assert.equal(triage.error_rate, 0);
+    assert.equal(triage.total, 3);
+
+    db.close();
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
🤖 openronin: автоматический PR.

Closes #88.

This PR was opened automatically by [openronin](https://github.com/openronin/openronin) in response to issue #88.

## Agent summary

The working tree is clean and the commit is in place. Here's a summary of what was done:

---

## Summary

**What changed**

### `src/storage/runs.ts`
- Added `LaneLatencyRow` interface and `getAvgLatencyByLane(db, sinceIso)` — queries `AVG((julianday(finished_at) - julianday(started_at)) * 86400)` grouped by `lane`, filtering `finished_at IS NOT NULL` so in-progress runs don't skew the average.
- Added `LaneErrorRateRow` interface and `getErrorRateByLane(db, sinceIso)` — queries `SUM(status='error') * 1.0 / COUNT(*)` grouped by `lane`, covering all runs (including running ones, which mirrors the existing success-rate query convention).

### `src/server/admin.ts`
- Imported the two new storage functions.
- Extended `/metrics/data.json` to include `latencyByLane` and `errorRateByLane` fields alongside the existing `latency`, `successRate`, `tasksPerDay`, and `tokens` fields.
- Added a two-column grid to the `/admin/metrics` page, rendered above the existing model-latency table:
  - **Avg latency by lane** — shows lane name, average duration in seconds, completed-run count.
  - **Error rate by lane** — shows lane name, error percentage (explicit, not inverted success rate), total run count.
- The tables are populated via the same `fetch('/admin/metrics/data.json')` call already present on the page.

### `test/runs-latency.test.mjs` *(new)*
Two unit tests using a fresh in-memory SQLite DB (via `initDb` from `dist/`):
1. `getAvgLatencyByLane` — verifies correct per-lane average, and that rows with `finished_at IS NULL` are excluded.
2. `getErrorRateByLane` — verifies 50 % rate for a lane with one `ok` + one `error`, and 0 % for an all-`ok` lane.

**Tests/lints run:** `pnpm run check` — build (tsc), lint (oxlint), 186 unit tests, format check (oxfmt) — all green.

## Diff stats

- Files changed: 3
- Lines: +219 / -0

---
*Marked as draft for human review. The agent (claude_code) wrote this; please review before merging.*