### PR TITLE
[openronin] Add structured logging and run timeline to admin UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to **openronin** are documented here. The format follows [Ke
 
 ## [Unreleased]
 
+### Observability — run timeline API and task-filter in logs UI (issue #38)
+
+- **`GET /api/runs`** — new REST endpoint for programmatic access to run logs. Supports filtering by `task_id`, `lane`, `status`, `repo`, `dateFrom`, `dateTo`, `limit`, and `offset`. Returns `{ runs, total, limit, offset }` so clients can paginate. Requires bearer token (`OPENRONIN_API_TOKEN`).
+- **`GET /api/runs/:id`** — fetch a single run record by ID.
+- **Task ID filter in `/admin/logs`** — a new "Task ID" numeric input in the logs filter bar lets operators jump directly to all runs for a specific task without navigating through the task detail page.
+- **`RunFilter.taskId`** — the underlying `listRunsFiltered` / `countRunsFiltered` storage helpers now support filtering by task ID.
+
 ### Patch lane — cost reduction (issue #30)
 
 - **Lower `per_task_usd` default** from `$5.00` to `$0.50`. Claude Code's `--max-budget-usd` flag enforces this inside the binary, so a runaway agent loop (the root cause of the $2–$3 runs) cannot spend more than the cap per issue.

--- a/src/server/admin.ts
+++ b/src/server/admin.ts
@@ -3205,7 +3205,10 @@ ${decisionPretty}</pre
   // -------- Logs (run viewer) --------
   app.get("/logs", (c) => {
     const qp = (key: string) => c.req.query(key);
+    const taskIdRaw = qp("taskId");
+    const taskIdNum = taskIdRaw ? parseInt(taskIdRaw, 10) : undefined;
     const filter = {
+      taskId: taskIdNum != null && !isNaN(taskIdNum) ? taskIdNum : undefined,
       lane: qp("lane") || undefined,
       engine: qp("engine") || undefined,
       model: qp("model") || undefined,
@@ -3215,6 +3218,7 @@ ${decisionPretty}</pre
       dateTo: qp("dateTo") || undefined,
       errorSearch: qp("errorSearch") || undefined,
     };
+    const filterStr = { ...filter, taskId: taskIdRaw || undefined };
     const page_ = Math.max(1, parseInt(qp("page") ?? "1", 10) || 1);
     const limit = 50;
     const offset = (page_ - 1) * limit;
@@ -3223,7 +3227,7 @@ ${decisionPretty}</pre
     const rows = hasMore ? runs.slice(0, limit) : runs;
     const distincts = getRunDistincts(db);
     const htmx = isHtmx(c.req.raw.headers);
-    const hasFilter = Object.values(filter).some(Boolean);
+    const hasFilter = Object.values(filterStr).some(Boolean);
 
     const selOpts = (list: string[], current: string | undefined, all = "all") =>
       raw(
@@ -3319,7 +3323,7 @@ ${decisionPretty}</pre
       <div class="flex gap-3 items-center mt-3 text-sm">
         ${page_ > 1
           ? html`<a
-              href="/admin/logs?${buildQueryString({ ...filter, page: String(page_ - 1) })}"
+              href="/admin/logs?${buildQueryString({ ...filterStr, page: String(page_ - 1) })}"
               class="text-brand hover:underline"
               >&larr; prev</a
             >`
@@ -3327,7 +3331,7 @@ ${decisionPretty}</pre
         <span class="text-muted">page ${page_}</span>
         ${hasMore
           ? html`<a
-              href="/admin/logs?${buildQueryString({ ...filter, page: String(page_ + 1) })}"
+              href="/admin/logs?${buildQueryString({ ...filterStr, page: String(page_ + 1) })}"
               class="text-brand hover:underline"
               >next &rarr;</a
             >`
@@ -3450,6 +3454,22 @@ ${decisionPretty}</pre
         <div class="flex flex-col gap-1">
           <label class="form-label">To</label>
           <input type="date" name="dateTo" value="${filter.dateTo ?? ""}" class="form-input" />
+        </div>
+        <div class="flex flex-col gap-1 w-24">
+          <label class="form-label">Task ID</label>
+          <input
+            type="number"
+            name="taskId"
+            value="${taskIdRaw ?? ""}"
+            placeholder="e.g. 42"
+            class="form-input"
+            hx-get="/admin/logs"
+            hx-include="closest form"
+            hx-target="#logs-table-wrap"
+            hx-swap="outerHTML"
+            hx-push-url="true"
+            hx-trigger="input changed delay:400ms"
+          />
         </div>
         <div class="flex flex-col gap-1 flex-1 min-w-36">
           <label class="form-label">Error search</label>

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -9,6 +9,9 @@ import {
   getCostGroupedByEngine,
   getCostGroupedByRepo,
   getCostUsdSince,
+  listRunsFiltered,
+  countRunsFiltered,
+  getRunById,
 } from "../storage/runs.js";
 import { GithubVcsProvider } from "../providers/github.js";
 import { isPaused } from "../lib/pause.js";
@@ -249,6 +252,40 @@ export function apiRoute({ db, getConfig }: Args): Hono {
       by_engine: getCostGroupedByEngine(db, iso),
       by_repo: getCostGroupedByRepo(db, iso),
     });
+  });
+
+  // GET /api/runs?lane=&status=&task_id=&repo=&dateFrom=&dateTo=&limit=&offset=
+  app.get("/runs", (c) => {
+    const taskIdRaw = c.req.query("task_id");
+    const taskId = taskIdRaw ? parseInt(taskIdRaw, 10) : undefined;
+    const limit = Math.min(parseInt(c.req.query("limit") ?? "50") || 50, 200);
+    const offset = Math.max(0, parseInt(c.req.query("offset") ?? "0") || 0);
+    const filter = {
+      taskId: taskId != null && !isNaN(taskId) ? taskId : undefined,
+      lane: c.req.query("lane") || undefined,
+      status: c.req.query("status") || undefined,
+      repo: c.req.query("repo") || undefined,
+      dateFrom: c.req.query("dateFrom") || undefined,
+      dateTo: c.req.query("dateTo") || undefined,
+      limit,
+      offset,
+    };
+    const runs = listRunsFiltered(db, filter);
+    const total = countRunsFiltered(db, filter);
+    return c.json({ runs, total, limit, offset });
+  });
+
+  // GET /api/runs/:id
+  app.get("/runs/:id", (c) => {
+    const id = parseInt(c.req.param("id"), 10);
+    if (isNaN(id)) {
+      return c.json({ error: { code: "bad_request", message: "Invalid run id" } }, 400);
+    }
+    const run = getRunById(db, id);
+    if (!run) {
+      return c.json({ error: { code: "not_found", message: "Run not found" } }, 404);
+    }
+    return c.json({ run });
   });
 
   // POST /api/issues

--- a/src/storage/runs.ts
+++ b/src/storage/runs.ts
@@ -231,6 +231,7 @@ export function getTokensPerDay(db: Db, sinceIso: string): TokensPerDay[] {
 }
 
 export interface RunFilter {
+  taskId?: number;
   lane?: string;
   engine?: string;
   model?: string;
@@ -250,6 +251,10 @@ export interface RunRowWithRepo extends RunRow {
 function buildRunFilter(filter: RunFilter): { where: string; params: (string | number)[] } {
   const conditions: string[] = [];
   const params: (string | number)[] = [];
+  if (filter.taskId != null) {
+    conditions.push("ru.task_id = ?");
+    params.push(filter.taskId);
+  }
   if (filter.lane) {
     conditions.push("ru.lane = ?");
     params.push(filter.lane);
@@ -303,6 +308,20 @@ export function listRunsFiltered(db: Db, filter: RunFilter): RunRowWithRepo[] {
        LIMIT ? OFFSET ?`,
     )
     .all(...params, limit, offset) as RunRowWithRepo[];
+}
+
+export function countRunsFiltered(db: Db, filter: RunFilter): number {
+  const { where, params } = buildRunFilter(filter);
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) AS n
+       FROM runs ru
+       LEFT JOIN tasks t ON t.id = ru.task_id
+       LEFT JOIN repos r ON r.id = t.repo_id
+       ${where}`,
+    )
+    .get(...params) as { n: number };
+  return row.n;
 }
 
 export interface RunDistincts {

--- a/test/runs-filter.test.mjs
+++ b/test/runs-filter.test.mjs
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+test("listRunsFiltered: taskId filter returns only matching task runs", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "aidev-runs-filter-"));
+  try {
+    const { initDb } = await import("../dist/storage/db.js");
+    const { ensureRepo, upsertTask } = await import("../dist/storage/tasks.js");
+    const { listRunsFiltered, countRunsFiltered } = await import("../dist/storage/runs.js");
+
+    const db = initDb(tmp);
+    const repoId = ensureRepo(db, { provider: "github", owner: "o", name: "n" });
+    const taskA = upsertTask(db, repoId, "10", "issue");
+    const taskB = upsertTask(db, repoId, "11", "issue");
+
+    db.prepare(
+      `INSERT INTO runs (task_id, lane, engine, started_at, status)
+       VALUES (?, 'patch', 'claude_code', '2026-05-29T10:00:00Z', 'ok')`,
+    ).run(taskA);
+    db.prepare(
+      `INSERT INTO runs (task_id, lane, engine, started_at, status)
+       VALUES (?, 'analyze', 'mimo', '2026-05-29T10:01:00Z', 'error')`,
+    ).run(taskA);
+    db.prepare(
+      `INSERT INTO runs (task_id, lane, engine, started_at, status)
+       VALUES (?, 'triage', 'mimo', '2026-05-29T10:02:00Z', 'ok')`,
+    ).run(taskB);
+
+    const rowsA = listRunsFiltered(db, { taskId: taskA });
+    assert.equal(rowsA.length, 2, "taskA has 2 runs");
+    assert.ok(
+      rowsA.every((r) => r.task_id === taskA),
+      "all rows belong to taskA",
+    );
+
+    const rowsB = listRunsFiltered(db, { taskId: taskB });
+    assert.equal(rowsB.length, 1, "taskB has 1 run");
+    assert.equal(rowsB[0].lane, "triage");
+
+    const countA = countRunsFiltered(db, { taskId: taskA });
+    assert.equal(countA, 2, "countRunsFiltered returns 2 for taskA");
+
+    const errorOnly = listRunsFiltered(db, { taskId: taskA, status: "error" });
+    assert.equal(errorOnly.length, 1, "taskA error-only: 1 run");
+    assert.equal(errorOnly[0].lane, "analyze");
+
+    db.close();
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
🤖 openronin: автоматический PR.

Closes #38.

This PR was opened automatically by [openronin](https://github.com/openronin/openronin) in response to issue #38.

## Agent summary

All done. Here's a summary of what was implemented:

---

## Summary

**Issue #38 — Add structured logging and run timeline to admin UI**

Most of the acceptance criteria were already met by prior commits (#85, #87, #89): structured JSONL logs written per run, `/admin/logs` with expandable entries and lane/status/time filtering, errors visible without SSH, metrics with latency per lane and error rate per lane. The remaining gap was a **programmatic REST API** for run data.

### Changes made

**`src/storage/runs.ts`**
- Added `taskId?: number` to `RunFilter` — lets callers filter runs by their owning task
- Added `countRunsFiltered()` — returns the total matching row count for pagination

**`src/server/api.ts`**
- `GET /api/runs` — filterable run list (`task_id`, `lane`, `status`, `repo`, `dateFrom`, `dateTo`, `limit`, `offset`). Returns `{ runs, total, limit, offset }`. Bearer-token protected like all `/api/*` routes.
- `GET /api/runs/:id` — fetch a single run record by ID

**`src/server/admin.ts`**
- Added a **Task ID** numeric input to the `/admin/logs` filter bar. Changing it HTMX-refreshes the table, pushing URL state — operators can deep-link to all runs for a specific task.

**`test/runs-filter.test.mjs`** — unit test covering `taskId` filter and `countRunsFiltered`

**`CHANGELOG.md`** — documented new endpoints under `[Unreleased]`

### Verification
- `pnpm run check` green: build ✓, lint ✓ (warnings pre-existing), 187/187 tests pass (including new test #170), format ✓

## Diff stats

- Files changed: 5
- Lines: +140 / -3

---
*Marked as draft for human review. The agent (claude_code) wrote this; please review before merging.*