### PR TITLE
fix: use bypassPermissions for git-write and read-write tool policies

### DIFF
--- a/src/engines/claude-code.ts
+++ b/src/engines/claude-code.ts
@@ -163,7 +163,7 @@ function mapPermission(policy: NonNullable<EngineRunOptions["tools"]>): string {
   switch (policy) {
     case "read-write":
     case "git-write":
-      return "acceptEdits";
+      return "bypassPermissions";
     default:
       return "default";
   }


### PR DESCRIPTION
## Problem

When `patch` or `pr_dialog` lanes run Claude Code with `tools: "git-write"`, the engine maps this to `--permission-mode acceptEdits`. This mode allows file edits but **blocks bash commands** — so `git add` and `git commit` calls are denied with permission errors.

## Reproducer

A `pr_dialog` run completed successfully (21 turns, \$0.84) and wrote all file changes to the worktree, but every `git add` / `git commit` attempt hit a `permission_denial`. The PR was never updated; only an emoji reaction was posted.

Log excerpt (`permission_denials` array in the run's `raw_response`):
```
{"tool_name":"Bash","tool_input":{"command":"git add app/src/Kernel.php ..."}}
{"tool_name":"Bash","tool_input":{"command":"git commit -m ..."}}
```
(7 denials total across multiple retry attempts)

## Fix

Map `git-write` and `read-write` to `bypassPermissions` instead of `acceptEdits`. This is equivalent to `--dangerously-skip-permissions` and grants full shell access, which is required for git operations inside the isolated worktree.

The worktree is already sandboxed (ephemeral clone, separate from the host system), so bypassing permission prompts there is the intended behavior.

## Test

After this fix, `patch` and `pr_dialog` lanes can `git add` / `git commit` / `git push` without prompts.