### PR TITLE
[openronin] Improve crash recovery and graceful shutdown handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to **openronin** are documented here. The format follows [Ke
 
 ## [Unreleased]
 
+### Reliability — crash recovery audit and richer healthz (issue #39)
+
+- **Recovery audit file.** Every boot, `recoverStuckTasks` now writes a small JSON summary to `$OPENRONIN_DATA_DIR/recovery/last.json` (atomic write-then-rename) capturing `ts`, `recovered`, per-table counts (`tasks`, `runs`, `deploys`), and a `clean_shutdown` flag. The healthz endpoint reads it back so external monitors can answer "what did the last boot recover?" without poking the DB.
+- **`GET /healthz` enriched.** Response gains `active_runs` (rows in `runs.status='running'`), `queued_runs` (due tasks per `queueStats`), and a `last_recovery` block exposing the audit above with an `age_sec` field. The endpoint now returns HTTP **503** when the DB query fails (`status: "down"`); the OK path remains 200 with `status: "ok"`. Internal helpers around it are factored out as `buildHealthz()` so tests can assert response shape directly.
+- The existing SIGTERM/SIGINT graceful shutdown (`scheduler.stop`) and the `recoverStuckTasks` startup sweep (which resets orphaned `runs`/`tasks`/`deploys` rows and abandons tasks that crash-loop 3× in a row) are unchanged — this change makes their outcomes visible.
+
 ### Observability — run timeline API and task-filter in logs UI (issue #38)
 
 - **`GET /api/runs`** — new REST endpoint for programmatic access to run logs. Supports filtering by `task_id`, `lane`, `status`, `repo`, `dateFrom`, `dateTo`, `limit`, and `offset`. Returns `{ runs, total, limit, offset }` so clients can paginate. Requires bearer token (`OPENRONIN_API_TOKEN`).

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -3,6 +3,7 @@ import type { RuntimeConfig } from "../config/schema.js";
 import { reconcileRepo, reconcileJiraTracker, type ReconcileResult } from "./reconcile.js";
 import { drainRepo, type WorkResult } from "./worker.js";
 import { ensureRepo } from "../storage/tasks.js";
+import { writeRecoveryReport } from "../storage/recovery.js";
 
 export interface SchedulerOptions {
   reconcileIntervalMs: number;
@@ -50,7 +51,10 @@ export interface SchedulerHandle {
 // Also close orphaned runs: when SIGTERM kills mid-engine-call, finishRun()
 // never gets a chance to flip the row to ok/error, so it stays 'running'
 // forever and confuses /admin and cost dashboards.
-export function recoverStuckTasks(db: Db): { tasks: number; runs: number; deploys: number } {
+export function recoverStuckTasks(
+  db: Db,
+  opts: { dataDir?: string } = {},
+): { tasks: number; runs: number; deploys: number } {
   // First: any task with 3+ accumulated 'crash recovery' stamps in last_error
   // is being killed every time it tries to start. Stop the loop — abandon
   // it with a far-future next_due_at and a 'done' status. Operator can
@@ -106,15 +110,32 @@ export function recoverStuckTasks(db: Db): { tasks: number; runs: number; deploy
   } catch {
     // deploys table may not exist on very old schemas; ignore.
   }
-  if (
+  const anyRecovered =
     abandoned.changes > 0 ||
     recoveredTasks.changes > 0 ||
     recoveredRuns.changes > 0 ||
-    recoveredDeploys.changes > 0
-  ) {
+    recoveredDeploys.changes > 0;
+  if (anyRecovered) {
     console.log(
       `[recovery] abandoned ${abandoned.changes}, reset ${recoveredTasks.changes} task(s) running→pending, ${recoveredRuns.changes} run(s) running→error, ${recoveredDeploys.changes} deploy(s) running→error`,
     );
+  }
+  // Persist a small audit so the operator (and /healthz) can answer
+  // "did the last boot recover anything?" without re-querying the tables
+  // (which the recovery pass itself just rewrote).
+  if (opts.dataDir) {
+    try {
+      writeRecoveryReport(opts.dataDir, {
+        ts: new Date().toISOString(),
+        recovered: anyRecovered,
+        tasks: recoveredTasks.changes,
+        runs: recoveredRuns.changes,
+        deploys: recoveredDeploys.changes,
+        clean_shutdown: !anyRecovered,
+      });
+    } catch (error) {
+      console.error("[recovery] failed to write recovery report:", error);
+    }
   }
   return {
     tasks: recoveredTasks.changes,
@@ -129,7 +150,7 @@ export function startScheduler(
   options: Partial<SchedulerOptions> = {},
 ): SchedulerHandle {
   const opts = { ...DEFAULT_OPTIONS, ...options };
-  recoverStuckTasks(db);
+  recoverStuckTasks(db, { dataDir: getConfig().dataDir });
   let reconcileBusy = false;
   let stopped = false;
 

--- a/src/server/healthz.ts
+++ b/src/server/healthz.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import type { Db } from "../storage/db.js";
 import type { RuntimeConfig } from "../config/schema.js";
+import { readRecoveryReport, recoveryReportAgeSec } from "../storage/recovery.js";
+import { queueStats } from "../scheduler/queue.js";
 
 interface Args {
   db: Db;
@@ -8,26 +10,91 @@ interface Args {
   getConfig: () => RuntimeConfig;
 }
 
-export function healthzRoute({ db, startedAt, getConfig }: Args): Hono {
+interface RecoveryHealthBlock {
+  ts: string;
+  recovered: boolean;
+  clean_shutdown: boolean;
+  age_sec: number;
+  tasks: number;
+  runs: number;
+  deploys: number;
+}
+
+export interface HealthzResponse {
+  status: "ok" | "degraded" | "down";
+  version: string;
+  db_ok: boolean;
+  data_dir: string;
+  watched_repos: number;
+  uptime_s: number;
+  active_runs: number;
+  queued_runs: number;
+  last_recovery: RecoveryHealthBlock | null;
+  ts: string;
+}
+
+export function buildHealthz(args: Args): HealthzResponse {
+  const { db, startedAt, getConfig } = args;
+  let dbOk = false;
+  let activeRuns = 0;
+  let queuedRuns = 0;
+  try {
+    const row = db.prepare("SELECT 1 AS ok").get() as { ok: number };
+    dbOk = row.ok === 1;
+  } catch {
+    dbOk = false;
+  }
+  if (dbOk) {
+    try {
+      const running = db
+        .prepare("SELECT COUNT(*) AS n FROM runs WHERE status = 'running'")
+        .get() as { n: number };
+      activeRuns = running.n;
+    } catch {
+      // Fall through with active_runs=0 rather than failing health entirely.
+    }
+    try {
+      queuedRuns = queueStats(db).due;
+    } catch {
+      // Same — keep the endpoint responsive even if the count query trips.
+    }
+  }
+  const config = getConfig();
+  const report = readRecoveryReport(config.dataDir);
+  const recoveryBlock: RecoveryHealthBlock | null = report
+    ? {
+        ts: report.ts,
+        recovered: report.recovered,
+        clean_shutdown: report.clean_shutdown,
+        age_sec: recoveryReportAgeSec(report),
+        tasks: report.tasks,
+        runs: report.runs,
+        deploys: report.deploys,
+      }
+    : null;
+  return {
+    status: dbOk ? "ok" : "down",
+    version: "0.0.1",
+    db_ok: dbOk,
+    data_dir: config.dataDir,
+    watched_repos: config.repos.length,
+    uptime_s: Math.floor((Date.now() - startedAt) / 1000),
+    active_runs: activeRuns,
+    queued_runs: queuedRuns,
+    last_recovery: recoveryBlock,
+    ts: new Date().toISOString(),
+  };
+}
+
+export function healthzRoute(args: Args): Hono {
   const app = new Hono();
   app.get("/", (c) => {
-    let dbOk = false;
-    try {
-      const row = db.prepare("SELECT 1 AS ok").get() as { ok: number };
-      dbOk = row.ok === 1;
-    } catch {
-      dbOk = false;
-    }
-    const config = getConfig();
-    return c.json({
-      status: dbOk ? "ok" : "degraded",
-      version: "0.0.1",
-      db_ok: dbOk,
-      data_dir: config.dataDir,
-      watched_repos: config.repos.length,
-      uptime_s: Math.floor((Date.now() - startedAt) / 1000),
-      ts: new Date().toISOString(),
-    });
+    const body = buildHealthz(args);
+    // 503 only when the DB is genuinely unreachable. `degraded` is reserved
+    // for future signals (e.g. last_recovery younger than N seconds) — keep
+    // that path returning 200 so noisy boots don't trip external monitors.
+    const httpStatus = body.status === "down" ? 503 : 200;
+    return c.json(body, httpStatus);
   });
   return app;
 }

--- a/src/storage/recovery.ts
+++ b/src/storage/recovery.ts
@@ -1,0 +1,70 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Persisted summary of the last crash-recovery sweep. Lives outside the DB
+// so the healthz endpoint can answer "when did we last recover, and from
+// what?" without touching the live runs/tasks tables (which themselves get
+// rewritten on each boot's recovery pass). The file is small and atomically
+// replaced via write-then-rename so a SIGKILL mid-write can't corrupt it.
+export interface RecoveryReport {
+  // ISO timestamp the recovery sweep ran.
+  ts: string;
+  // Whether anything was actually recovered. False means a clean shutdown:
+  // no rows were in 'running' state at startup.
+  recovered: boolean;
+  // Counts mirror recoverStuckTasks return shape.
+  tasks: number;
+  runs: number;
+  deploys: number;
+  // Whether the previous shutdown looked clean from this side (no orphaned
+  // running rows of any kind). Mirrors `recovered === false` but kept
+  // explicit for readability of operators inspecting the file.
+  clean_shutdown: boolean;
+}
+
+function recoveryDir(dataDir: string): string {
+  return resolve(dataDir, "recovery");
+}
+
+function reportPath(dataDir: string): string {
+  return resolve(recoveryDir(dataDir), "last.json");
+}
+
+// Atomic write — render to a tmp sibling, then rename. SQLite's WAL plus
+// systemd's TimeoutStopSec can mean SIGKILL strikes mid-write; rename is
+// the only way to guarantee the operator never sees a half-written file.
+export function writeRecoveryReport(dataDir: string, report: RecoveryReport): string {
+  const dir = recoveryDir(dataDir);
+  mkdirSync(dir, { recursive: true });
+  const target = reportPath(dataDir);
+  const tmp = `${target}.tmp`;
+  writeFileSync(tmp, JSON.stringify(report, null, 2) + "\n", { mode: 0o644 });
+  renameSync(tmp, target);
+  return target;
+}
+
+export function readRecoveryReport(dataDir: string): RecoveryReport | null {
+  const path = reportPath(dataDir);
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = JSON.parse(raw) as Partial<RecoveryReport>;
+    if (typeof parsed.ts !== "string") return null;
+    return {
+      ts: parsed.ts,
+      recovered: Boolean(parsed.recovered),
+      tasks: Number(parsed.tasks ?? 0),
+      runs: Number(parsed.runs ?? 0),
+      deploys: Number(parsed.deploys ?? 0),
+      clean_shutdown: Boolean(parsed.clean_shutdown),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function recoveryReportAgeSec(report: RecoveryReport, now = Date.now()): number {
+  const t = Date.parse(report.ts);
+  if (Number.isNaN(t)) return -1;
+  return Math.max(0, Math.floor((now - t) / 1000));
+}

--- a/test/recovery.test.mjs
+++ b/test/recovery.test.mjs
@@ -1,0 +1,215 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+test("recovery report: write/read roundtrip + age calculation", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "aidev-recovery-"));
+  try {
+    const { writeRecoveryReport, readRecoveryReport, recoveryReportAgeSec } =
+      await import("../dist/storage/recovery.js");
+    const ts = new Date(Date.now() - 5000).toISOString();
+    const path = writeRecoveryReport(tmp, {
+      ts,
+      recovered: true,
+      tasks: 2,
+      runs: 1,
+      deploys: 0,
+      clean_shutdown: false,
+    });
+    assert.ok(existsSync(path), "report file written");
+
+    const back = readRecoveryReport(tmp);
+    assert.ok(back, "report read back");
+    assert.equal(back.ts, ts);
+    assert.equal(back.recovered, true);
+    assert.equal(back.tasks, 2);
+    assert.equal(back.runs, 1);
+    assert.equal(back.deploys, 0);
+    assert.equal(back.clean_shutdown, false);
+
+    const age = recoveryReportAgeSec(back);
+    assert.ok(age >= 4 && age <= 10, `age ~5s, got ${age}`);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("recovery report: read returns null when missing or malformed", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "aidev-recovery-"));
+  try {
+    const { readRecoveryReport } = await import("../dist/storage/recovery.js");
+    assert.equal(readRecoveryReport(tmp), null, "missing file → null");
+
+    // Write a malformed file
+    const { mkdirSync } = await import("node:fs");
+    const dir = resolve(tmp, "recovery");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, "last.json"), "{not json");
+    assert.equal(readRecoveryReport(tmp), null, "malformed file → null");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("recoverStuckTasks: writes a clean-shutdown report when nothing was running", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "aidev-recovery-"));
+  try {
+    const { initDb } = await import("../dist/storage/db.js");
+    const { recoverStuckTasks } = await import("../dist/scheduler/index.js");
+    const { readRecoveryReport } = await import("../dist/storage/recovery.js");
+    const db = initDb(tmp);
+    const result = recoverStuckTasks(db, { dataDir: tmp });
+    assert.equal(result.tasks, 0);
+    assert.equal(result.runs, 0);
+    assert.equal(result.deploys, 0);
+    const report = readRecoveryReport(tmp);
+    assert.ok(report, "report written even on clean boot");
+    assert.equal(report.recovered, false);
+    assert.equal(report.clean_shutdown, true);
+    db.close();
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("recoverStuckTasks: marks orphaned runs/tasks and reports counts", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "aidev-recovery-"));
+  try {
+    const { initDb } = await import("../dist/storage/db.js");
+    const { ensureRepo, upsertTask } = await import("../dist/storage/tasks.js");
+    const { recoverStuckTasks } = await import("../dist/scheduler/index.js");
+    const { readRecoveryReport } = await import("../dist/storage/recovery.js");
+    const { createRun } = await import("../dist/storage/runs.js");
+
+    const db = initDb(tmp);
+    const repoId = ensureRepo(db, { provider: "github", owner: "o", name: "n" });
+    const t = upsertTask(db, repoId, "1", "issue");
+    db.prepare("UPDATE tasks SET status = 'running' WHERE id = ?").run(t);
+    const runId = createRun(db, { taskId: t, lane: "patch", engine: "claude_code" });
+
+    const result = recoverStuckTasks(db, { dataDir: tmp });
+    assert.equal(result.tasks, 1, "one task reset");
+    assert.equal(result.runs, 1, "one run closed as error");
+    const report = readRecoveryReport(tmp);
+    assert.ok(report);
+    assert.equal(report.recovered, true);
+    assert.equal(report.tasks, 1);
+    assert.equal(report.runs, 1);
+    assert.equal(report.clean_shutdown, false);
+
+    // Task is back to pending and the run is closed with the crash marker.
+    const task = db.prepare("SELECT status FROM tasks WHERE id = ?").get(t);
+    assert.equal(task.status, "pending");
+    const run = db.prepare("SELECT status, error FROM runs WHERE id = ?").get(runId);
+    assert.equal(run.status, "error");
+    assert.ok(run.error.includes("crash recovery"));
+    db.close();
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("healthz: enriched response includes active_runs/queued_runs/last_recovery and ok status", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "aidev-recovery-"));
+  try {
+    const { initDb } = await import("../dist/storage/db.js");
+    const { buildHealthz } = await import("../dist/server/healthz.js");
+    const { writeRecoveryReport } = await import("../dist/storage/recovery.js");
+    const { loadConfig } = await import("../dist/config/loader.js");
+
+    const db = initDb(tmp);
+    writeRecoveryReport(tmp, {
+      ts: new Date().toISOString(),
+      recovered: false,
+      tasks: 0,
+      runs: 0,
+      deploys: 0,
+      clean_shutdown: true,
+    });
+    process.env.OPENRONIN_DATA_DIR = tmp;
+    const config = loadConfig({ dataDir: tmp });
+
+    const body = buildHealthz({ db, startedAt: Date.now() - 12_000, getConfig: () => config });
+    assert.equal(body.status, "ok");
+    assert.equal(body.db_ok, true);
+    assert.equal(body.active_runs, 0);
+    assert.equal(body.queued_runs, 0);
+    assert.ok(body.last_recovery, "last_recovery block present");
+    assert.equal(body.last_recovery.clean_shutdown, true);
+    assert.ok(body.uptime_s >= 10);
+    db.close();
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("healthz: reports active_runs when a row is in 'running' state", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "aidev-recovery-"));
+  try {
+    const { initDb } = await import("../dist/storage/db.js");
+    const { ensureRepo, upsertTask } = await import("../dist/storage/tasks.js");
+    const { createRun } = await import("../dist/storage/runs.js");
+    const { buildHealthz } = await import("../dist/server/healthz.js");
+    const { loadConfig } = await import("../dist/config/loader.js");
+
+    const db = initDb(tmp);
+    const repoId = ensureRepo(db, { provider: "github", owner: "o", name: "n" });
+    const t = upsertTask(db, repoId, "7", "issue");
+    createRun(db, { taskId: t, lane: "patch", engine: "claude_code" });
+
+    process.env.OPENRONIN_DATA_DIR = tmp;
+    const config = loadConfig({ dataDir: tmp });
+    const body = buildHealthz({ db, startedAt: Date.now(), getConfig: () => config });
+    assert.equal(body.active_runs, 1);
+    db.close();
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("healthz: returns down + 503 when DB has been closed", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "aidev-recovery-"));
+  try {
+    const { initDb } = await import("../dist/storage/db.js");
+    const { healthzRoute } = await import("../dist/server/healthz.js");
+    const { loadConfig } = await import("../dist/config/loader.js");
+
+    const db = initDb(tmp);
+    db.close();
+    process.env.OPENRONIN_DATA_DIR = tmp;
+    const config = loadConfig({ dataDir: tmp });
+    const app = healthzRoute({ db, startedAt: Date.now(), getConfig: () => config });
+    const res = await app.request("/");
+    assert.equal(res.status, 503, "DB unreachable → 503");
+    const body = await res.json();
+    assert.equal(body.status, "down");
+    assert.equal(body.db_ok, false);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("recovery report: write is atomic (no .tmp leftover after success)", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "aidev-recovery-"));
+  try {
+    const { writeRecoveryReport } = await import("../dist/storage/recovery.js");
+    writeRecoveryReport(tmp, {
+      ts: new Date().toISOString(),
+      recovered: false,
+      tasks: 0,
+      runs: 0,
+      deploys: 0,
+      clean_shutdown: true,
+    });
+    const final = resolve(tmp, "recovery", "last.json");
+    const tmpFile = resolve(tmp, "recovery", "last.json.tmp");
+    assert.ok(existsSync(final), "final file present");
+    assert.ok(!existsSync(tmpFile), "no .tmp residue");
+    const raw = JSON.parse(readFileSync(final, "utf8"));
+    assert.equal(raw.clean_shutdown, true);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
🤖 openronin: автоматический PR.

Closes #39.

This PR was opened automatically by [openronin](https://github.com/openronin/openronin) in response to issue #39.

## Agent summary

Working tree clean. Here is the summary.

## Summary

Implements **issue #39 — Improve crash recovery and graceful shutdown handling** by making the existing recovery machinery observable. The SIGTERM/SIGINT graceful shutdown (`scheduler.stop`) and the startup `recoverStuckTasks` sweep already covered the functional acceptance criteria; this change persists a recovery audit and exposes it (and live run counts) through `/healthz` so external monitors and operators can actually see what happened across restarts.

### What changed

- **`src/storage/recovery.ts`** *(new)* — `writeRecoveryReport` / `readRecoveryReport` / `recoveryReportAgeSec`. Persists `$OPENRONIN_DATA_DIR/recovery/last.json` via atomic write-then-rename so a SIGKILL mid-write can't leave a half-written file. Schema: `{ ts, recovered, clean_shutdown, tasks, runs, deploys }`.
- **`src/scheduler/index.ts`** — `recoverStuckTasks` accepts an optional `{ dataDir }` and writes the audit on every boot, including the clean-shutdown case (so the absence of a file means the audit subsystem itself never ran).
- **`src/server/healthz.ts`** — adds `active_runs` (rows in `runs.status='running'`), `queued_runs` (due tasks via `queueStats`), and a `last_recovery` block. Returns HTTP **503** when the DB query fails (`status: "down"`); OK path stays 200. The response builder is exported as `buildHealthz()` so tests can assert the response shape directly.
- **`CHANGELOG.md`** — `[Unreleased]` entry under "Reliability — crash recovery audit and richer healthz (issue #39)".
- **`test/recovery.test.mjs`** *(new, 8 tests)* — writer/reader roundtrip, atomic-write residue check, malformed-file null path, clean-boot report, orphaned-run recovery counts, enriched healthz fields, active_runs detection, and the DB-closed → 503 path.

### Acceptance criteria

- [x] SIGTERM: current step finishes — unchanged (`scheduler.stop` already does this; verified by inspection of `src/index.ts:53-64`).
- [x] Unfinished runs recover after crash — unchanged (`recoverStuckTasks` already handles tasks/runs/deploys; now also leaves an audit trail).
- [x] Healthcheck endpoint works — enriched with `active_runs`, `queued_runs`, `last_recovery`, and proper 503 on DB failure.
- [x] `pnpm run check` green — build + lint + 195 tests (8 new) + format-check all pass.
- [x] Behavior captured in `CHANGELOG.md` `[Unreleased]`.

### Verification

```
pnpm run check
  → tsc: ok
  → oxlint: ok (only pre-existing warnings, none from new code)
  → node --test: 195 passed, 0 failed
  → oxfmt --check: ok
```

### Out of scope (respected)

- No DB schema changes (no migration needed).
- `src/scheduler/worker.ts` not touched — per-step checkpointing inside the worker is left out for that reason; the file-based recovery report is the closest equivalent that fits the constraint.

## Diff stats

- Files changed: 5
- Lines: +401 / -22

---
*Marked as draft for human review. The agent (claude_code) wrote this; please review before merging.*