### PR TITLE
[openronin] MIMO digest-генератор: массовая ошибка 'Not supported model'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to **openronin** are documented here. The format follows [Ke
 
 ## [Unreleased]
 
+### Reliability — digest retry backoff and graceful fallback (issue #79)
+
+- **Schema v20** adds `digest_failure_count` + `digest_next_attempt_at` columns to `director_budget_state` so digest failures can be backed off without keeping the loop in a tight retry storm.
+- **Exponential backoff on transient digest failures.** Previously `runDigest` left `last_digest_date` untouched on error; the service loop (10s wake) then fired the digest every 10s for the rest of the day. With a stuck MIMO model name this produced ~25 `MIMO error 400: Not supported model` log lines in a 5-minute window. Backoff is **1m → 2m → 4m → … → capped at 1h**; `shouldRunDigest` honours `digest_next_attempt_at` and refuses to fire before it. A success resets the counter and clears the deadline.
+- **Permanent-error fallback.** A digest error matching `Not supported model` is now classified as terminal-for-today: ONE chat notification ("digest unavailable — set OPENRONIN_DIRECTOR_DIGEST_MODEL to a valid model") is posted, `last_digest_date` is set to today so the predicate stops firing, and the failure counter is reset. Tomorrow's wake-up tries again — by which time the operator has had a chance to fix the model name.
+- **New public helpers** in `src/director/digest.ts`: `getDigestRetryState`, `computeDigestBackoffMs`, `isUnsupportedModelError`. The legacy `getLastDigestDate` is preserved as a thin wrapper for back-compat.
+
 ### Reliability — crash recovery audit and richer healthz (issue #39)
 
 - **Recovery audit file.** Every boot, `recoverStuckTasks` now writes a small JSON summary to `$OPENRONIN_DATA_DIR/recovery/last.json` (atomic write-then-rename) capturing `ts`, `recovered`, per-table counts (`tasks`, `runs`, `deploys`), and a `clean_shutdown` flag. The healthz endpoint reads it back so external monitors can answer "what did the last boot recover?" without poking the DB.

--- a/src/director/digest.ts
+++ b/src/director/digest.ts
@@ -69,15 +69,23 @@ export function localHourInTz(d: Date, tz: string): number {
 // Returns true when:
 //   • digest.enabled, AND
 //   • we're past the configured hour today in the configured timezone, AND
-//   • we haven't already fired a digest for today's local date.
+//   • we haven't already fired a digest for today's local date, AND
+//   • we're past the backoff deadline (or no backoff is active).
 //
 // `now` is injectable for tests; production passes `new Date()`.
+// `nextAttemptAt` is the UTC ISO timestamp written by a prior failed
+// attempt's exponential backoff — null means no backoff active.
 export function shouldRunDigest(
   digest: DigestConfig,
   lastDigestDate: string | null,
   now: Date = new Date(),
+  nextAttemptAt: string | null = null,
 ): boolean {
   if (!digest.enabled) return false;
+  if (nextAttemptAt) {
+    const next = Date.parse(nextAttemptAt);
+    if (!Number.isNaN(next) && now.getTime() < next) return false;
+  }
   const hour = localHourInTz(now, digest.timezone);
   if (hour < digest.hour) return false;
   const today = localDateInTz(now, digest.timezone);
@@ -85,7 +93,7 @@ export function shouldRunDigest(
 }
 
 // Persist that we've fired today's digest. Called after a successful run
-// (and skipped on failure so we'll retry on the next loop pass).
+// (and skipped on transient failure so we'll retry after the backoff).
 export function recordDigestFired(db: Db, repoId: number, today: string): void {
   db.prepare(`UPDATE director_budget_state SET last_digest_date = ? WHERE repo_id = ?`).run(
     today,
@@ -94,10 +102,80 @@ export function recordDigestFired(db: Db, repoId: number, today: string): void {
 }
 
 export function getLastDigestDate(db: Db, repoId: number): string | null {
+  return getDigestRetryState(db, repoId).lastDate;
+}
+
+// Read both the last fired date AND the backoff state for the digest.
+// shouldRunDigest needs both — the predicate gates on either of them being
+// "already done for today" or "still within backoff window".
+export function getDigestRetryState(
+  db: Db,
+  repoId: number,
+): { lastDate: string | null; nextAttemptAt: string | null; failureCount: number } {
   const row = db
-    .prepare(`SELECT last_digest_date FROM director_budget_state WHERE repo_id = ?`)
-    .get(repoId) as { last_digest_date: string | null } | undefined;
-  return row?.last_digest_date ?? null;
+    .prepare(
+      `SELECT last_digest_date, digest_next_attempt_at, digest_failure_count
+       FROM director_budget_state WHERE repo_id = ?`,
+    )
+    .get(repoId) as
+    | {
+        last_digest_date: string | null;
+        digest_next_attempt_at: string | null;
+        digest_failure_count: number | null;
+      }
+    | undefined;
+  return {
+    lastDate: row?.last_digest_date ?? null,
+    nextAttemptAt: row?.digest_next_attempt_at ?? null,
+    failureCount: row?.digest_failure_count ?? 0,
+  };
+}
+
+// Exponential backoff for the digest retry loop. Starts at 1 minute,
+// doubles each failure, capped at 1 hour. The cap is intentional: a stuck
+// MIMO model name shouldn't produce more than one error message per hour
+// (cf. issue #79: ~25 errors in 5 min).
+const DIGEST_BACKOFF_BASE_MS = 60_000;
+const DIGEST_BACKOFF_MAX_MS = 60 * 60_000;
+
+export function computeDigestBackoffMs(failureCount: number): number {
+  const exponent = Math.max(0, failureCount - 1);
+  const ms = DIGEST_BACKOFF_BASE_MS * 2 ** exponent;
+  return Math.min(ms, DIGEST_BACKOFF_MAX_MS);
+}
+
+// Classify a digest error message as "retrying won't help today" — typically
+// MIMO rejecting the configured model with HTTP 400. The digest then skips
+// for the rest of the day rather than burning backoff slots on a request
+// that will fail identically every time.
+export function isUnsupportedModelError(detail: string): boolean {
+  return /not supported model/i.test(detail);
+}
+
+function recordDigestFailure(
+  db: Db,
+  repoId: number,
+  nextAttemptAt: string,
+): { failureCount: number } {
+  db.prepare(
+    `UPDATE director_budget_state
+     SET digest_failure_count = digest_failure_count + 1,
+         digest_next_attempt_at = ?
+     WHERE repo_id = ?`,
+  ).run(nextAttemptAt, repoId);
+  const row = db
+    .prepare(`SELECT digest_failure_count FROM director_budget_state WHERE repo_id = ?`)
+    .get(repoId) as { digest_failure_count: number };
+  return { failureCount: row.digest_failure_count };
+}
+
+function resetDigestRetryState(db: Db, repoId: number): void {
+  db.prepare(
+    `UPDATE director_budget_state
+     SET digest_failure_count = 0,
+         digest_next_attempt_at = NULL
+     WHERE repo_id = ?`,
+  ).run(repoId);
 }
 
 // ── Digest tick runner ──────────────────────────────────────────────────
@@ -165,12 +243,52 @@ export async function runDigest(opts: DigestRunOptions): Promise<DigestRunResult
     });
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
+    // Permanent classification: the configured model is rejected by MIMO,
+    // so retrying with the same config will fail identically. Post ONE
+    // notification of unavailability, mark today as fired so the loop
+    // stops retrying for the rest of the day, and reset the backoff state.
+    // Tomorrow's wake-up will attempt again — by then the operator has
+    // had a chance to fix the model name.
+    if (isUnsupportedModelError(detail)) {
+      appendMessage(db, {
+        repoId,
+        role: "system",
+        type: "error",
+        body:
+          `digest unavailable: ${detail}. ` +
+          `Configured digest model is not supported by MIMO — set OPENRONIN_DIRECTOR_DIGEST_MODEL ` +
+          `to a valid model (e.g. mimo-v2.5-pro). Skipping digest for ${today}.`,
+        metadata: {
+          repo: repoKey(repo),
+          kind: "digest",
+          today,
+          classification: "model_unavailable",
+        },
+      });
+      recordDigestFired(db, repoId, today);
+      resetDigestRetryState(db, repoId);
+      return { status: "error", detail, costUsd: 0 };
+    }
+    // Transient failure: bump the failure count, push next_attempt_at out
+    // with exponential backoff, and post a single "failed, will retry"
+    // message. Without this, the service loop would re-invoke runDigest
+    // every 10s until midnight (issue #79).
+    const prior = getDigestRetryState(db, repoId).failureCount;
+    const projected = prior + 1;
+    const nextAttemptMs = now.getTime() + computeDigestBackoffMs(projected);
+    const nextAttemptIso = new Date(nextAttemptMs).toISOString();
+    const { failureCount } = recordDigestFailure(db, repoId, nextAttemptIso);
     appendMessage(db, {
       repoId,
       role: "system",
       type: "error",
-      body: `digest failed: ${detail}`,
-      metadata: { repo: repoKey(repo), kind: "digest" },
+      body: `digest failed (attempt ${failureCount}): ${detail}. Next retry at ${nextAttemptIso}.`,
+      metadata: {
+        repo: repoKey(repo),
+        kind: "digest",
+        failureCount,
+        nextAttemptAt: nextAttemptIso,
+      },
     });
     return { status: "error", detail, costUsd: 0 };
   }
@@ -194,5 +312,6 @@ export async function runDigest(opts: DigestRunOptions): Promise<DigestRunResult
     },
   });
   recordDigestFired(db, repoId, today);
+  resetDigestRetryState(db, repoId);
   return { status: "ok", detail: `digest posted for ${today}`, costUsd: cost };
 }

--- a/src/director/index.ts
+++ b/src/director/index.ts
@@ -19,7 +19,7 @@ import { ensureBudgetState, rolloverDayIfNeeded } from "./budget.js";
 import { appendMessage, unansweredUserDirectives } from "./chat.js";
 import { runTick, type TickReason } from "./tick.js";
 import { releaseTick, tryAcquireTick } from "./active-tick.js";
-import { getLastDigestDate, runDigest, shouldRunDigest } from "./digest.js";
+import { getDigestRetryState, runDigest, shouldRunDigest } from "./digest.js";
 import { maybePostTrustRampSuggestion } from "./trust-ramp.js";
 import { expireStalePending } from "./decisions.js";
 import { runOutcomeFollowupSweep } from "./outcome-followup.js";
@@ -157,9 +157,11 @@ function sleep(ms: number): Promise<void> {
 async function maybeRunDigest(db: Db, target: RepoLookup, dataDir: string): Promise<void> {
   // Digest fires at most once per local-TZ day per repo. shouldRunDigest is
   // pure — it checks the configured hour against the current wall-clock in
-  // the configured TZ, plus the persisted last-digest-date string.
-  const last = getLastDigestDate(db, target.repoId);
-  if (!shouldRunDigest(target.director.digest, last)) return;
+  // the configured TZ, plus the persisted last-digest-date string. The
+  // next_attempt_at value implements the exponential backoff that gates
+  // retries after a transient failure (see issue #79).
+  const { lastDate, nextAttemptAt } = getDigestRetryState(db, target.repoId);
+  if (!shouldRunDigest(target.director.digest, lastDate, new Date(), nextAttemptAt)) return;
   // Use the same per-repo lock as planning ticks so a digest doesn't
   // race with a chat-triggered planning tick.
   if (!tryAcquireTick(db, target.repoId, "morning_digest")) return;

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -458,4 +458,21 @@ function applyMigrationsInner(db: Db): void {
       "INSERT INTO schema_version (version, applied_at) VALUES (18, datetime('now'))",
     ).run();
   }
+
+  // v20 — Digest retry backoff. Before this, runDigest only persisted
+  // last_digest_date on success; a failure left it stale, so the service
+  // loop's shouldRunDigest predicate kept firing the digest every 10s for
+  // hours (see issue #79: ~25 'Not supported model' errors in 5 minutes).
+  // digest_failure_count tracks consecutive failures and feeds an
+  // exponential backoff; digest_next_attempt_at is the earliest UTC
+  // ISO timestamp the predicate will allow a retry. Both reset on success.
+  if (current < 20) {
+    db.exec(`
+      ALTER TABLE director_budget_state ADD COLUMN digest_failure_count INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE director_budget_state ADD COLUMN digest_next_attempt_at TEXT;
+    `);
+    db.prepare(
+      "INSERT INTO schema_version (version, applied_at) VALUES (20, datetime('now'))",
+    ).run();
+  }
 }

--- a/test/director-digest.test.mjs
+++ b/test/director-digest.test.mjs
@@ -15,7 +15,10 @@ import { join } from "node:path";
 
 import { initDb } from "../dist/storage/db.js";
 import {
+  computeDigestBackoffMs,
+  getDigestRetryState,
   getLastDigestDate,
+  isUnsupportedModelError,
   localDateInTz,
   localHourInTz,
   runDigest,
@@ -86,6 +89,202 @@ test("shouldRunDigest: timezone shifts when a day rolls", () => {
   assert.equal(shouldRunDigest(digest, "2026-05-04", new Date("2026-05-04T23:00:00Z")), false);
   // 06:00 UTC on -05 = 09:00 Moscow on -05 → fire.
   assert.equal(shouldRunDigest(digest, "2026-05-04", new Date("2026-05-05T06:00:00Z")), true);
+});
+
+test("computeDigestBackoffMs: doubles per failure, capped at 1h", () => {
+  // First failure → 1 min; subsequent ones double until the cap.
+  assert.equal(computeDigestBackoffMs(1), 60_000);
+  assert.equal(computeDigestBackoffMs(2), 120_000);
+  assert.equal(computeDigestBackoffMs(3), 240_000);
+  assert.equal(computeDigestBackoffMs(6), 32 * 60_000);
+  // Cap at 1 hour = 3_600_000 ms; should not exceed.
+  assert.equal(computeDigestBackoffMs(7), 60 * 60_000);
+  assert.equal(computeDigestBackoffMs(20), 60 * 60_000);
+});
+
+test("isUnsupportedModelError: matches the MIMO 400 'Not supported model' shape", () => {
+  assert.equal(isUnsupportedModelError("MIMO error 400: Not supported model"), true);
+  assert.equal(isUnsupportedModelError("not supported MODEL: whatever"), true);
+  assert.equal(isUnsupportedModelError("network ECONNRESET"), false);
+  assert.equal(isUnsupportedModelError("HTTP 500"), false);
+});
+
+test("shouldRunDigest: respects the backoff next_attempt_at deadline", () => {
+  const digest = { enabled: true, hour: 9, timezone: "UTC" };
+  const now = new Date("2026-05-05T10:00:00Z");
+  // No backoff active → fire.
+  assert.equal(shouldRunDigest(digest, null, now, null), true);
+  // Backoff still in the future (5 minutes from now) → don't fire.
+  const future = new Date(now.getTime() + 5 * 60_000).toISOString();
+  assert.equal(shouldRunDigest(digest, null, now, future), false);
+  // Backoff already elapsed → fire.
+  const past = new Date(now.getTime() - 1_000).toISOString();
+  assert.equal(shouldRunDigest(digest, null, now, past), true);
+});
+
+test("runDigest: 'Not supported model' marks today done, posts ONE notification, won't retry", async () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  const repo = {
+    provider: "github",
+    owner: "openronin",
+    name: "openronin",
+    watched: true,
+    lanes: ["triage"],
+  };
+  try {
+    const fail = () =>
+      runDigest({
+        db,
+        repoId,
+        repo,
+        digest: { enabled: true, hour: 9, timezone: "UTC" },
+        persona: undefined,
+        language: "English",
+        dataDir: dir,
+        now: new Date("2026-05-05T09:30:00Z"),
+        engineFactory: () => ({
+          id: "mock",
+          defaultModel: "mock",
+          async run() {
+            throw new Error("MIMO error 400: Not supported model");
+          },
+        }),
+      });
+    const first = await fail();
+    assert.equal(first.status, "error");
+    // last_digest_date is set to today, so subsequent calls in the same
+    // service-loop iteration are gated out by shouldRunDigest.
+    assert.equal(getLastDigestDate(db, repoId), "2026-05-05");
+    // Failure counter reset — we're not in "retry with backoff" mode.
+    const state = getDigestRetryState(db, repoId);
+    assert.equal(state.failureCount, 0);
+    assert.equal(state.nextAttemptAt, null);
+    // Exactly one error message posted.
+    const errs = recentMessages(db, repoId, 20).filter(
+      (m) => m.metadata?.kind === "digest" && m.type === "error",
+    );
+    assert.equal(errs.length, 1);
+    assert.equal(errs[0].metadata.classification, "model_unavailable");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("runDigest: transient failure bumps backoff and does NOT mark today done", async () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  const repo = {
+    provider: "github",
+    owner: "openronin",
+    name: "openronin",
+    watched: true,
+    lanes: ["triage"],
+  };
+  try {
+    const startAt = new Date("2026-05-05T09:30:00Z");
+    const result = await runDigest({
+      db,
+      repoId,
+      repo,
+      digest: { enabled: true, hour: 9, timezone: "UTC" },
+      persona: undefined,
+      language: "English",
+      dataDir: dir,
+      now: startAt,
+      engineFactory: () => ({
+        id: "mock",
+        defaultModel: "mock",
+        async run() {
+          throw new Error("MIMO error 500: upstream timeout");
+        },
+      }),
+    });
+    assert.equal(result.status, "error");
+    // last_digest_date untouched: tomorrow's predicate still sees null.
+    assert.equal(getLastDigestDate(db, repoId), null);
+    const state = getDigestRetryState(db, repoId);
+    assert.equal(state.failureCount, 1);
+    // Next attempt = now + 60s (first-failure backoff).
+    assert.equal(state.nextAttemptAt, new Date(startAt.getTime() + 60_000).toISOString());
+    // shouldRunDigest now refuses to fire until the backoff elapses.
+    assert.equal(
+      shouldRunDigest(
+        { enabled: true, hour: 9, timezone: "UTC" },
+        null,
+        new Date(startAt.getTime() + 30_000),
+        state.nextAttemptAt,
+      ),
+      false,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("runDigest: success resets a prior failure count", async () => {
+  const { db, dir, repoId } = freshDb();
+  ensureBudgetState(db, repoId, sampleBudget);
+  const repo = {
+    provider: "github",
+    owner: "openronin",
+    name: "openronin",
+    watched: true,
+    lanes: ["triage"],
+  };
+  try {
+    const digest = { enabled: true, hour: 9, timezone: "UTC" };
+    // First call fails transiently.
+    await runDigest({
+      db,
+      repoId,
+      repo,
+      digest,
+      persona: undefined,
+      language: "English",
+      dataDir: dir,
+      now: new Date("2026-05-05T09:30:00Z"),
+      engineFactory: () => ({
+        id: "mock",
+        defaultModel: "mock",
+        async run() {
+          throw new Error("transient blip");
+        },
+      }),
+    });
+    assert.equal(getDigestRetryState(db, repoId).failureCount, 1);
+    // Second call succeeds → counter resets to 0, backoff cleared.
+    const ok = await runDigest({
+      db,
+      repoId,
+      repo,
+      digest,
+      persona: undefined,
+      language: "English",
+      dataDir: dir,
+      now: new Date("2026-05-05T09:32:00Z"),
+      engineFactory: () => ({
+        id: "mock",
+        defaultModel: "mock",
+        async run() {
+          return {
+            content: "Good morning.",
+            json: null,
+            usage: { tokensIn: 100, tokensOut: 5, costUsd: 0.0001 },
+            finishReason: "end_turn",
+            durationMs: 10,
+          };
+        },
+      }),
+    });
+    assert.equal(ok.status, "ok");
+    const after = getDigestRetryState(db, repoId);
+    assert.equal(after.failureCount, 0);
+    assert.equal(after.nextAttemptAt, null);
+    assert.equal(after.lastDate, "2026-05-05");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("runDigest: posts a single status message and records today", async () => {


### PR DESCRIPTION
🤖 openronin: автоматический PR.

Closes #79.

This PR was opened automatically by [openronin](https://github.com/openronin/openronin) in response to issue #79.

## Agent summary

Working tree clean. Here is the PR summary:

---

## Summary

Fixes #79 — the digest generator was emitting `MIMO error 400: Not supported model` repeatedly (~25 errors in 5 minutes) because `runDigest` only persisted `last_digest_date` on success. A failure left the predicate stale, and the service-loop (10s wake interval) re-invoked the digest every 10s for the rest of the day.

## Changes

- **Schema v20** (`src/storage/db.ts`) — adds two columns to `director_budget_state`:
  - `digest_failure_count INTEGER NOT NULL DEFAULT 0`
  - `digest_next_attempt_at TEXT`

- **Exponential backoff** (`src/director/digest.ts`) — transient failures push `digest_next_attempt_at` out by `1m → 2m → 4m → … → cap 1h`. `shouldRunDigest` gains an optional `nextAttemptAt` parameter and refuses to fire before the deadline. A success resets both the counter and the deadline.

- **Permanent-error fallback** — errors matching `Not supported model` are classified as terminal-for-today. The system posts **one** notification ("digest unavailable: ... — set OPENRONIN_DIRECTOR_DIGEST_MODEL to a valid model") instead of retrying, marks today as fired so the loop stops, and resets the failure counter. Tomorrow's wake-up tries again from clean state.

- **`src/director/index.ts`** — `maybeRunDigest` reads `getDigestRetryState` and forwards `nextAttemptAt` to `shouldRunDigest`.

## New helpers (exported)

- `getDigestRetryState(db, repoId)` — returns `{ lastDate, nextAttemptAt, failureCount }`
- `computeDigestBackoffMs(failureCount)` — pure function for backoff math
- `isUnsupportedModelError(detail)` — classification predicate
- `getLastDigestDate` preserved as a back-compat thin wrapper

## Tests / lint

- 4 new test cases in `test/director-digest.test.mjs` covering backoff math, the unsupported-model classifier, the `shouldRunDigest` deadline gate, the permanent-error path (one message, today marked done), the transient path (failure counter bumped, today NOT marked done), and the reset-on-success path.
- `pnpm run check` — **201/201 tests pass, lint clean, format clean.**

## Out of scope

- The MIMO engine code (`src/engines/mimo.ts`) and its default model (`mimo-v2.5-pro`) were already correct — no changes to engine wiring. The fallback acts on the symptom side so any future model-mismatch (e.g. operator overrides `OPENRONIN_DIRECTOR_DIGEST_MODEL` to a typo) is also handled gracefully.

## Diff stats

- Files changed: 5
- Lines: +355 / -11

---
*Marked as draft for human review. The agent (claude_code) wrote this; please review before merging.*