### PR TITLE
[openronin] Update documentation: CHANGELOG.md and .env.example after recent changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,19 @@ TELEGRAM_BOT_TOKEN=
 #   mimo      → mimo-v2.5-pro
 # OPENRONIN_DIRECTOR_THINK_MODEL=claude-sonnet-4-6
 
+# Model for the director's reactive (chat-reply) ticks. Reactive ticks
+# prefer MIMO for cost/latency; this env pins which MIMO variant they use
+# without affecting the planning default. Only consulted when MIMO is the
+# selected engine for chat replies. Default: mimo-v2.5-pro.
+# OPENRONIN_DIRECTOR_CHAT_MODEL=mimo-v2.5-flash
+
+# Model used for the director's daily morning digest. Always MIMO (the
+# digest is intentionally cheap and never falls over to a pricier engine).
+# A digest call returning "Not supported model" posts a one-shot chat
+# notification and stops retrying until tomorrow — see CHANGELOG.
+# Default: mimo-v2.5-pro.
+# OPENRONIN_DIRECTOR_DIGEST_MODEL=mimo-v2.5-pro
+
 # ── Observability ──────────────────────────────────────────────────────────
 # Runs with status='running' that stay active longer than this many minutes are
 # highlighted as "stale" in the admin UI (/admin/logs, dashboard worker cards).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to **openronin** are documented here. The format follows [Ke
 
 ## [Unreleased]
 
+### Observability — per-lane latency and error-rate metrics (issue #88)
+
+- The cost dashboard / metrics view now surfaces **p50 and p95 latency per lane** and **error rate per lane** so operators can spot which lane is slowest or failing most without grepping raw logs. Data is aggregated from the existing `runs` table; no schema change.
+
+### Observability — running-run age and stale highlight in admin UI
+
+- `/admin/logs` and the dashboard recent-runs table show **"running for Nm Ss"** next to the status badge for runs still in `status='running'`.
+- Runs that exceed the configurable threshold are flagged with a **"stale"** label and a warning-tone badge so the operator can spot hangs without SSH.
+- The `/api/workers` panel similarly shows how long the current drain worker has been busy, with the same stale colouring.
+- **New env var** `OPENRONIN_STALE_RUN_THRESHOLD_MINUTES` (default `30`) — already documented in `.env.example`.
+- Crash-recovered runs already land in `status='error'` with `[crash recovery: orphaned run, process exited mid-call]` via `recoverStuckTasks()`; that text is shown beneath each run in the UI (no schema change).
+
+### Fixed — scheduler: lift transient pr_branches parks on human webhook events
+
+- `TERMINAL_BRANCH_STATUSES` split into two cohorts:
+  - **`TRANSIENT_PARK_STATUSES`** (`error`, `dirty`): caused by infra/agent failure. A verified non-bot comment on the parent issue lifts the `pr_branches` row to `'cancelled'` in the GitHub webhook handler, so `pickLane` can re-route the task on the next drain without operator SQLite surgery.
+  - **Human-gated parks** (`guardrail_blocked`, `no_changes`, `needs_human`): unchanged — still lifted only by admin Retry, label removal, or the 24h TTL.
+- Loop-safety: the lift only fires when `candidateBody` is non-empty and `kind === "issue"`. Label/edit webhook events carry no body text, so the bot's own `in_progress_label` removal in `src/lanes/patch.ts` finalize cannot trigger a re-run loop.
+
 ### Reliability — digest retry backoff and graceful fallback (issue #79)
 
 - **Schema v20** adds `digest_failure_count` + `digest_next_attempt_at` columns to `director_budget_state` so digest failures can be backed off without keeping the loop in a tight retry storm.


### PR DESCRIPTION
🤖 openronin: автоматический PR.

Closes #42.

This PR was opened automatically by [openronin](https://github.com/openronin/openronin) in response to issue #42.

## Agent summary

Working tree clean, commit landed.

## Summary

Docs-only refresh to bring `CHANGELOG.md` and `.env.example` in line with recent merges. Scope intentionally narrow — the bigger items called out in the issue (#30, #38, #39, plus the digest fix #79) were already documented when this branch was cut; the gap was elsewhere.

### `CHANGELOG.md` — three new `[Unreleased]` entries

Added the three behavior-affecting merges that landed without a CHANGELOG note:

- **PR #89** — per-lane p50/p95 latency and error-rate metrics on the cost dashboard (closes #88). No schema change; aggregated from `runs`.
- **PR #87** — running-run age ("running for Nm Ss") on `/admin/logs` + dashboard, "stale" highlight past the threshold, same colouring on `/api/workers`. Notes the existing `OPENRONIN_STALE_RUN_THRESHOLD_MINUTES` env var (already documented).
- **PR #84** — `TERMINAL_BRANCH_STATUSES` split into `TRANSIENT_PARK_STATUSES` (`error`, `dirty`) vs human-gated parks. Non-bot comment on the parent issue now lifts the transient park to `cancelled` so the next drain re-routes the task. Loop-safety guard documented.

The wave-style entries already present for #30, #38, #39, #79 were left as-is — they accurately reflect what shipped.

### `.env.example` — two missing director vars

Documented two env vars referenced in the code that were not in the template:

- **`OPENRONIN_DIRECTOR_DIGEST_MODEL`** — used in `src/director/index.ts:181` and `src/server/slash-commands.ts:183` to pick the MIMO model for the daily digest. Default `mimo-v2.5-pro`. Already implicitly referenced by the digest backoff CHANGELOG entry.
- **`OPENRONIN_DIRECTOR_CHAT_MODEL`** — used in `src/director/tick.ts:380` to pin the MIMO variant for reactive (chat-reply) ticks without disturbing the planning default. Documented in the Wave 2 "engine split (chat-vs-plan)" CHANGELOG entry but missing from the env template.

`README.md` was not touched — it doesn't list env vars and no recent change altered its scope.

### Validation

- `pnpm run check` — green: build OK, oxlint clean, **201/201 unit tests pass**, `oxfmt --check` clean across all 121 files.

### Out of scope (intentionally skipped)

- Reorganising the existing `[Unreleased]` section — left alone to keep the diff minimal.
- Code changes — issue is explicitly documentation-only.

## Diff stats

- Files changed: 2
- Lines: +32 / -0

---
*Marked as draft for human review. The agent (claude_code) wrote this; please review before merging.*